### PR TITLE
Improve competency quiz UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -360,6 +360,26 @@
             }, 250);
         }
 
+        function celebrateCompetencySection(sectionElement) {
+            const targetId = sectionElement.id;
+            const tabButton = document.querySelector(`.competency-tab[data-target="${targetId}"]`);
+            if (tabButton && !tabButton.classList.contains('cleared')) {
+                tabButton.classList.add('cleared');
+                playSound(clearAudio);
+                const duration = 2000;
+                const animationEnd = Date.now() + duration;
+                const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 201 };
+                function randomInRange(min, max) { return Math.random() * (max - min) + min; }
+                const interval = setInterval(() => {
+                    const timeLeft = animationEnd - Date.now();
+                    if (timeLeft <= 0) return clearInterval(interval);
+                    const particleCount = 50 * (timeLeft / duration);
+                    confetti({ ...defaults, particleCount, origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 } });
+                    confetti({ ...defaults, particleCount, origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 } });
+                }, 250);
+            }
+        }
+
         function handleInputChange(e) {
             const input = e.target;
             if (!input.matches('input[data-answer]') || input.disabled) return;
@@ -419,8 +439,12 @@
                     comboCounter.classList.add(CONSTANTS.CSS_CLASSES.COMBO_POP);
                 }
                 
-                if (checkStageClear(input.closest('section'))) {
-                    setTimeout(showStageClear, 300);
+                if (checkStageClear(section)) {
+                    if (gameState.selectedSubject === CONSTANTS.SUBJECTS.COMPETENCY) {
+                        setTimeout(() => celebrateCompetencySection(section), 300);
+                    } else {
+                        setTimeout(showStageClear, 300);
+                    }
                 }
             } else {
                 gameState.combo = 0;
@@ -526,6 +550,20 @@
             timeSetterWrapper.style.display = gameState.gameMode === CONSTANTS.MODES.NORMAL ? 'block' : 'none';
             document.getElementById('hard-core-description').classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, gameState.gameMode !== CONSTANTS.MODES.HARD_CORE);
         });
