### PR TITLE
Group activity examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -863,6 +863,7 @@
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="기본 체력운동" aria-label="기본 체력운동" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="체력운동 관련 기본 움직임 기술" aria-label="체력운동 관련 기본 움직임 기술" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="걷기" aria-label="걷기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="달리기" aria-label="달리기" placeholder="구체적 예시">
@@ -870,27 +871,34 @@
                     <input class="example-input" data-answer="버티기나 굽히기" aria-label="버티기나 굽히기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="밀기" aria-label="밀기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="당기기" aria-label="당기기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="체력운동 기능" aria-label="체력운동 기능" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="오래 달리거나 걷기" aria-label="오래 달리거나 걷기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="팔굽혀펴기" aria-label="팔굽혀펴기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="윗몸말아올리기" aria-label="윗몸말아올리기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="왕복달리기" aria-label="왕복달리기" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="건강 운동 및 생활습관" aria-label="건강 운동 및 생활습관" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="건강 생활 습관" aria-label="건강 생활 습관" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="자세" aria-label="자세" placeholder="구체적 예시">
                     <input class="example-input" data-answer="체중 및 체형 관리" aria-label="체중 및 체형 관리" placeholder="구체적 예시">
                     <input class="example-input" data-answer="위생" aria-label="위생" placeholder="구체적 예시">
                     <input class="example-input" data-answer="식습관" aria-label="식습관" placeholder="구체적 예시">
                     <input class="example-input" data-answer="정서 관리 활동" aria-label="정서 관리 활동" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="운동 생활 습관" aria-label="운동 생활 습관" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="맨손체조" aria-label="맨손체조" placeholder="구체적 예시">
                     <input class="example-input" data-answer="산책" aria-label="산책" placeholder="구체적 예시">
                     <input class="example-input" data-answer="계단 오르기" aria-label="계단 오르기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="생활 주변 운동기구 활용하기" aria-label="생활 주변 운동기구 활용하기" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
               </tbody>
@@ -903,30 +911,38 @@
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="건강 체력 및 운동 체력" aria-label="건강 체력 및 운동 체력" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="건강체력 관련 운동" aria-label="건강체력 관련 운동" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="근력" aria-label="근력" placeholder="구체적 예시">
                     <input class="example-input" data-answer="근지구력" aria-label="근지구력" placeholder="구체적 예시">
                     <input class="example-input" data-answer="심폐지구력" aria-label="심폐지구력" placeholder="구체적 예시">
                     <input class="example-input" data-answer="유연성 운동" aria-label="유연성 운동" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="운동체력 관련 운동" aria-label="운동체력 관련 운동" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="순발력" aria-label="순발력" placeholder="구체적 예시">
                     <input class="example-input" data-answer="민첩성" aria-label="민첩성" placeholder="구체적 예시">
                     <input class="example-input" data-answer="평형성" aria-label="평형성" placeholder="구체적 예시">
                     <input class="example-input" data-answer="협응성 운동" aria-label="협응성 운동" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="성장 및 안전 활동" aria-label="성장 및 안전 활동" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="성장 관련 활동" aria-label="성장 관련 활동" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="신체 변화 및 제2차 성징 이해 활동" aria-label="신체 변화 및 제2차 성징 이해 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="감정 수용 및 조절 활동" aria-label="감정 수용 및 조절 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="관계 형성 활동" aria-label="관계 형성 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="성 건강 활동" aria-label="성 건강 활동" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="안전 활동" aria-label="안전 활동" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="운동 관련 안전사고 예방 및 대처 활동" aria-label="운동 관련 안전사고 예방 및 대처 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="생활 안전사고 예방 및 대처 활동" aria-label="생활 안전사고 예방 및 대처 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="자연환경 변화 대처 활동" aria-label="자연환경 변화 대처 활동" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
               </tbody>
