### PR TITLE
Improve competency subject UI design

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@
   </main>
 
 <!-- competency main start -->
-<main id="competency-quiz-main" class="hidden">
+<main id="competency-quiz-main" class="hidden competency-ui">
   <div class="tabs">
     <div class="tab active" data-target="summary">총론</div>
     <div class="tab" data-target="korean">국어</div>

--- a/styles.css
+++ b/styles.css
@@ -775,7 +775,7 @@
             right: 10px;
         }
     }
-    @media (max-width: 480px) {
+@media (max-width: 480px) {
         .hud-center {
             flex-direction: column;
         }
@@ -796,4 +796,28 @@
             margin-top: -20px;
         }
     }
+
+/* Competency Section Enhancements */
+#competency-quiz-main.competency-ui .tabs {
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+#competency-quiz-main.competency-ui .tab {
+    flex: 1 1 140px;
+}
+
+#competency-quiz-main.competency-ui .grade-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+}
+
+#competency-quiz-main.competency-ui .grade-container > div {
+    border-color: var(--accent);
+}
+
+#competency-quiz-main.competency-ui th {
+    color: var(--primary);
+}
 


### PR DESCRIPTION
## Summary
- improve UI layout for the competency subject
- wrap competency tabs and use grid layout for cards

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ea10df8c8832caf5a5ef30ac9d6b4