### PR TITLE
Fix competency tab reset

### DIFF
--- a/app.js
+++ b/app.js
@@ -314,6 +314,10 @@
             document.getElementById('timer-container').classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             livesContainer.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
 
+            // Reset competency tab states
+            document.querySelectorAll('.competency-tab.cleared')
+                .forEach(tab => tab.classList.remove('cleared'));
+
             if (showStartModal) {
                 startModal.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
                 updateStartModalUI();


### PR DESCRIPTION
## Summary
- remove `cleared` styling from competency tabs when resetting the game

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872c728cf20832c8a7a2e702f735b57