### PR TITLE
Hide subject selection when competency chosen

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,6 +91,7 @@
         const increaseTimeBtn = document.getElementById('increase-time');
         const timeSetterWrapper = document.getElementById('time-setter-wrapper');
         const topicSelector = document.querySelector('.topic-selector');
+        const subjectTitle = document.getElementById('subject-title');
         const subjectSelector = document.querySelector('.subject-selector');
         const quizContainers = document.querySelectorAll('main[id$="-quiz-main"]');
         const modalCharacterPlaceholder = document.getElementById('modal-character-placeholder');
@@ -163,11 +164,9 @@
         }
 
         function updateStartModalUI() {
-            if (gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM) {
-                subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
-            } else {
-                subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
-            }
+            const showSubject = gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM;
+            subjectTitle.classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, !showSubject);
+            subjectSelector.classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, !showSubject);
         }
 
         function setCharacterState(state, duration = 1500) {
@@ -544,6 +543,7 @@
             const topic = e.target.dataset.topic;
             gameState.selectedTopic = topic;
             if (topic === CONSTANTS.TOPICS.CURRICULUM) {
+                subjectTitle.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
                 subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
                 if (!document.querySelector('.subject-btn.selected')) {
                     const defaultBtn = document.querySelector('.subject-btn[data-subject="music"]');
@@ -551,6 +551,7 @@
                     gameState.selectedSubject = CONSTANTS.SUBJECTS.MUSIC;
                 }
             } else {
+                subjectTitle.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
                 gameState.selectedSubject = CONSTANTS.SUBJECTS.COMPETENCY;

--- a/index.html
+++ b/index.html
@@ -819,7 +819,7 @@
                 <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>
                 <button class="btn topic-btn" data-topic="competency">역량</button>
             </div>
-            <h2>과목 선택</h2>
+            <h2 id="subject-title">과목 선택</h2>
             <div class="subject-selector">
                 <button class="btn subject-btn selected" data-subject="music">음악</button>
                 <button class="btn subject-btn" data-subject="art">미술</button>


### PR DESCRIPTION
## Summary
- give the subject selector heading an id
- toggle the subject title and buttons together when switching topics

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872091c6360832c8b0518ea43a80c33