### PR TITLE
Fix model quiz layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,7 +485,7 @@
     </div>
     <section id="roleplay" class="active">
       <h2>역할놀이 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="역할놀이 준비" aria-label="역할놀이 준비" placeholder="단계명">
         <input data-answer="역할놀이 참가자 선정" aria-label="역할놀이 참가자 선정" placeholder="단계명">
         <input data-answer="무대설치" aria-label="무대설치" placeholder="단계명">
@@ -498,7 +498,7 @@
     </section>
     <section id="concept-analysis">
       <h2>개념 분석 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="분석될 가치 개념의 확인" aria-label="분석될 가치 개념의 확인" placeholder="단계명">
         <input data-answer="개념의 전형적인 사례와 개념에 반대되는 사례 탐구" aria-label="개념의 전형적인 사례와 개념에 반대되는 사례 탐구" placeholder="단계명">
         <input data-answer="개념의 경계에 해당하는 사례 확인" aria-label="개념의 경계에 해당하는 사례 확인" placeholder="단계명">
@@ -509,7 +509,7 @@
     </section>
     <section id="value-analysis">
       <h2>가치 분석 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
         <input data-answer="가치 문제의 확인과 명료화" aria-label="가치 문제의 확인과 명료화" placeholder="단계명">
         <input data-answer="자기 입장의 설정 및 사실적 타당성 탐색" aria-label="자기 입장의 설정 및 사실적 타당성 탐색" placeholder="단계명">
@@ -520,7 +520,7 @@
     </section>
     <section id="conflict-resolution">
       <h2>가치 갈등 해결 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
         <input data-answer="관련 규범 확인 및 의미 파악" aria-label="관련 규범 확인 및 의미 파악" placeholder="단계명">
         <input data-answer="문제 사태의 성격 분석" aria-label="문제 사태의 성격 분석" placeholder="단계명">
@@ -530,7 +530,7 @@
     </section>
     <section id="value-clarification">
       <h2>가치 명료화 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
         <input data-answer="자유롭게 선택하기" aria-label="자유롭게 선택하기" placeholder="단계명">
         <input data-answer="여러 대안으로부터 선택하기" aria-label="여러 대안으로부터 선택하기" placeholder="단계명">
@@ -543,7 +543,7 @@
     </section>
     <section id="rational-decision">
       <h2>합리적 의사 결정 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시와 분석" aria-label="도덕적 문제 사태의 제시와 분석" placeholder="단계명">
         <input data-answer="관련 규범의 확인 및 그 의미와 타당성 파악" aria-label="관련 규범의 확인 및 그 의미와 타당성 파악" placeholder="단계명">
         <input data-answer="여러 대안의 설정과 각 대안의 결과 검토" aria-label="여러 대안의 설정과 각 대안의 결과 검토" placeholder="단계명">
@@ -553,7 +553,7 @@
     </section>
     <section id="moral-discussion">
       <h2>도덕적 토론 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
         <input data-answer="도덕적 토론의 도입" aria-label="도덕적 토론의 도입" placeholder="단계명">
         <input data-answer="왜라는 질문하기" aria-label="왜라는 질문하기" placeholder="세부 단계">
@@ -569,7 +569,7 @@
     </section>
     <section id="moral-story">
       <h2>도덕 이야기 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="학습 문제 인식과 동기 유발" aria-label="학습 문제 인식과 동기 유발" placeholder="단계명">
         <input data-answer="도덕 이야기의 제시와 주요 내용 파악" aria-label="도덕 이야기의 제시와 주요 내용 파악" placeholder="단계명">
         <input data-answer="도덕 이야기의 탐구 및 자신의 도덕적 경험 발표와 공유" aria-label="도덕 이야기의 탐구 및 자신의 도덕적 경험 발표와 공유" placeholder="단계명">
@@ -579,7 +579,7 @@
     </section>
     <section id="experience-learning">
       <h2>경험 학습 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="경험 학습의 주제 설정하기" aria-label="경험 학습의 주제 설정하기" placeholder="단계명">
         <input data-answer="경험 학습 계획 세우기" aria-label="경험 학습 계획 세우기" placeholder="단계명">
         <input data-answer="경험 학습 실행하기" aria-label="경험 학습 실행하기" placeholder="단계명">
@@ -589,7 +589,7 @@
     </section>
     <section id="group-inquiry">
       <h2>집단 탐구 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="탐구 문제의 설정" aria-label="탐구 문제의 설정" placeholder="단계명">
         <input data-answer="탐구 계획의 수립" aria-label="탐구 계획의 수립" placeholder="단계명">
         <input data-answer="탐구의 실시" aria-label="탐구의 실시" placeholder="단계명">
@@ -599,7 +599,7 @@
     </section>
     <section id="p4c">
       <h2>철학적 탐구 공동체 수업모형</h2>
-      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="생각 열기" aria-label="생각 열기" placeholder="단계명">
         <input data-answer="교재 읽기" aria-label="교재 읽기" placeholder="단계명">
         <input data-answer="질문 만들기" aria-label="질문 만들기" placeholder="단계명">


### PR DESCRIPTION
## Summary
- show model sequence inputs in a single column
- keep two-column layout elsewhere

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68748cbbfba4832c9574d7656ab7c9b8