### PR TITLE
Add social subject models

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,7 @@
                 PE: 'pe',
                 ETHICS: 'ethics',
                 PRACTICAL: 'practical',
+                SOCIAL: 'social',
                 COMPETENCY: "competency",
                 RANDOM: 'random'
             },
@@ -358,6 +359,7 @@
                 [CONSTANTS.SUBJECTS.PE]: '체육',
                 [CONSTANTS.SUBJECTS.ETHICS]: '도덕',
                 [CONSTANTS.SUBJECTS.PRACTICAL]: '실과',
+                [CONSTANTS.SUBJECTS.SOCIAL]: '사회',
                 [CONSTANTS.SUBJECTS.COMPETENCY]: '역량'
             };
             headerTitle.textContent = subjectMap[gameState.selectedSubject] || '퀴즈';

--- a/index.html
+++ b/index.html
@@ -692,6 +692,157 @@
       </td></tr></tbody></table></div></div>
     </section>
   </main>
+  <main id="social-quiz-main" class="hidden">
+    <div class="tabs">
+      <div class="tab active" data-target="attribute">속성 모형</div>
+      <div class="tab" data-target="prototype">원형모형</div>
+      <div class="tab" data-target="context">상황모형</div>
+      <div class="tab" data-target="inquiry-mc">탐구학습(마시알라스)</div>
+      <div class="tab" data-target="inquiry-banks">탐구학습(뱅크스)</div>
+      <div class="tab" data-target="problem-solving">문제해결학습</div>
+      <div class="tab" data-target="rational-banks">합리적 의사결정</div>
+      <div class="tab" data-target="decision-matrix">의사결정 매트릭스</div>
+      <div class="tab" data-target="controversy">논쟁문제</div>
+      <div class="tab" data-target="controversy-minor">논쟁문제(Minor)</div>
+      <div class="tab" data-target="jigsaw2">직소Ⅱ</div>
+      <div class="tab" data-target="stad">STAD</div>
+    </div>
+    <section id="attribute" class="active">
+      <h2>속성 모형 (개념학습모형)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
+        <input data-answer="속성 제시와 정의" aria-label="속성 제시와 정의" placeholder="단계명">
+        <input data-answer="속성 검토" aria-label="속성 검토" placeholder="단계명">
+        <input data-answer="사례(예/비례) 검토" aria-label="사례(예/비례) 검토" placeholder="단계명">
+        <input data-answer="가설 검증" aria-label="가설 검증" placeholder="단계명">
+        <input data-answer="개념 분석" aria-label="개념 분석" placeholder="단계명">
+        <input data-answer="관련 문제 검토" aria-label="관련 문제 검토" placeholder="단계명">
+        <input data-answer="평가" aria-label="평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="prototype">
+      <h2>원형모형 (개념학습모형)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
+        <input data-answer="개념의 원형과 정의 제시" aria-label="개념의 원형과 정의 제시" placeholder="단계명">
+        <input data-answer="비례 제시" aria-label="비례 제시" placeholder="단계명">
+        <input data-answer="속성 검토" aria-label="속성 검토" placeholder="단계명">
+        <input data-answer="개념 분석" aria-label="개념 분석" placeholder="단계명">
+        <input data-answer="관련 문제 검토" aria-label="관련 문제 검토" placeholder="단계명">
+        <input data-answer="평가" aria-label="평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="context">
+      <h2>상황모형 (개념학습모형)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
+        <input data-answer="상황 및 경험의 제시" aria-label="상황 및 경험의 제시" placeholder="단계명">
+        <input data-answer="사례(예/비례) 검토" aria-label="사례(예/비례) 검토" placeholder="단계명">
+        <input data-answer="속성 검토" aria-label="속성 검토" placeholder="단계명">
+        <input data-answer="개념 분석" aria-label="개념 분석" placeholder="단계명">
+        <input data-answer="관련 문제 검토" aria-label="관련 문제 검토" placeholder="단계명">
+        <input data-answer="평가" aria-label="평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="inquiry-mc">
+      <h2>탐구학습모형 (마시알라스, 콕스)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="탐구 문제 파악" aria-label="탐구 문제 파악" placeholder="단계명">
+        <input data-answer="가설 설정" aria-label="가설 설정" placeholder="단계명">
+        <input data-answer="탐색" aria-label="탐색" placeholder="단계명">
+        <input data-answer="증거 제시" aria-label="증거 제시" placeholder="단계명">
+        <input data-answer="일반화" aria-label="일반화" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="inquiry-banks">
+      <h2>탐구학습모형 (뱅크스, 차경수)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
+        <input data-answer="가설 설정" aria-label="가설 설정" placeholder="단계명">
+        <input data-answer="용어 정의 및 개념화" aria-label="용어 정의 및 개념화" placeholder="단계명">
+        <input data-answer="자료 수집" aria-label="자료 수집" placeholder="단계명">
+        <input data-answer="자료 분석" aria-label="자료 분석" placeholder="단계명">
+        <input data-answer="가설 검증 및 일반화" aria-label="가설 검증 및 일반화" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="problem-solving">
+      <h2>문제해결학습모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 확인" aria-label="문제 확인" placeholder="단계명">
+        <input data-answer="문제 발생 원인 파악" aria-label="문제 발생 원인 파악" placeholder="단계명">
+        <input data-answer="문제 해결방안 탐색" aria-label="문제 해결방안 탐색" placeholder="단계명">
+        <input data-answer="문제 해결방안 결정" aria-label="문제 해결방안 결정" placeholder="단계명">
+        <input data-answer="문제 해결방안 실천" aria-label="문제 해결방안 실천" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="rational-banks">
+      <h2>합리적 의사결정 모형 (뱅크스)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
+        <input data-answer="사회 탐구" aria-label="사회 탐구" placeholder="단계명">
+        <input data-answer="가치 탐구" aria-label="가치 탐구" placeholder="단계명">
+        <input data-answer="의사 결정" aria-label="의사 결정" placeholder="단계명">
+        <input data-answer="행동" aria-label="행동" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="decision-matrix">
+      <h2>의사결정 매트릭스 모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 정의" aria-label="문제 정의" placeholder="단계명">
+        <input data-answer="대안 나열" aria-label="대안 나열" placeholder="단계명">
+        <input data-answer="선택 기준 작성" aria-label="선택 기준 작성" placeholder="단계명">
+        <input data-answer="대안 평가" aria-label="대안 평가" placeholder="단계명">
+        <input data-answer="의사 결정" aria-label="의사 결정" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="controversy">
+      <h2>논쟁문제 학습모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
+        <input data-answer="개념의 명확화" aria-label="개념의 명확화" placeholder="단계명">
+        <input data-answer="사실의 경험적 확인" aria-label="사실의 경험적 확인" placeholder="단계명">
+        <input data-answer="가치 갈등의 해결" aria-label="가치 갈등의 해결" placeholder="단계명">
+        <input data-answer="대안 모색 및 결론" aria-label="대안 모색 및 결론" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="controversy-minor">
+      <h2>논쟁문제 학습모형(Minor)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
+        <input data-answer="가치 문제 확인" aria-label="가치 문제 확인" placeholder="단계명">
+        <input data-answer="개념의 명확화" aria-label="개념의 명확화" placeholder="세부 단계">
+        <input data-answer="사실의 경험적 확인" aria-label="사실의 경험적 확인" placeholder="세부 단계">
+        <input data-answer="가치 갈등의 해결" aria-label="가치 갈등의 해결" placeholder="세부 단계">
+        <input data-answer="비슷한 다른 경우와의 비교" aria-label="비슷한 다른 경우와의 비교" placeholder="세부 단계">
+        <input data-answer="대안 모색과 결과의 예측" aria-label="대안 모색과 결과의 예측" placeholder="세부 단계">
+        <input data-answer="선택 및 결론" aria-label="선택 및 결론" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="jigsaw2">
+      <h2>직소Ⅱ (협동학습모형)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="소집단 구성" aria-label="소집단 구성" placeholder="단계명">
+        <input data-answer="전체 학습지와" aria-label="전체 학습지와" placeholder="단계명">
+        <input data-answer="자료 배부" aria-label="자료 배부" placeholder="단계명">
+        <input data-answer="전문가 집단 학습" aria-label="전문가 집단 학습" placeholder="단계명">
+        <input data-answer="소집단 학습" aria-label="소집단 학습" placeholder="단계명">
+        <input data-answer="전체 학습지 작성 및  답지 확인" aria-label="전체 학습지 작성 및  답지 확인" placeholder="단계명">
+        <input data-answer="개별 평가 및" aria-label="개별 평가 및" placeholder="단계명">
+        <input data-answer="집단 보상" aria-label="집단 보상" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="stad">
+      <h2>STAD (협동학습모형)</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="집단 구성" aria-label="집단 구성" placeholder="단계명">
+        <input data-answer="교사의 수업 안내와 학습지 배부" aria-label="교사의 수업 안내와 학습지 배부" placeholder="단계명">
+        <input data-answer="집단 학습" aria-label="집단 학습" placeholder="단계명">
+        <input data-answer="학습지 작성 및 정답지 확인" aria-label="학습지 작성 및 정답지 확인" placeholder="단계명">
+        <input data-answer="개별 평가 및" aria-label="개별 평가 및" placeholder="단계명">
+        <input data-answer="집단 보상" aria-label="집단 보상" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+  </main>
   <main id="korean-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="listening-speaking">듣기·말하기</div>
@@ -1606,6 +1757,7 @@
                 <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
                 <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
                 <button class="btn subject-btn" data-subject="practical" data-topic="model">실과</button>
+                <button class="btn subject-btn" data-subject="social" data-topic="model">사회</button>
                 <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum model">랜덤</button>
             </div>
             <h2>게임 모드</h2>


### PR DESCRIPTION
## Summary
- add a `사회` button in the subject selector
- introduce a new quiz section for 사회 models with learning steps
- register `SOCIAL` constant and label in the code

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68749e11543c832c873317a7e942a40c