### PR TITLE
Hide subject selector for competency topic

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,6 +92,7 @@
         const timeSetterWrapper = document.getElementById('time-setter-wrapper');
         const topicSelector = document.querySelector('.topic-selector');
         const subjectSelector = document.querySelector('.subject-selector');
+        const subjectHeading = document.getElementById('subject-heading');
         const quizContainers = document.querySelectorAll('main[id$="-quiz-main"]');
         const modalCharacterPlaceholder = document.getElementById('modal-character-placeholder');
         const speechBubble = document.querySelector('.speech-bubble');
@@ -163,11 +164,9 @@
         }
 
         function updateStartModalUI() {
-            if (gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM) {
-                subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
-            } else {
-                subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
-            }
+            const showSubjects = gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM;
+            subjectSelector.classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, !showSubjects);
+            subjectHeading.classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, !showSubjects);
         }
 
         function setCharacterState(state, duration = 1500) {
@@ -544,17 +543,16 @@
             const topic = e.target.dataset.topic;
             gameState.selectedTopic = topic;
             if (topic === CONSTANTS.TOPICS.CURRICULUM) {
-                subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
                 if (!document.querySelector('.subject-btn.selected')) {
                     const defaultBtn = document.querySelector('.subject-btn[data-subject="music"]');
                     if (defaultBtn) defaultBtn.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
                     gameState.selectedSubject = CONSTANTS.SUBJECTS.MUSIC;
                 }
             } else {
-                subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
                 gameState.selectedSubject = CONSTANTS.SUBJECTS.COMPETENCY;
             }
+            updateStartModalUI();
         });
 
         subjectSelector.addEventListener('click', e => {

--- a/index.html
+++ b/index.html
@@ -819,7 +819,7 @@
                 <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>
                 <button class="btn topic-btn" data-topic="competency">역량</button>
             </div>
-            <h2>과목 선택</h2>
+            <h2 id="subject-heading">과목 선택</h2>
             <div class="subject-selector">
                 <button class="btn subject-btn selected" data-subject="music">음악</button>
                 <button class="btn subject-btn" data-subject="art">미술</button>


### PR DESCRIPTION
## Summary
- hide "과목 선택" header and subject buttons when topic is set to 역량
- keep UI consistent via `updateStartModalUI` helper

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687213883374832ca8e09c776b040101