+
+        const competencyTabs = document.querySelector('.competency-tabs');
+        if (competencyTabs) {
+            competencyTabs.addEventListener('click', e => {
+                if (!e.target.matches('.competency-tab')) return;
+                playSound(clickAudio);
+                document.querySelectorAll('.competency-tab').forEach(tab => tab.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE));
+                e.target.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+                const targetId = e.target.dataset.target;
+                document.querySelectorAll('#competency-quiz-main section').forEach(sec => sec.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE));
+                const targetSection = document.getElementById(targetId);
+                if (targetSection) targetSection.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+            });
+        }
         
         function toggleAccordion(header) {
             const accordion = header.closest('.accordion');

--- a/index.html
+++ b/index.html
@@ -647,88 +647,88 @@
 
 <!-- competency main start -->
 <main id="competency-quiz-main" class="hidden competency-ui">
-  <div id="competency-accordion" class="accordion">
-    <button class="accordion-header" aria-controls="summary" aria-expanded="true">총론</button>
+  <div class="tabs competency-tabs">
+    <button class="competency-tab tab active" data-target="summary">총론</button>
+    <button class="competency-tab tab" data-target="korean">국어</button>
+    <button class="competency-tab tab" data-target="math">수학</button>
+    <button class="competency-tab tab" data-target="social">사회</button>
+    <button class="competency-tab tab" data-target="science">과학</button>
+    <button class="competency-tab tab" data-target="english">영어</button>
+    <button class="competency-tab tab" data-target="music-subject">음악</button>
+    <button class="competency-tab tab" data-target="art">미술</button>
+    <button class="competency-tab tab" data-target="pe">체육</button>
+    <button class="competency-tab tab" data-target="practical">실과</button>
+    <button class="competency-tab tab" data-target="integrated">통합</button>
+    <button class="competency-tab tab" data-target="goodlife">통합-바생(총론)</button>
+    <button class="competency-tab tab" data-target="sociality">통합-슬생(총론)</button>
+    <button class="competency-tab tab" data-target="joyful">통합-즐생(총론)</button>
+    <button class="competency-tab tab" data-target="moral-future">도덕-미래사회가 요구하는 역량</button>
+    <button class="competency-tab tab" data-target="moral-emphasis">도덕-도덕과 강조점</button>
+  </div>
     <section id="summary" class="active">
       <h2>총론</h2>
       <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="자기관리 역량" aria-label="자기관리 역량" placeholder="정답"><input data-answer="지식정보처리 역량" aria-label="지식정보처리 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="창의적 사고 역량" aria-label="창의적 사고 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="korean" aria-expanded="false">국어</button>
     <section id="korean">
       <h2>국어</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="공동체·대인관계 역량" aria-label="공동체·대인관계 역량" placeholder="정답"><input data-answer="자기 성찰·계발 역량" aria-label="자기 성찰·계발 역량" placeholder="정답"><input data-answer="디지털·미디어 역량" aria-label="디지털·미디어 역량" placeholder="정답"><input data-answer="비판적·창의적 사고 역량" aria-label="비판적·창의적 사고 역량" placeholder="정답"><input data-answer="문화 향유 역량" aria-label="문화 향유 역량" placeholder="정답"><input data-answer="의사소통 역량" aria-label="의사소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="math" aria-expanded="false">수학</button>
     <section id="math">
       <h2>수학</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="연결" aria-label="연결" placeholder="정답"><input data-answer="문제해결" aria-label="문제해결" placeholder="정답"><input data-answer="의사소통" aria-label="의사소통" placeholder="정답"><input data-answer="추론" aria-label="추론" placeholder="정답"><input data-answer="정보처리" aria-label="정보처리" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="social" aria-expanded="false">사회</button>
     <section id="social">
       <h2>사회</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="창의적 사고력" aria-label="창의적 사고력" placeholder="정답"><input data-answer="문제해결력 및 의사결정력" aria-label="문제해결력 및 의사결정력" placeholder="정답"><input data-answer="의사소통 및 협업능력" aria-label="의사소통 및 협업능력" placeholder="정답"><input data-answer="정보 활용 능력" aria-label="정보 활용 능력" placeholder="정답"><input data-answer="비판적 사고력" aria-label="비판적 사고력" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="science" aria-expanded="false">과학</button>
     <section id="science">
       <h2>과학</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="과학적 탐구와 문제해결 능력" aria-label="과학적 탐구와 문제해결 능력" placeholder="정답"><input data-answer="과학적 의사결정 능력" aria-label="과학적 의사결정 능력" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="english" aria-expanded="false">영어</button>
     <section id="english">
       <h2>영어</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="영어 의사소통 역량" aria-label="영어 의사소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="music-subject" aria-expanded="false">음악</button>
     <section id="music-subject">
       <h2>음악</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="자기주도성 역량" aria-label="자기주도성 역량" placeholder="정답"><input data-answer="소통 역량" aria-label="소통 역량" placeholder="정답"><input data-answer="감성 역량" aria-label="감성 역량" placeholder="정답"><input data-answer="창의성 역량" aria-label="창의성 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="art" aria-expanded="false">미술</button>
     <section id="art">
       <h2>미술</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="정체성 역량" aria-label="정체성 역량" placeholder="정답"><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="창의·융합 역량" aria-label="창의·융합 역량" placeholder="정답"><input data-answer="시각적 소통 역량" aria-label="시각적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="pe" aria-expanded="false">체육</button>
     <section id="pe">
       <h2>체육</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="신체활동 문화 향유 역량" aria-label="신체활동 문화 향유 역량" placeholder="정답"><input data-answer="움직임 수행 역량" aria-label="움직임 수행 역량" placeholder="정답"><input data-answer="건강 관리 역량" aria-label="건강 관리 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="practical" aria-expanded="false">실과</button>
     <section id="practical">
       <h2>실과</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="실천적 문제 해결 능력" aria-label="실천적 문제 해결 능력" placeholder="정답"><input data-answer="생활 자립 능력" aria-label="생활 자립 능력" placeholder="정답"><input data-answer="관계 형성 능력" aria-label="관계 형성 능력" placeholder="정답"><input data-answer="기술적 실천 능력" aria-label="기술적 실천 능력" placeholder="정답"><input data-answer="기술적 문제해결 능력" aria-label="기술적 문제해결 능력" placeholder="정답"><input data-answer="기술학적 지식의 이해 능력" aria-label="기술학적 지식의 이해 능력" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="integrated" aria-expanded="false">통합</button>
     <section id="integrated">
       <h2>통합</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="지금-여기-우리 삶" aria-label="지금-여기-우리 삶" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="goodlife" aria-expanded="false">통합-바생(총론)</button>
     <section id="goodlife">
       <h2>통합-바생(총론)</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="자기관리 역량" aria-label="자기관리 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="sociality" aria-expanded="false">통합-슬생(총론)</button>
     <section id="sociality">
       <h2>통합-슬생(총론)</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="지식정보처리 역량" aria-label="지식정보처리 역량" placeholder="정답"><input data-answer="창의적 사고 역량" aria-label="창의적 사고 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="joyful" aria-expanded="false">통합-즐생(총론)</button>
     <section id="joyful">
       <h2>통합-즐생(총론)</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="moral-future" aria-expanded="false">도덕-미래사회가 요구하는 역량</button>
     <section id="moral-future">
       <h2>도덕-미래사회가 요구하는 역량</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="비판적·배려적 사고력" aria-label="비판적·배려적 사고력" placeholder="정답"><input data-answer="도덕적 상상력" aria-label="도덕적 상상력" placeholder="정답"><input data-answer="도덕적 판단 능력" aria-label="도덕적 판단 능력" placeholder="정답"><input data-answer="인공 지능 및 디지털 윤리" aria-label="인공 지능 및 디지털 윤리" placeholder="정답"><input data-answer="도덕 공동체 의식" aria-label="도덕 공동체 의식" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <button class="accordion-header" aria-controls="moral-emphasis" aria-expanded="false">도덕-도덕과 강조점</button>
     <section id="moral-emphasis">
       <h2>도덕-도덕과 강조점</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="도덕 현상에 관한 탐구" aria-label="도덕 현상에 관한 탐구" placeholder="정답"><input data-answer="일상의 실천" aria-label="일상의 실천" placeholder="정답"><input data-answer="내면의 도덕성에 대한 성찰" aria-label="내면의 도덕성에 대한 성찰" placeholder="정답"></td></tr></tbody></table></div></div>
   </section>
-  </div>
 </main>
 <!-- competency main end -->
 

--- a/styles.css
+++ b/styles.css
@@ -844,3 +844,11 @@
     color: var(--primary);
 }
 
+#competency-quiz-main .competency-tabs {
+    flex-wrap: wrap;
+}
+#competency-quiz-main .competency-tab.cleared {
+    background: var(--correct);
+    color: var(--bg-dark);
+}
+


### PR DESCRIPTION
## Summary
- switch competency sections from accordion to tab buttons
- celebrate competency part completion with confetti and button highlight
- add styling for competency tabs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f68ee70cc832caf053beecb22a6f3