### PR TITLE
Improve activity and example input styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -317,14 +317,16 @@ th input.sub-area-input {
 
 td input.activity-input {
   border: 3px solid var(--accent);
-  background: var(--secondary);
-  font-weight: 700;
+  background: var(--primary);
+  font-weight: 800;
+  color: var(--text-light);
 }
 
 td input.example-input {
   border: 2px dashed var(--text-dark);
-  background: var(--bg-dark);
+  background: var(--bg-light);
   margin-left: 1rem;
+  border-left: 5px dotted var(--primary);
 }
 
 td input.activity-input:not(:first-child) {


### PR DESCRIPTION
## Summary
- enhance `.activity-input` with bright background and heavier font weight
- give `.example-input` a distinct border and background

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68738211288c832ca79d99831eaacb94