### PR TITLE
Implement topic selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,10 @@
                 COMPETENCY: "competency",
                 RANDOM: 'random'
             },
+            TOPICS: {
+                CURRICULUM: 'curriculum',
+                COMPETENCY: 'competency'
+            },
             MODES: {
                 NORMAL: 'normal',
                 HARD_CORE: 'hard-core'
@@ -55,6 +59,7 @@
             combo: 0,
             lives: CONSTANTS.HARD_CORE_LIVES,
             selectedSubject: CONSTANTS.SUBJECTS.MUSIC,
+            selectedTopic: CONSTANTS.TOPICS.CURRICULUM,
             gameMode: CONSTANTS.MODES.NORMAL,
             isRandomizing: false,
             typingInterval: null
@@ -85,6 +90,7 @@
         const decreaseTimeBtn = document.getElementById('decrease-time');
         const increaseTimeBtn = document.getElementById('increase-time');
         const timeSetterWrapper = document.getElementById('time-setter-wrapper');
+        const topicSelector = document.querySelector('.topic-selector');
         const subjectSelector = document.querySelector('.subject-selector');
         const quizContainers = document.querySelectorAll('main[id$="-quiz-main"]');
         const modalCharacterPlaceholder = document.getElementById('modal-character-placeholder');
@@ -154,6 +160,14 @@
             heartIcons.forEach((heart, index) => {
                 heart.classList.toggle(CONSTANTS.CSS_CLASSES.LOST, index >= gameState.lives);
             });
+        }
+
+        function updateStartModalUI() {
+            if (gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM) {
+                subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+            } else {
+                subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
+            }
         }
 
         function setCharacterState(state, duration = 1500) {
@@ -291,11 +305,12 @@
             forceQuitBtn.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             document.getElementById('timer-container').classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             livesContainer.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
-            
+
             if (showStartModal) {
                 startModal.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+                updateStartModalUI();
             }
-            
+
             setCharacterState('idle');
         }
 
@@ -521,6 +536,27 @@
         }
 
         // --- EVENT LISTENERS ---
+        topicSelector.addEventListener('click', e => {
+            if (!e.target.matches('.btn')) return;
+            playSound(clickAudio);
+            document.querySelectorAll('.topic-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
+            e.target.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
+            const topic = e.target.dataset.topic;
+            gameState.selectedTopic = topic;
+            if (topic === CONSTANTS.TOPICS.CURRICULUM) {
+                subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+                if (!document.querySelector('.subject-btn.selected')) {
+                    const defaultBtn = document.querySelector('.subject-btn[data-subject="music"]');
+                    if (defaultBtn) defaultBtn.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
+                    gameState.selectedSubject = CONSTANTS.SUBJECTS.MUSIC;
+                }
+            } else {
+                subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
+                document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
+                gameState.selectedSubject = CONSTANTS.SUBJECTS.COMPETENCY;
+            }
+        });
+
         subjectSelector.addEventListener('click', e => {
             if (!e.target.matches('.btn') || gameState.isRandomizing) return;
 
@@ -698,7 +734,10 @@
 
         // --- INITIAL SETUP ---
         function initializeApp() {
+            gameState.selectedTopic = CONSTANTS.TOPICS.CURRICULUM;
+            gameState.selectedSubject = CONSTANTS.SUBJECTS.MUSIC;
             resetGame(false); // Reset state without showing any modal
+            updateStartModalUI();
             guideModal.classList.add('active'); // Always show guide on page load
         }
 

--- a/index.html
+++ b/index.html
@@ -792,7 +792,7 @@
           <div class="guide-steps">
               <div class="guide-step">
                   <div class="guide-label">STEP 1</div>
-                  <div class="guide-text"><strong>설정:</strong> 학습할 과목, 모드, 시간을 선택하세요.</div>
+                  <div class="guide-text"><strong>설정:</strong> 학습할 주제와 과목, 모드, 시간을 선택하세요.</div>
               </div>
               <div class="guide-step">
                   <div class="guide-label">STEP 2</div>
@@ -814,12 +814,16 @@
 
   <div id="start-modal" class="modal-overlay">
         <div class="modal-content">
+            <h2>주제 선택</h2>
+            <div class="topic-selector">
+                <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>
+                <button class="btn topic-btn" data-topic="competency">역량</button>
+            </div>
             <h2>과목 선택</h2>
             <div class="subject-selector">
                 <button class="btn subject-btn selected" data-subject="music">음악</button>
                 <button class="btn subject-btn" data-subject="art">미술</button>
                 <button class="btn subject-btn" data-subject="korean">국어</button>
-                <button class="btn subject-btn" data-subject="competency">역량</button>
                 <button id="random-subject-btn" class="btn" data-subject="random">랜덤</button>
             </div>
             <h2>게임 모드</h2>

--- a/styles.css
+++ b/styles.css
@@ -420,7 +420,7 @@
         color: var(--correct);
     }
 
-    .time-setter, .subject-selector, .mode-selector {
+    .time-setter, .subject-selector, .mode-selector, .topic-selector {
         display: flex;
         justify-content: center;
         align-items: center;
@@ -439,10 +439,10 @@
         font-size: 2rem;
         padding: 0.5rem 1.5rem;
     }
-    .subject-btn, .mode-btn, #random-subject-btn {
+    .subject-btn, .mode-btn, .topic-btn, #random-subject-btn {
         font-size: 1.6rem;
     }
-    .subject-btn.selected, .mode-btn.selected {
+    .subject-btn.selected, .mode-btn.selected, .topic-btn.selected {
         background: var(--primary);
         color: var(--text-light);
         transform: translateY(3px);


### PR DESCRIPTION
## Summary
- add a new topic selection step in the start modal
- update app logic to handle topics and show/hide subject choices
- tweak guide text and UI styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872065b7cf8832ca739e157478fdce4