### PR TITLE
Fix answer reveal for competency subject

### DIFF
--- a/app.js
+++ b/app.js
@@ -624,15 +624,19 @@
         });
 
         showAnswersBtn.addEventListener('click', () => {
-            document.querySelectorAll(`#${gameState.selectedSubject}-quiz-main input[data-answer]`).forEach(input => {
-                input.value = input.dataset.answer;
-                input.disabled = true;
-                if (input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
-                } else {
-                    input.classList.remove(CONSTANTS.CSS_CLASSES.INCORRECT, CONSTANTS.CSS_CLASSES.RETRYING);
-                    input.classList.add(CONSTANTS.CSS_CLASSES.REVEALED);
-                }
-            });
+            document
+                .querySelectorAll(`#${gameState.selectedSubject}-quiz-main input[data-answer]`)
+                .forEach(input => {
+                    if (!input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
+                        input.value = input.dataset.answer;
+                        input.classList.remove(
+                            CONSTANTS.CSS_CLASSES.INCORRECT,
+                            CONSTANTS.CSS_CLASSES.RETRYING
+                        );
+                        input.classList.add(CONSTANTS.CSS_CLASSES.REVEALED);
+                    }
+                    input.disabled = true;
+                });
             showAnswersBtn.disabled = true;
         });
 


### PR DESCRIPTION
## Summary
- preserve user-provided answers for the competency subject when showing all answers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f81ac9430832c9bfb4ef93088c7fe