### PR TITLE
Add PE activity examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,6 +770,7 @@
       <div class="tab active" data-target="exercise">운동</div>
       <div class="tab" data-target="sports">스포츠</div>
       <div class="tab" data-target="expression-pe">표현</div>
+      <div class="tab" data-target="activity-examples">신체활동 예시</div>
     </div>
     <section id="exercise" class="active">
       <h2>운동</h2>
@@ -845,6 +846,188 @@
           </table>
         </div>
       </div>
+    </section>
+    <section id="activity-examples">
+      <h2>신체활동 예시</h2>
+      <div class="tabs">
+        <div class="tab active" data-target="exercise-examples">운동</div>
+        <div class="tab" data-target="sports-examples">스포츠</div>
+        <div class="tab" data-target="expression-examples">표현</div>
+      </div>
+      <section id="exercise-examples" class="active">
+        <div class="grade-container">
+          <div>
+            <div class="grade-title">3~4학년</div>
+            <table>
+            <tbody>
+              <tr>
+                <th>세부 영역</th>
+                <td>
+                  <input data-answer="[기본 체력운동]" aria-label="세부 영역" placeholder="정답">
+                  <input data-answer="체력운동 관련 기본 움직임 기술(걷기, 달리기, 매달리기, 버티기나 굽히기, 밀기, 당기기)" aria-label="신체활동 예시" placeholder="정답">
+                  <input data-answer="체력운동 기능(오래 달리거나 걷기, 팔굽혀펴기, 윗몸말아올리기, 왕복달리기)" aria-label="신체활동 예시" placeholder="정답">
+                </td>
+              </tr>
+              <tr>
+                <th>세부 영역</th>
+                <td>
+                  <input data-answer="[건강 운동 및 생활습관]" aria-label="세부 영역" placeholder="정답">
+                  <input data-answer="건강 생활 습관(자세, 체중 및 체형 관리, 위생, 식습관, 정서 관리 활동)" aria-label="신체활동 예시" placeholder="정답">
+                  <input data-answer="운동 생활 습관(맨손체조, 산책, 계단 오르기, 생활 주변 운동기구 활용하기)" aria-label="신체활동 예시" placeholder="정답">
+                </td>
+              </tr>
+            </tbody>
+            </table>
+          </div>
+          <div>
+            <div class="grade-title">5~6학년</div>
+            <table>
+            <tbody>
+              <tr>
+                <th>세부 영역</th>
+                <td>
+                  <input data-answer="[건강 체력 및 운동 체력]" aria-label="세부 영역" placeholder="정답">
+                  <input data-answer="건강체력 관련 운동(근력, 근지구력, 심폐지구력, 유연성 운동)" aria-label="신체활동 예시" placeholder="정답">
+                  <input data-answer="운동체력 관련 운동(순발력, 민첩성, 평형성, 협응성 운동)" aria-label="신체활동 예시" placeholder="정답">
+                </td>
+              </tr>
+              <tr>
+                <th>세부 영역</th>
+                <td>
+                  <input data-answer="[성장 및 안전 활동]" aria-label="세부 영역" placeholder="정답">
+                  <input data-answer="성장 관련 활동(신체 변화 및 제2차 성징 이해 활동, 감정 수용 및 조절 활동, 관계 형성 활동, 성 건강 활동)" aria-label="신체활동 예시" placeholder="정답">
+                  <input data-answer="안전 활동(운동 관련 안전사고 예방 및 대처 활동, 생활 안전사고 예방 및 대처 활동, 자연환경 변화 대처 활동)" aria-label="신체활동 예시" placeholder="정답">
+                </td>
+              </tr>
+            </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+      <section id="sports-examples">
+        <div class="grade-container">
+          <div>
+            <div class="grade-title">3~4학년</div>
+            <table>
+              <tbody>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[기본 움직임의 기초 기술]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="이동 움직임(방향 전환 달리기, 뛰기, 구르기, 물에서 이동하기)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="비이동 움직임(균형잡기, 구부리기, 회전하기, 물에 뜨기)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="조작 움직임(던지기, 굴리기, 차기, 잡기, 치기, 튀기기, 몰기, 타기)" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[스포츠 유형별 움직임 기술]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="기술형 스포츠 유형별 움직임(앞뒤 구르기, 옆돌기, 전력 달리기, 헤엄치기, 발차기)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="전략형 스포츠 유형별 움직임(공던지기와 잡기, 공몰기, 공차기와 멈추기, 공치기와 받기, 라켓으로 치기)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="생태형 스포츠 유형별 움직임(균형 잡고 이동하기, 타고 버티기, 잡고 오르기)" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <div class="grade-title">5~6학년</div>
+            <table>
+              <tbody>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[기술형 스포츠 유형별 활동]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="기록형(육상 활동, 경영 활동, 빙상 활동, 표적 활동)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="동작형(매트 활동, 뜀틀 활동, 평균대 활동)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="투기형(태권도 활동, 씨름 활동)" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[전략형 스포츠 유형별 활동]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="영역형(축구형 게임, 농구형 게임, 핸드볼형 게임, 럭비형 게임, 하키형 게임)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="필드형(야구형 게임 등)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="네트형(배구형 게임, 배드민턴형 게임, 족구형 게임, 탁구형 게임, 테니스형 게임)" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[생태형 스포츠 유형별 활동]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="생활환경형(골프형 활동, 플라잉디스크형 활동, 자전거타기형 활동, 인라인스케이팅 활동, 스포츠클라이밍 활동, 민속놀이)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="자연환경형(오리엔티어링, 등산 활동, 캠핑 활동, 수상 활동, 설상 활동, 승마 활동)" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+      <section id="expression-examples">
+        <div class="grade-container">
+          <div>
+            <div class="grade-title">3~4학년</div>
+            <table>
+              <tbody>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[기본 움직임의 기초 표현]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="이동 움직임 표현(워킹, 점핑, 호핑, 스키핑, 갤러핑, 리핑, 슬라이딩)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="비이동 움직임 표현(펴기, 접기, 비틀기, 제자리 돌기, 털기, 흔들기)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="조작 움직임 표현(들기, 돌리기)" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[기본 움직임의 표현 방법]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="추상 표현(언어 표현, 느낌이나 생각 표현하기)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="모방 표현(사물 표현, 인물 표현, 자연 현상 표현하기)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="리듬 표현(박자, 강약, 빠르기, 패턴에 따라 표현하기)" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="도구 표현(줄, 공, 천, 훌라후프 등을 활용하여 표현하기)" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <div class="grade-title">5~6학년</div>
+            <table>
+              <tbody>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[스포츠 표현 활동]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="창작체조 활동" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="음악줄넘기 활동" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[전통 표현 활동]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="우리나라의 민속무용 활동" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="외국의 민속무용 활동" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+                <tr>
+                  <th>세부 영역</th>
+                  <td>
+                    <input data-answer="[현대 표현 활동]" aria-label="세부 영역" placeholder="정답">
+                    <input data-answer="라인댄스 활동" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="댄스스포츠 활동" aria-label="신체활동 예시" placeholder="정답">
+                    <input data-answer="스트리트댄스 활동" aria-label="신체활동 예시" placeholder="정답">
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
     </section>
   </main>
 <!-- competency main start -->


### PR DESCRIPTION
## Summary
- add '신체활동 예시' tab under 체육 with 운동, 스포츠, 표현 sample activities

## Testing
- `npm run lint` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687343eba0b4832c8679225211559b1e