### PR TITLE
Disable subject selector when competency topic chosen

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,11 +162,15 @@
             });
         }
 
-        function updateStartModalUI() {
+       function updateStartModalUI() {
+            const subjectButtons = subjectSelector.querySelectorAll('.btn');
+
             if (gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM) {
                 subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+                subjectButtons.forEach(btn => { btn.disabled = false; });
             } else {
                 subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
+                subjectButtons.forEach(btn => { btn.disabled = true; });
             }
         }
 
@@ -555,6 +559,7 @@
                 document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
                 gameState.selectedSubject = CONSTANTS.SUBJECTS.COMPETENCY;
             }
+            updateStartModalUI();
         });
 
         subjectSelector.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- disable all subject buttons when '역량' topic is selected
- re-enable subject buttons when switching back to '내체표'
- keep subject selector UI up to date on topic changes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687216bcea84832c9d963eeeab96f9ba