@@ -943,16 +959,21 @@
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="기본 움직임의 기초 기술" aria-label="기본 움직임의 기초 기술" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="이동 움직임" aria-label="이동 움직임" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="방향 전환 달리기" aria-label="방향 전환 달리기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="뛰기" aria-label="뛰기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="구르기" aria-label="구르기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="물에서 이동하기" aria-label="물에서 이동하기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="비이동 움직임" aria-label="비이동 움직임" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="균형잡기" aria-label="균형잡기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="구부리기" aria-label="구부리기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="회전하기" aria-label="회전하기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="물에 뜨기" aria-label="물에 뜨기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="조작 움직임" aria-label="조작 움직임" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="던지기" aria-label="던지기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="굴리기" aria-label="굴리기" placeholder="구체적 예시">
@@ -962,27 +983,34 @@
                     <input class="example-input" data-answer="튀기기" aria-label="튀기기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="몰기" aria-label="몰기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="타기" aria-label="타기" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="스포츠 유형별 움직임 기술" aria-label="스포츠 유형별 움직임 기술" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="기술형 스포츠 유형별 움직임" aria-label="기술형 스포츠 유형별 움직임" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="앞뒤 구르기" aria-label="앞뒤 구르기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="옆돌기" aria-label="옆돌기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="전력 달리기" aria-label="전력 달리기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="헤엄치기" aria-label="헤엄치기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="발차기" aria-label="발차기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="전략형 스포츠 유형별 움직임" aria-label="전략형 스포츠 유형별 움직임" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="공던지기와 잡기" aria-label="공던지기와 잡기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="공몰기" aria-label="공몰기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="공차기와 멈추기" aria-label="공차기와 멈추기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="공치기와 받기" aria-label="공치기와 받기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="라켓으로 치기" aria-label="라켓으로 치기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="생태형 스포츠 유형별 움직임" aria-label="생태형 스포츠 유형별 움직임" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="균형 잡고 이동하기" aria-label="균형 잡고 이동하기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="타고 버티기" aria-label="타고 버티기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="잡고 오르기" aria-label="잡고 오르기" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
               </tbody>
@@ -995,42 +1023,55 @@
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="기술형 스포츠 유형별 활동" aria-label="기술형 스포츠 유형별 활동" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="기록형" aria-label="기록형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="육상 활동" aria-label="육상 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="경영 활동" aria-label="경영 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="빙상 활동" aria-label="빙상 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="표적 활동" aria-label="표적 활동" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="동작형" aria-label="동작형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="매트 활동" aria-label="매트 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="뜀틀 활동" aria-label="뜀틀 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="평균대 활동" aria-label="평균대 활동" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="투기형" aria-label="투기형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="태권도 활동" aria-label="태권도 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="씨름 활동" aria-label="씨름 활동" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="전략형 스포츠 유형별 활동" aria-label="전략형 스포츠 유형별 활동" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="영역형" aria-label="영역형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="축구형 게임" aria-label="축구형 게임" placeholder="구체적 예시">
                     <input class="example-input" data-answer="농구형 게임" aria-label="농구형 게임" placeholder="구체적 예시">
                     <input class="example-input" data-answer="핸드볼형 게임" aria-label="핸드볼형 게임" placeholder="구체적 예시">
                     <input class="example-input" data-answer="럭비형 게임" aria-label="럭비형 게임" placeholder="구체적 예시">
                     <input class="example-input" data-answer="하키형 게임" aria-label="하키형 게임" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="필드형" aria-label="필드형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="야구형 게임" aria-label="야구형 게임" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="네트형" aria-label="네트형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="배구형 게임" aria-label="배구형 게임" placeholder="구체적 예시">
                     <input class="example-input" data-answer="배드민턴형 게임" aria-label="배드민턴형 게임" placeholder="구체적 예시">
                     <input class="example-input" data-answer="족구형 게임" aria-label="족구형 게임" placeholder="구체적 예시">
                     <input class="example-input" data-answer="탁구형 게임" aria-label="탁구형 게임" placeholder="구체적 예시">
                     <input class="example-input" data-answer="테니스형 게임" aria-label="테니스형 게임" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="생태형 스포츠 유형별 활동" aria-label="생태형 스포츠 유형별 활동" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="생활환경형" aria-label="생활환경형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="골프형 활동" aria-label="골프형 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="플라잉디스크형 활동" aria-label="플라잉디스크형 활동" placeholder="구체적 예시">
@@ -1038,6 +1079,8 @@
                     <input class="example-input" data-answer="인라인스케이팅 활동" aria-label="인라인스케이팅 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="스포츠클라이밍 활동" aria-label="스포츠클라이밍 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="민속놀이" aria-label="민속놀이" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="자연환경형" aria-label="자연환경형" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="오리엔티어링" aria-label="오리엔티어링" placeholder="구체적 예시">
                     <input class="example-input" data-answer="등산 활동" aria-label="등산 활동" placeholder="구체적 예시">
