### PR TITLE
Ensure exercise sub-tab default in PE activity examples

### DIFF
--- a/app.js
+++ b/app.js
@@ -655,7 +655,20 @@
                     const targetId = e.target.dataset.target;
                     main.querySelectorAll('section').forEach(sec => sec.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE));
                     const targetSection = main.querySelector(`#${targetId}`);
-                    if (targetSection) targetSection.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+                    if (targetSection) {
+                        targetSection.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+                        if (targetId === 'activity-examples') {
+                            const subTabs = targetSection.querySelector('.sub-tabs');
+                            if (subTabs) {
+                                const defaultTab = subTabs.querySelector('[data-target="activity-exercise"]');
+                                subTabs.querySelectorAll('.tab').forEach(tab => tab.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE));
+                                if (defaultTab) defaultTab.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+                            }
+                            targetSection.querySelectorAll('section').forEach(sec => sec.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE));
+                            const defaultSection = targetSection.querySelector('#activity-exercise');
+                            if (defaultSection) defaultSection.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+                        }
+                    }
                 }
             });
         });


### PR DESCRIPTION
## Summary
- when selecting `신체활동 예시` in PE, always default to the '운동' sub-tab

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873de421834832cb91d0613be4cf253