### PR TITLE
Add automatic stage progression and start from first stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1689,7 +1689,6 @@
     <div class="modal-content">
       <h2>Stage Clear!</h2>
       <p>축하합니다! 이 영역을 마스터했습니다!</p>
-      <button id="close-modal-btn" class="btn">닫기</button>
     </div>
   </div>
   


### PR DESCRIPTION
## Summary
- start games from the first area every time
- pause timer when stage is cleared
- close the stage clear popup automatically and proceed to the next area
- remove the manual close button from the stage clear popup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6874ef40a35c832c83d54a5321c0a766