### PR TITLE
Update PE activity input styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
             <table>
               <tbody>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="기본 체력운동" aria-label="기본 체력운동" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="기본 체력운동" aria-label="기본 체력운동" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="체력운동 관련 기본 움직임 기술" aria-label="체력운동 관련 기본 움직임 기술" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="걷기" aria-label="걷기" placeholder="구체적 예시">
@@ -878,7 +878,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="건강 운동 및 생활습관" aria-label="건강 운동 및 생활습관" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="건강 운동 및 생활습관" aria-label="건강 운동 및 생활습관" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="건강 생활 습관" aria-label="건강 생활 습관" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="자세" aria-label="자세" placeholder="구체적 예시">
@@ -901,7 +901,7 @@
             <table>
               <tbody>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="건강 체력 및 운동 체력" aria-label="건강 체력 및 운동 체력" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="건강 체력 및 운동 체력" aria-label="건강 체력 및 운동 체력" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="건강체력 관련 운동" aria-label="건강체력 관련 운동" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="근력" aria-label="근력" placeholder="구체적 예시">
@@ -916,7 +916,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="성장 및 안전 활동" aria-label="성장 및 안전 활동" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="성장 및 안전 활동" aria-label="성장 및 안전 활동" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="성장 관련 활동" aria-label="성장 관련 활동" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="신체 변화 및 제2차 성징 이해 활동" aria-label="신체 변화 및 제2차 성징 이해 활동" placeholder="구체적 예시">
@@ -941,7 +941,7 @@
             <table>
               <tbody>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="기본 움직임의 기초 기술" aria-label="기본 움직임의 기초 기술" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="기본 움직임의 기초 기술" aria-label="기본 움직임의 기초 기술" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="이동 움직임" aria-label="이동 움직임" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="방향 전환 달리기" aria-label="방향 전환 달리기" placeholder="구체적 예시">
@@ -965,7 +965,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="스포츠 유형별 움직임 기술" aria-label="스포츠 유형별 움직임 기술" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="스포츠 유형별 움직임 기술" aria-label="스포츠 유형별 움직임 기술" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="기술형 스포츠 유형별 움직임" aria-label="기술형 스포츠 유형별 움직임" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="앞뒤 구르기" aria-label="앞뒤 구르기" placeholder="구체적 예시">
@@ -993,7 +993,7 @@
             <table>
               <tbody>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="기술형 스포츠 유형별 활동" aria-label="기술형 스포츠 유형별 활동" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="기술형 스포츠 유형별 활동" aria-label="기술형 스포츠 유형별 활동" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="기록형" aria-label="기록형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="육상 활동" aria-label="육상 활동" placeholder="구체적 예시">
@@ -1010,7 +1010,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="전략형 스포츠 유형별 활동" aria-label="전략형 스포츠 유형별 활동" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="전략형 스포츠 유형별 활동" aria-label="전략형 스포츠 유형별 활동" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="영역형" aria-label="영역형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="축구형 게임" aria-label="축구형 게임" placeholder="구체적 예시">
@@ -1029,7 +1029,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="생태형 스포츠 유형별 활동" aria-label="생태형 스포츠 유형별 활동" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="생태형 스포츠 유형별 활동" aria-label="생태형 스포츠 유형별 활동" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="생활환경형" aria-label="생활환경형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="골프형 활동" aria-label="골프형 활동" placeholder="구체적 예시">
@@ -1059,7 +1059,7 @@
             <table>
               <tbody>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="기본 움직임의 기초 표현" aria-label="기본 움직임의 기초 표현" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="기본 움직임의 기초 표현" aria-label="기본 움직임의 기초 표현" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="이동 움직임 표현" aria-label="이동 움직임 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="워킹" aria-label="워킹" placeholder="구체적 예시">
@@ -1082,7 +1082,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="기본 움직임의 표현 방법" aria-label="기본 움직임의 표현 방법" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="기본 움직임의 표현 방법" aria-label="기본 움직임의 표현 방법" placeholder="세부 영역"></th>
                   <td>
                     <input class="activity-input" data-answer="추상 표현" aria-label="추상 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="언어 표현" aria-label="언어 표현" placeholder="구체적 예시">
@@ -1111,21 +1111,21 @@
             <table>
               <tbody>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="스포츠 표현 활동" aria-label="스포츠 표현 활동" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="스포츠 표현 활동" aria-label="스포츠 표현 활동" placeholder="세부 영역"></th>
                   <td>
                     <input class="example-input" data-answer="창작체조 활동" aria-label="창작체조 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="음악줄넘기 활동" aria-label="음악줄넘기 활동" placeholder="구체적 예시">
                   </td>
                 </tr>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="전통 표현 활동" aria-label="전통 표현 활동" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="전통 표현 활동" aria-label="전통 표현 활동" placeholder="세부 영역"></th>
                   <td>
                     <input class="example-input" data-answer="우리나라의 민속무용 활동" aria-label="우리나라의 민속무용 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="외국의 민속무용 활동" aria-label="외국의 민속무용 활동" placeholder="구체적 예시">
                   </td>
                 </tr>
                 <tr>
-                  <th><input class="sub-area-input" data-answer="현대 표현 활동" aria-label="현대 표현 활동" placeholder="세부 영역"></th>
+                  <th class="sub-area-cell"><input class="sub-area-input" data-answer="현대 표현 활동" aria-label="현대 표현 활동" placeholder="세부 영역"></th>
                   <td>
                     <input class="example-input" data-answer="라인댄스 활동" aria-label="라인댄스 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="댄스스포츠 활동" aria-label="댄스스포츠 활동" placeholder="구체적 예시">

--- a/styles.css
+++ b/styles.css
@@ -300,22 +300,28 @@
       background: var(--bg-light);
     }
 
+    th.sub-area-cell {
+      min-width: 18rem;
+    }
+
     th input.sub-area-input {
       width: 100%;
-      padding: 1.2rem;
-      font-size: 1.4rem;
-      border: 2px solid var(--accent);
-      background: var(--bg-dark);
+      padding: 1.4rem 1.6rem;
+      font-size: 1.6rem;
+      border: 3px solid var(--accent);
+      background: var(--secondary);
       color: var(--text-light);
       border-radius: 8px;
     }
 
     td input.activity-input {
-      border-color: var(--accent);
+      border: 3px solid var(--accent);
+      background: var(--bg-dark);
     }
 
     td input.example-input {
-      border-color: var(--text-dark);
+      border: 2px dashed var(--text-dark);
+      background: var(--bg-light);
     }
     
     .grade-container table tr:not(:last-child) > * {


### PR DESCRIPTION
## Summary
- style PE sub-area inputs with more width and accent colors
- differentiate activity/example input fields
- adjust HTML to use new `sub-area-cell` class

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68736bb3db1c832cb607f353c2e642b5