### PR TITLE
Hide subject options when competency topic selected

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,6 +92,7 @@
         const timeSetterWrapper = document.getElementById('time-setter-wrapper');
         const topicSelector = document.querySelector('.topic-selector');
         const subjectSelector = document.querySelector('.subject-selector');
+        const subjectHeading = document.getElementById('subject-heading');
         const quizContainers = document.querySelectorAll('main[id$="-quiz-main"]');
         const modalCharacterPlaceholder = document.getElementById('modal-character-placeholder');
         const speechBubble = document.querySelector('.speech-bubble');
@@ -165,8 +166,10 @@
         function updateStartModalUI() {
             if (gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM) {
                 subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+                subjectHeading.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
             } else {
                 subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
+                subjectHeading.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             }
         }
 
@@ -545,6 +548,7 @@
             gameState.selectedTopic = topic;
             if (topic === CONSTANTS.TOPICS.CURRICULUM) {
                 subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+                subjectHeading.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
                 if (!document.querySelector('.subject-btn.selected')) {
                     const defaultBtn = document.querySelector('.subject-btn[data-subject="music"]');
                     if (defaultBtn) defaultBtn.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
@@ -552,6 +556,7 @@
                 }
             } else {
                 subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
+                subjectHeading.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
                 gameState.selectedSubject = CONSTANTS.SUBJECTS.COMPETENCY;
             }

--- a/index.html
+++ b/index.html
@@ -819,7 +819,7 @@
                 <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>
                 <button class="btn topic-btn" data-topic="competency">역량</button>
             </div>
-            <h2>과목 선택</h2>
+            <h2 id="subject-heading">과목 선택</h2>
             <div class="subject-selector">
                 <button class="btn subject-btn selected" data-subject="music">음악</button>
                 <button class="btn subject-btn" data-subject="art">미술</button>


### PR DESCRIPTION
## Summary
- add `subject-heading` ID to the subject heading
- hide subject heading and buttons when selecting the competency topic

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68720e75eda4832c9aaf882288c121ec