### PR TITLE
Add new 'competency' subject

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@
                 MUSIC: 'music',
                 ART: 'art',
                 KOREAN: 'korean',
+                COMPETENCY: "competency",
                 RANDOM: 'random'
             },
             MODES: {
@@ -294,7 +295,7 @@
             playSound(startAudio);
             startModal.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE);
             
-            const subjectMap = { [CONSTANTS.SUBJECTS.MUSIC]: '음악', [CONSTANTS.SUBJECTS.ART]: '미술', [CONSTANTS.SUBJECTS.KOREAN]: '국어' };
+            const subjectMap = { [CONSTANTS.SUBJECTS.MUSIC]: '음악', [CONSTANTS.SUBJECTS.ART]: '미술', [CONSTANTS.SUBJECTS.KOREAN]: '국어', [CONSTANTS.SUBJECTS.COMPETENCY]: '역량' };
             headerTitle.textContent = subjectMap[gameState.selectedSubject] || '퀴즈';
             document.getElementById(`${gameState.selectedSubject}-quiz-main`).classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
             

--- a/index.html
+++ b/index.html
@@ -644,6 +644,75 @@
     </section>
   </main>
 
+<!-- competency main start -->
+<main id="competency-quiz-main" class="hidden">
+  <section class="active">
+    <h2>총론</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="자기관리 역량" aria-label="자기관리 역량" placeholder="정답"><input data-answer="지식정보처리 역량" aria-label="지식정보처리 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="창의적 사고 역량" aria-label="창의적 사고 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>국어</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="공동체·대인관계 역량" aria-label="공동체·대인관계 역량" placeholder="정답"><input data-answer="자기 성찰·계발 역량" aria-label="자기 성찰·계발 역량" placeholder="정답"><input data-answer="디지털·미디어 역량" aria-label="디지털·미디어 역량" placeholder="정답"><input data-answer="비판적·창의적 사고 역량" aria-label="비판적·창의적 사고 역량" placeholder="정답"><input data-answer="문화 향유 역량" aria-label="문화 향유 역량" placeholder="정답"><input data-answer="의사소통 역량" aria-label="의사소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>수학</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="연결" aria-label="연결" placeholder="정답"><input data-answer="문제해결" aria-label="문제해결" placeholder="정답"><input data-answer="의사소통" aria-label="의사소통" placeholder="정답"><input data-answer="추론" aria-label="추론" placeholder="정답"><input data-answer="정보처리" aria-label="정보처리" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>사회</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="창의적 사고력" aria-label="창의적 사고력" placeholder="정답"><input data-answer="문제해결력 및 의사결정력" aria-label="문제해결력 및 의사결정력" placeholder="정답"><input data-answer="의사소통 및 협업능력" aria-label="의사소통 및 협업능력" placeholder="정답"><input data-answer="정보 활용 능력" aria-label="정보 활용 능력" placeholder="정답"><input data-answer="비판적 사고력" aria-label="비판적 사고력" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>과학</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="과학적 탐구와 문제해결 능력" aria-label="과학적 탐구와 문제해결 능력" placeholder="정답"><input data-answer="과학적 의사결정 능력" aria-label="과학적 의사결정 능력" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>영어</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="영어 의사소통 역량" aria-label="영어 의사소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>음악</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="자기주도성 역량" aria-label="자기주도성 역량" placeholder="정답"><input data-answer="소통 역량" aria-label="소통 역량" placeholder="정답"><input data-answer="감성 역량" aria-label="감성 역량" placeholder="정답"><input data-answer="창의성 역량" aria-label="창의성 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>미술</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="정체성 역량" aria-label="정체성 역량" placeholder="정답"><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="창의·융합 역량" aria-label="창의·융합 역량" placeholder="정답"><input data-answer="시각적 소통 역량" aria-label="시각적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>체육</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="신체활동 문화 향유 역량" aria-label="신체활동 문화 향유 역량" placeholder="정답"><input data-answer="움직임 수행 역량" aria-label="움직임 수행 역량" placeholder="정답"><input data-answer="건강 관리 역량" aria-label="건강 관리 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>실과</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="실천적 문제 해결 능력" aria-label="실천적 문제 해결 능력" placeholder="정답"><input data-answer="생활 자립 능력" aria-label="생활 자립 능력" placeholder="정답"><input data-answer="관계 형성 능력" aria-label="관계 형성 능력" placeholder="정답"><input data-answer="기술적 실천 능력" aria-label="기술적 실천 능력" placeholder="정답"><input data-answer="기술적 문제해결 능력" aria-label="기술적 문제해결 능력" placeholder="정답"><input data-answer="기술학적 지식의 이해 능력" aria-label="기술학적 지식의 이해 능력" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>통합</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="지금-여기-우리 삶" aria-label="지금-여기-우리 삶" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>통합-바생(총론)</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="자기관리 역량" aria-label="자기관리 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>통합-슬생(총론)</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="지식정보처리 역량" aria-label="지식정보처리 역량" placeholder="정답"><input data-answer="창의적 사고 역량" aria-label="창의적 사고 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>통합-즐생(총론)</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>도덕-미래사회가 요구하는 역량</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="비판적·배려적 사고력" aria-label="비판적·배려적 사고력" placeholder="정답"><input data-answer="도덕적 상상력" aria-label="도덕적 상상력" placeholder="정답"><input data-answer="도덕적 판단 능력" aria-label="도덕적 판단 능력" placeholder="정답"><input data-answer="인공 지능 및 디지털 윤리" aria-label="인공 지능 및 디지털 윤리" placeholder="정답"><input data-answer="도덕 공동체 의식" aria-label="도덕 공동체 의식" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+  <section class="active">
+    <h2>도덕-도덕과 강조점</h2>
+    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td><input data-answer="도덕 현상에 관한 탐구" aria-label="도덕 현상에 관한 탐구" placeholder="정답"><input data-answer="일상의 실천" aria-label="일상의 실천" placeholder="정답"><input data-answer="내면의 도덕성에 대한 성찰" aria-label="내면의 도덕성에 대한 성찰" placeholder="정답"></td></tr></tbody></table></div></div>
+  </section>
+</main>
+<!-- competency main end -->
+
   <div id="character-assistant" class="idle">
       <div class="mushroom">
           <div class="devil-horns">
@@ -725,6 +794,7 @@
                 <button class="btn subject-btn selected" data-subject="music">음악</button>
                 <button class="btn subject-btn" data-subject="art">미술</button>
                 <button class="btn subject-btn" data-subject="korean">국어</button>
+                <button class="btn subject-btn" data-subject="competency">역량</button>
                 <button id="random-subject-btn" class="btn" data-subject="random">랜덤</button>
             </div>
             <h2>게임 모드</h2>


### PR DESCRIPTION
## Summary
- add a new quiz section for 역량 with 16 parts
- allow selecting the new subject from the start menu
- extend game constants and header mapping for the competency subject

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e90451948832ca1c15febba6bd5f8