### PR TITLE
Add 실과 model subject

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@
                 JOY: 'joy',
                 PE: 'pe',
                 ETHICS: 'ethics',
+                PRACTICAL: 'practical',
                 COMPETENCY: "competency",
                 RANDOM: 'random'
             },
@@ -347,6 +348,7 @@
                 [CONSTANTS.SUBJECTS.JOY]: '즐거운 생활',
                 [CONSTANTS.SUBJECTS.PE]: '체육',
                 [CONSTANTS.SUBJECTS.ETHICS]: '도덕',
+                [CONSTANTS.SUBJECTS.PRACTICAL]: '실과',
                 [CONSTANTS.SUBJECTS.COMPETENCY]: '역량'
             };
             headerTitle.textContent = subjectMap[gameState.selectedSubject] || '퀴즈';

--- a/index.html
+++ b/index.html
@@ -609,6 +609,89 @@
       </td></tr></tbody></table></div></div>
     </section>
   </main>
+  <main id="practical-quiz-main" class="hidden">
+    <div class="tabs">
+      <div class="tab active" data-target="problem-solving">문제 해결</div>
+      <div class="tab" data-target="project">프로젝트</div>
+      <div class="tab" data-target="practice-centered">실습 중심</div>
+      <div class="tab" data-target="cooperative">협동 학습</div>
+      <div class="tab" data-target="home-project">홈 프로젝트</div>
+      <div class="tab" data-target="practical-problem">실천적 문제 중심 학습</div>
+      <div class="tab" data-target="technical-problem-solving">기술적 문제해결 과정</div>
+    </div>
+    <section id="problem-solving" class="active">
+      <h2>문제 해결 교수·학습 방법</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="문제 인식" aria-label="문제 인식" placeholder="단계명">
+        <input data-answer="정보의 수집" aria-label="정보의 수집" placeholder="단계명">
+        <input data-answer="문제 해결 방안의 마련과 선택의 준비" aria-label="문제 해결 방안의 마련과 선택의 준비" placeholder="단계명">
+        <input data-answer="문제 해결 방안 설정" aria-label="문제 해결 방안 설정" placeholder="단계명">
+        <input data-answer="문제 해결 방안 적용" aria-label="문제 해결 방안 적용" placeholder="단계명">
+        <input data-answer="결과에 대한 평가" aria-label="결과에 대한 평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="project">
+      <h2>프로젝트 교수·학습 방법</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="목적 설정" aria-label="목적 설정" placeholder="단계명">
+        <input data-answer="계획" aria-label="계획" placeholder="단계명">
+        <input data-answer="실행" aria-label="실행" placeholder="단계명">
+        <input data-answer="평가" aria-label="평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="practice-centered">
+      <h2>실습 중심 교수·학습 방법</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="실습 활동의 목적 및 관련 지식 이해" aria-label="실습 활동의 목적 및 관련 지식 이해" placeholder="단계명">
+        <input data-answer="실습 과정의 제시" aria-label="실습 과정의 제시" placeholder="단계명">
+        <input data-answer="기본 기능 시범 관찰" aria-label="기본 기능 시범 관찰" placeholder="단계명">
+        <input data-answer="실습 과제 수행 과정에서의 기본 기능 습득" aria-label="실습 과제 수행 과정에서의 기본 기능 습득" placeholder="단계명">
+        <input data-answer="자기 평가 및 교사 평가" aria-label="자기 평가 및 교사 평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="cooperative">
+      <h2>협동 학습 교수·학습 방법</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="모둠 구성" aria-label="모둠 구성" placeholder="단계명">
+        <input data-answer="과제 제시 및 선택" aria-label="과제 제시 및 선택" placeholder="단계명">
+        <input data-answer="전문가 집단 활동" aria-label="전문가 집단 활동" placeholder="단계명">
+        <input data-answer="모집단 활동" aria-label="모집단 활동" placeholder="단계명">
+        <input data-answer="평가하기" aria-label="평가하기" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="home-project">
+      <h2>홈 프로젝트 모형 (가정 실습형)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
+        <input data-answer="실습 계획 수립" aria-label="실습 계획 수립" placeholder="단계명">
+        <input data-answer="시범 실습" aria-label="시범 실습" placeholder="단계명">
+        <input data-answer="홈 프로젝트 과제 제시" aria-label="홈 프로젝트 과제 제시" placeholder="단계명">
+        <input data-answer="실습 준비" aria-label="실습 준비" placeholder="단계명">
+        <input data-answer="실습" aria-label="실습" placeholder="단계명">
+        <input data-answer="반성 평가" aria-label="반성 평가" placeholder="단계명">
+        <input data-answer="정리" aria-label="정리" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="practical-problem">
+      <h2>실천적 문제 중심 학습</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="문제 정의" aria-label="문제 정의" placeholder="단계명">
+        <input data-answer="문제 해결을 위한 정보 수집" aria-label="문제 해결을 위한 정보 수집" placeholder="단계명">
+        <input data-answer="대안 탐색 및 최선의 대안 선택" aria-label="대안 탐색 및 최선의 대안 선택" placeholder="단계명">
+        <input data-answer="행동" aria-label="행동" placeholder="단계명">
+        <input data-answer="행동에 대한 평가" aria-label="행동에 대한 평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="technical-problem-solving">
+      <h2>기술적 문제해결 과정</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td class="two-col-answers">
+        <input data-answer="문제 확인" aria-label="문제 확인" placeholder="단계명">
+        <input data-answer="아이디어 탐색 및 구체화" aria-label="아이디어 탐색 및 구체화" placeholder="단계명">
+        <input data-answer="실행" aria-label="실행" placeholder="단계명">
+        <input data-answer="평가" aria-label="평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+  </main>
   <main id="korean-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="listening-speaking">듣기·말하기</div>
@@ -1522,6 +1605,7 @@
                 <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐거운 생활</button>
                 <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
                 <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
+                <button class="btn subject-btn" data-subject="practical" data-topic="model">실과</button>
                 <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum model">랜덤</button>
             </div>
             <h2>게임 모드</h2>


### PR DESCRIPTION
## Summary
- expand subject constants to include 실과(practical)
- map 실과 subject label in `startGame`
- add 실과 option to the subject selector
- implement 실과 model quiz sections

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68748e3653d0832ca9290b06051344bd