### PR TITLE
Add status styles for sub-area inputs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -314,6 +314,23 @@ th input.sub-area-input {
   border-radius: 8px;
   font-weight: 700;
 }
+th input.sub-area-input.correct {
+  border-color: var(--correct);
+  color: var(--correct);
+}
+th input.sub-area-input.incorrect {
+  border-color: var(--incorrect);
+  color: var(--incorrect);
+}
+th input.sub-area-input.retrying {
+  border-color: var(--retrying);
+  color: var(--retrying);
+}
+th input.sub-area-input.revealed {
+  border-color: var(--revealed);
+  color: var(--revealed);
+  background: var(--bg-light);
+}
 
 td input.activity-input {
   border: 3px solid var(--accent);


### PR DESCRIPTION
## Summary
- mirror td input status styles for `.sub-area-input`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873e2b8f934832c96f44acc1455197f