@@ -1045,6 +1088,7 @@
                     <input class="example-input" data-answer="수상 활동" aria-label="수상 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="설상 활동" aria-label="설상 활동" placeholder="구체적 예시">
                     <input class="example-input" data-answer="승마 활동" aria-label="승마 활동" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
               </tbody>
@@ -1061,6 +1105,7 @@
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="기본 움직임의 기초 표현" aria-label="기본 움직임의 기초 표현" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="이동 움직임 표현" aria-label="이동 움직임 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="워킹" aria-label="워킹" placeholder="구체적 예시">
                     <input class="example-input" data-answer="점핑" aria-label="점핑" placeholder="구체적 예시">
@@ -1069,6 +1114,8 @@
                     <input class="example-input" data-answer="갤러핑" aria-label="갤러핑" placeholder="구체적 예시">
                     <input class="example-input" data-answer="리핑" aria-label="리핑" placeholder="구체적 예시">
                     <input class="example-input" data-answer="슬라이딩" aria-label="슬라이딩" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="비이동 움직임 표현" aria-label="비이동 움직임 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="펴기" aria-label="펴기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="접기" aria-label="접기" placeholder="구체적 예시">
@@ -1076,31 +1123,42 @@
                     <input class="example-input" data-answer="제자리 돌기" aria-label="제자리 돌기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="털기" aria-label="털기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="흔들기" aria-label="흔들기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="조작 움직임 표현" aria-label="조작 움직임 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="들기" aria-label="들기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="돌리기" aria-label="돌리기" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
                 <tr>
                   <th class="sub-area-cell"><input class="sub-area-input" data-answer="기본 움직임의 표현 방법" aria-label="기본 움직임의 표현 방법" placeholder="세부 영역"></th>
                   <td>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="추상 표현" aria-label="추상 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="언어 표현" aria-label="언어 표현" placeholder="구체적 예시">
                     <input class="example-input" data-answer="느낌이나 생각 표현하기" aria-label="느낌이나 생각 표현하기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="모방 표현" aria-label="모방 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="사물 표현" aria-label="사물 표현" placeholder="구체적 예시">
                     <input class="example-input" data-answer="인물 표현" aria-label="인물 표현" placeholder="구체적 예시">
                     <input class="example-input" data-answer="자연 현상 표현하기" aria-label="자연 현상 표현하기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="리듬 표현" aria-label="리듬 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="박자" aria-label="박자" placeholder="구체적 예시">
                     <input class="example-input" data-answer="강약" aria-label="강약" placeholder="구체적 예시">
                     <input class="example-input" data-answer="빠르기" aria-label="빠르기" placeholder="구체적 예시">
                     <input class="example-input" data-answer="패턴에 따라 표현하기" aria-label="패턴에 따라 표현하기" placeholder="구체적 예시">
+                    </div>
+                    <div class="activity-group">
                     <input class="activity-input" data-answer="도구 표현" aria-label="도구 표현" placeholder="신체활동 예시">
                     <input class="example-input" data-answer="줄" aria-label="줄" placeholder="구체적 예시">
                     <input class="example-input" data-answer="공" aria-label="공" placeholder="구체적 예시">
                     <input class="example-input" data-answer="천" aria-label="천" placeholder="구체적 예시">
                     <input class="example-input" data-answer="훌라후프 등을 활용하여 표현하기" aria-label="훌라후프 등을 활용하여 표현하기" placeholder="구체적 예시">
+                    </div>
                   </td>
                 </tr>
               </tbody>

--- a/styles.css
+++ b/styles.css
@@ -330,6 +330,19 @@ td input.example-input {
 td input.activity-input:not(:first-child) {
   margin-top: 1.5rem;
 }
+.activity-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1rem;
+  border: 2px dashed var(--secondary);
+  border-radius: 8px;
+}
+
+.activity-group + .activity-group {
+  margin-top: 1.5rem;
+}
+
     
     .grade-container table tr:not(:last-child) > * {
         border-bottom: 3px dotted var(--secondary);


### PR DESCRIPTION
## Summary
- wrap each activity-input and its examples in new `<div class="activity-group">` wrappers
- style `.activity-group` for visual separation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873821496d4832cb14230ea2a217f11