### PR TITLE
Improve competency tab navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -552,7 +552,25 @@
         });
 
         const competencyTabs = document.querySelector('.competency-tabs');
+        const scrollLeftBtn = document.querySelector('.competency-tab-wrapper .scroll-btn.left');
+        const scrollRightBtn = document.querySelector('.competency-tab-wrapper .scroll-btn.right');
+
+        function updateScrollButtons() {
+            if (!competencyTabs) return;
+            if (scrollLeftBtn) scrollLeftBtn.disabled = competencyTabs.scrollLeft <= 0;
+            if (scrollRightBtn) scrollRightBtn.disabled = competencyTabs.scrollLeft + competencyTabs.clientWidth >= competencyTabs.scrollWidth - 1;
+        }
+
         if (competencyTabs) {
+            updateScrollButtons();
+            if (scrollLeftBtn) scrollLeftBtn.addEventListener('click', () => {
+                competencyTabs.scrollBy({ left: -200, behavior: 'smooth' });
+            });
+            if (scrollRightBtn) scrollRightBtn.addEventListener('click', () => {
+                competencyTabs.scrollBy({ left: 200, behavior: 'smooth' });
+            });
+            competencyTabs.addEventListener('scroll', updateScrollButtons);
+            window.addEventListener('resize', updateScrollButtons);
             competencyTabs.addEventListener('click', e => {
                 if (!e.target.matches('.competency-tab')) return;
                 playSound(clickAudio);

--- a/index.html
+++ b/index.html
@@ -647,7 +647,9 @@
 
 <!-- competency main start -->
 <main id="competency-quiz-main" class="hidden competency-ui">
-  <div class="tabs competency-tabs">
+  <div class="competency-tab-wrapper">
+    <button class="scroll-btn left" aria-label="이전">&#9664;</button>
+    <div class="tabs competency-tabs scroll-container">
     <button class="competency-tab tab active" data-target="summary">총론</button>
     <button class="competency-tab tab" data-target="korean">국어</button>
     <button class="competency-tab tab" data-target="math">수학</button>
@@ -664,6 +666,8 @@
     <button class="competency-tab tab" data-target="joyful">통합-즐생(총론)</button>
     <button class="competency-tab tab" data-target="moral-future">도덕-미래사회가 요구하는 역량</button>
     <button class="competency-tab tab" data-target="moral-emphasis">도덕-도덕과 강조점</button>
+    </div>
+    <button class="scroll-btn right" aria-label="다음">&#9654;</button>
   </div>
     <section id="summary" class="active">
       <h2>총론</h2>

--- a/styles.css
+++ b/styles.css
@@ -844,8 +844,38 @@
     color: var(--primary);
 }
 
+#competency-quiz-main .competency-tab-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
 #competency-quiz-main .competency-tabs {
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 1rem;
+    scroll-behavior: smooth;
+    scrollbar-width: none;
+}
+#competency-quiz-main .competency-tabs::-webkit-scrollbar {
+    display: none;
+}
+
+#competency-quiz-main .scroll-btn {
+    background: var(--secondary);
+    border: 3px solid var(--primary);
+    color: var(--text-light);
+    padding: 0.8rem 1.2rem;
+    cursor: pointer;
+    font-size: 1.6rem;
+    border-radius: 50%;
+    flex: 0 0 auto;
+}
+
+#competency-quiz-main .scroll-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
 }
 #competency-quiz-main .competency-tab.cleared {
     background: var(--correct);


### PR DESCRIPTION
## Summary
- improve UI/UX for competency subject buttons
- add scroll buttons and wrapper to competency tab area
- style competency tab wrapper and scroll buttons
- handle scroll button behavior in JS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f6b91a2c4832cba6ba91945003e44