### PR TITLE
Add ethics subject with model topic

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,12 +24,14 @@
                 WISE: 'wise',
                 JOY: 'joy',
                 PE: 'pe',
+                ETHICS: 'ethics',
                 COMPETENCY: "competency",
                 RANDOM: 'random'
             },
             TOPICS: {
                 CURRICULUM: 'curriculum',
-                COMPETENCY: 'competency'
+                COMPETENCY: 'competency',
+                MODEL: 'model'
             },
             MODES: {
                 NORMAL: 'normal',
@@ -168,10 +170,16 @@
 
        function updateStartModalUI() {
             const subjectButtons = subjectSelector.querySelectorAll('.btn');
+            const topic = gameState.selectedTopic;
 
-            if (gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM) {
+            if (topic === CONSTANTS.TOPICS.CURRICULUM || topic === CONSTANTS.TOPICS.MODEL) {
                 subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
-                subjectButtons.forEach(btn => { btn.disabled = false; });
+                subjectButtons.forEach(btn => {
+                    const btnTopics = (btn.dataset.topic || '').split(' ');
+                    const visible = btnTopics.includes(topic) || btnTopics.length === 0;
+                    btn.classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, !visible);
+                    btn.disabled = false;
+                });
             } else {
                 subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 subjectButtons.forEach(btn => { btn.disabled = true; });
@@ -338,6 +346,7 @@
                 [CONSTANTS.SUBJECTS.WISE]: '슬기로운 생활',
                 [CONSTANTS.SUBJECTS.JOY]: '즐거운 생활',
                 [CONSTANTS.SUBJECTS.PE]: '체육',
+                [CONSTANTS.SUBJECTS.ETHICS]: '도덕',
                 [CONSTANTS.SUBJECTS.COMPETENCY]: '역량'
             };
             headerTitle.textContent = subjectMap[gameState.selectedSubject] || '퀴즈';
@@ -564,13 +573,13 @@
             e.target.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
             const topic = e.target.dataset.topic;
             gameState.selectedTopic = topic;
-            if (topic === CONSTANTS.TOPICS.CURRICULUM) {
+            if (topic === CONSTANTS.TOPICS.CURRICULUM || topic === CONSTANTS.TOPICS.MODEL) {
                 subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
-                if (!document.querySelector('.subject-btn.selected')) {
-                    const defaultBtn = document.querySelector('.subject-btn[data-subject="music"]');
-                    if (defaultBtn) defaultBtn.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
-                    gameState.selectedSubject = CONSTANTS.SUBJECTS.MUSIC;
-                }
+                document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
+                const defaultSubject = topic === CONSTANTS.TOPICS.MODEL ? CONSTANTS.SUBJECTS.ETHICS : CONSTANTS.SUBJECTS.MUSIC;
+                const defaultBtn = document.querySelector(`.subject-btn[data-subject="${defaultSubject}"]`);
+                if (defaultBtn) defaultBtn.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
+                gameState.selectedSubject = defaultSubject;
             } else {
                 subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
@@ -591,7 +600,7 @@
 
             if (subject === CONSTANTS.SUBJECTS.RANDOM) {
                 gameState.isRandomizing = true;
-                const subjectBtns = Array.from(document.querySelectorAll('.subject-btn:not([data-subject="random"])'));
+                const subjectBtns = Array.from(document.querySelectorAll('.subject-btn:not([data-subject="random"]):not(.hidden)'));
                 const allSelectorBtns = document.querySelectorAll('.subject-selector .btn');
                 
                 allSelectorBtns.forEach(b => b.disabled = true);

--- a/index.html
+++ b/index.html
@@ -469,6 +469,139 @@
         </div>
     </section>
   </main>
+  <main id="ethics-quiz-main" class="hidden">
+    <div class="tabs">
+      <div class="tab active" data-target="roleplay">역할놀이</div>
+      <div class="tab" data-target="concept-analysis">개념 분석</div>
+      <div class="tab" data-target="value-analysis">가치 분석</div>
+      <div class="tab" data-target="conflict-resolution">가치 갈등 해결</div>
+      <div class="tab" data-target="value-clarification">가치 명료화</div>
+      <div class="tab" data-target="rational-decision">합리적 의사 결정</div>
+      <div class="tab" data-target="moral-discussion">도덕적 토론</div>
+      <div class="tab" data-target="moral-story">도덕 이야기</div>
+      <div class="tab" data-target="experience-learning">경험 학습</div>
+      <div class="tab" data-target="group-inquiry">집단 탐구</div>
+      <div class="tab" data-target="p4c">철학적 탐구 공동체</div>
+    </div>
+    <section id="roleplay" class="active">
+      <h2>역할놀이 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="역할놀이 준비" aria-label="역할놀이 준비" placeholder="단계명">
+        <input data-answer="역할놀이 참가자 선정" aria-label="역할놀이 참가자 선정" placeholder="단계명">
+        <input data-answer="무대설치" aria-label="무대설치" placeholder="단계명">
+        <input data-answer="참여적 관찰자로서의 청중의 준비" aria-label="참여적 관찰자로서의 청중의 준비" placeholder="단계명">
+        <input data-answer="역할놀이 시연" aria-label="역할놀이 시연" placeholder="단계명">
+        <input data-answer="토론 및 평가" aria-label="토론 및 평가" placeholder="단계명">
+        <input data-answer="재연" aria-label="재연" placeholder="단계명">
+        <input data-answer="경험의 공유와 일반화" aria-label="경험의 공유와 일반화" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="concept-analysis">
+      <h2>개념 분석 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="분석될 가치 개념의 확인" aria-label="분석될 가치 개념의 확인" placeholder="단계명">
+        <input data-answer="개념의 전형적인 사례와 개념에 반대되는 사례 탐구" aria-label="개념의 전형적인 사례와 개념에 반대되는 사례 탐구" placeholder="단계명">
+        <input data-answer="개념의 경계에 해당하는 사례 확인" aria-label="개념의 경계에 해당하는 사례 확인" placeholder="단계명">
+        <input data-answer="그 개념과 관련된 개념의 분석" aria-label="그 개념과 관련된 개념의 분석" placeholder="단계명">
+        <input data-answer="가상적인 사태에의 적용" aria-label="가상적인 사태에의 적용" placeholder="단계명">
+        <input data-answer="분석된 의미의 수용 여부 검토와 정리" aria-label="분석된 의미의 수용 여부 검토와 정리" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="value-analysis">
+      <h2>가치 분석 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
+        <input data-answer="가치 문제의 확인과 명료화" aria-label="가치 문제의 확인과 명료화" placeholder="단계명">
+        <input data-answer="자기 입장의 설정 및 사실적 타당성 탐색" aria-label="자기 입장의 설정 및 사실적 타당성 탐색" placeholder="단계명">
+        <input data-answer="잠정적 가치 결정 및 가치 원리의 검사" aria-label="잠정적 가치 결정 및 가치 원리의 검사" placeholder="단계명">
+        <input data-answer="입장의 수정 및 의사 결정" aria-label="입장의 수정 및 의사 결정" placeholder="단계명">
+        <input data-answer="실천 동기 강화 및 일상생활에의 확대적용" aria-label="실천 동기 강화 및 일상생활에의 확대적용" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="conflict-resolution">
+      <h2>가치 갈등 해결 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
+        <input data-answer="관련 규범 확인 및 의미 파악" aria-label="관련 규범 확인 및 의미 파악" placeholder="단계명">
+        <input data-answer="문제 사태의 성격 분석" aria-label="문제 사태의 성격 분석" placeholder="단계명">
+        <input data-answer="자기 입장의 선택과 정당화" aria-label="자기 입장의 선택과 정당화" placeholder="단계명">
+        <input data-answer="자기 입장의 수정 및 대안 숙고" aria-label="자기 입장의 수정 및 대안 숙고" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="value-clarification">
+      <h2>가치 명료화 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
+        <input data-answer="자유롭게 선택하기" aria-label="자유롭게 선택하기" placeholder="단계명">
+        <input data-answer="여러 대안으로부터 선택하기" aria-label="여러 대안으로부터 선택하기" placeholder="단계명">
+        <input data-answer="대안들의 결과를 심사숙고하여 선택하기" aria-label="대안들의 결과를 심사숙고하여 선택하기" placeholder="단계명">
+        <input data-answer="선택한 바를 소중히 하기" aria-label="선택한 바를 소중히 하기" placeholder="단계명">
+        <input data-answer="선택한 바를 다른 사람들에게 공언하기" aria-label="선택한 바를 다른 사람들에게 공언하기" placeholder="단계명">
+        <input data-answer="자기가 선택한 바를 행동으로 나타내기" aria-label="자기가 선택한 바를 행동으로 나타내기" placeholder="단계명">
+        <input data-answer="생활 속에서 지속적·반복적으로 실천하기" aria-label="생활 속에서 지속적·반복적으로 실천하기" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="rational-decision">
+      <h2>합리적 의사 결정 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="도덕적 문제 사태의 제시와 분석" aria-label="도덕적 문제 사태의 제시와 분석" placeholder="단계명">
+        <input data-answer="관련 규범의 확인 및 그 의미와 타당성 파악" aria-label="관련 규범의 확인 및 그 의미와 타당성 파악" placeholder="단계명">
+        <input data-answer="여러 대안의 설정과 각 대안의 결과 검토" aria-label="여러 대안의 설정과 각 대안의 결과 검토" placeholder="단계명">
+        <input data-answer="대안의 선택 및 정당화" aria-label="대안의 선택 및 정당화" placeholder="단계명">
+        <input data-answer="대안 선택의 수정 및 잠정적 의사결정" aria-label="대안 선택의 수정 및 잠정적 의사결정" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="moral-discussion">
+      <h2>도덕적 토론 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
+        <input data-answer="도덕적 토론의 도입" aria-label="도덕적 토론의 도입" placeholder="단계명">
+        <input data-answer="도덕적 토론의 심화" aria-label="도덕적 토론의 심화" placeholder="단계명">
+        <input data-answer="실천 동기 강화 및 생활에의 확대 적용" aria-label="실천 동기 강화 및 생활에의 확대 적용" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="moral-story">
+      <h2>도덕 이야기 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="학습 문제 인식과 동기 유발" aria-label="학습 문제 인식과 동기 유발" placeholder="단계명">
+        <input data-answer="도덕 이야기의 제시와 주요 내용 파악" aria-label="도덕 이야기의 제시와 주요 내용 파악" placeholder="단계명">
+        <input data-answer="도덕 이야기의 탐구 및 자신의 도덕적 경험 발표와 공유" aria-label="도덕 이야기의 탐구 및 자신의 도덕적 경험 발표와 공유" placeholder="단계명">
+        <input data-answer="자신의 도덕 이야기 또는 유사한 상상의 이야기 구성" aria-label="자신의 도덕 이야기 또는 유사한 상상의 이야기 구성" placeholder="단계명">
+        <input data-answer="정리 및 확대 적용과 실천 생활화" aria-label="정리 및 확대 적용과 실천 생활화" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="experience-learning">
+      <h2>경험 학습 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="경험 학습의 주제 설정하기" aria-label="경험 학습의 주제 설정하기" placeholder="단계명">
+        <input data-answer="경험 학습 계획 세우기" aria-label="경험 학습 계획 세우기" placeholder="단계명">
+        <input data-answer="경험 학습 실행하기" aria-label="경험 학습 실행하기" placeholder="단계명">
+        <input data-answer="경험의 교류와 논의를 통해 경험을 공유하고 일반화하기" aria-label="경험의 교류와 논의를 통해 경험을 공유하고 일반화하기" placeholder="단계명">
+        <input data-answer="종합 정리 및 평가하기" aria-label="종합 정리 및 평가하기" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="group-inquiry">
+      <h2>집단 탐구 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="탐구 문제의 설정" aria-label="탐구 문제의 설정" placeholder="단계명">
+        <input data-answer="탐구 계획의 수립" aria-label="탐구 계획의 수립" placeholder="단계명">
+        <input data-answer="탐구의 실시" aria-label="탐구의 실시" placeholder="단계명">
+        <input data-answer="탐구 결과 발표 및 논의" aria-label="탐구 결과 발표 및 논의" placeholder="단계명">
+        <input data-answer="종합 정리 및 평가" aria-label="종합 정리 및 평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="p4c">
+      <h2>철학적 탐구 공동체 수업모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="생각 열기" aria-label="생각 열기" placeholder="단계명">
+        <input data-answer="교재 읽기" aria-label="교재 읽기" placeholder="단계명">
+        <input data-answer="질문 만들기" aria-label="질문 만들기" placeholder="단계명">
+        <input data-answer="대표 질문 선정하기" aria-label="대표 질문 선정하기" placeholder="단계명">
+        <input data-answer="토의(토론)하기" aria-label="토의(토론)하기" placeholder="단계명">
+        <input data-answer="생각 정리 및 표현하기" aria-label="생각 정리 및 표현하기" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+  </main>
   <main id="korean-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="listening-speaking">듣기·말하기</div>
@@ -1370,17 +1503,19 @@
             <div class="topic-selector">
                 <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>
                 <button class="btn topic-btn" data-topic="competency">역량</button>
+                <button class="btn topic-btn" data-topic="model">모형</button>
             </div>
             <h2>과목 선택</h2>
             <div class="subject-selector">
-                <button class="btn subject-btn selected" data-subject="music">음악</button>
-                <button class="btn subject-btn" data-subject="art">미술</button>
-                <button class="btn subject-btn" data-subject="korean">국어</button>
-                <button class="btn subject-btn" data-subject="life">바른 생활</button>
-                <button class="btn subject-btn" data-subject="wise">슬기로운 생활</button>
-                <button class="btn subject-btn" data-subject="joy">즐거운 생활</button>
-                <button class="btn subject-btn" data-subject="pe">체육</button>
-                <button id="random-subject-btn" class="btn" data-subject="random">랜덤</button>
+                <button class="btn subject-btn selected" data-subject="music" data-topic="curriculum">음악</button>
+                <button class="btn subject-btn" data-subject="art" data-topic="curriculum">미술</button>
+                <button class="btn subject-btn" data-subject="korean" data-topic="curriculum">국어</button>
+                <button class="btn subject-btn" data-subject="life" data-topic="curriculum">바른 생활</button>
+                <button class="btn subject-btn" data-subject="wise" data-topic="curriculum">슬기로운 생활</button>
+                <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐거운 생활</button>
+                <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
+                <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
+                <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum model">랜덤</button>
             </div>
             <h2>게임 모드</h2>
             <div class="mode-selector">


### PR DESCRIPTION
## Summary
- add new `ethics` subject under a new `model` topic
- display additional subject button and topic option in the start modal
- show/hide subject buttons by topic
- include steps for various moral instruction models in `ethics-quiz-main`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68747f850f98832c93c36f21cc69b422