### PR TITLE
Improve sub-area input styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -301,15 +301,15 @@
     }
 
 th.sub-area-cell {
-  min-width: 22rem;
+  min-width: 28rem;
 }
 
 th input.sub-area-input {
   width: 100%;
-  padding: 2rem 2.6rem;
-  font-size: 2.2rem;
-  border: 4px double var(--accent);
-  background: var(--secondary);
+  padding: 1.2rem;
+  font-size: 1.4rem;
+  border: 3px solid var(--accent);
+  background: var(--primary);
   color: var(--text-light);
   border-radius: 8px;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- widen the `sub-area-cell` to 28rem
- restyle `sub-area-input` with solid border and consistent padding

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873e083de88832c81128b16188e1cfa