### PR TITLE
Modify hard-core settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,9 +52,9 @@
                 COMBO_POP: 'combo-pop'
             },
             DEFAULT_DURATION: 600,
-            HARD_CORE_DURATION: 30, 
-            HARD_CORE_LIVES: 3,
-            HARD_CORE_TIME_BONUS: 3,
+            HARD_CORE_DURATION: 60,
+            HARD_CORE_LIVES: Infinity,
+            HARD_CORE_TIME_BONUS: 5,
             RANDOM_ANIMATION_DURATION: 2000,
             RANDOM_ANIMATION_INTERVAL: 100
         };
@@ -449,8 +449,7 @@
             if (gameState.gameMode === CONSTANTS.MODES.HARD_CORE) {
                 gameState.duration = CONSTANTS.HARD_CORE_DURATION;
                 gameState.lives = CONSTANTS.HARD_CORE_LIVES;
-                updateLivesUI();
-                livesContainer.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+                livesContainer.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 document.getElementById('timer-container').classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
                 document.getElementById('bar').style.display = 'none';
             } else {
@@ -658,13 +657,6 @@
                     input.classList.remove(CONSTANTS.CSS_CLASSES.RETRYING);
                     input.classList.add(CONSTANTS.CSS_CLASSES.INCORRECT);
 
-                    if (gameState.gameMode === CONSTANTS.MODES.HARD_CORE) {
-                        gameState.lives--;
-                        updateLivesUI();
-                        if (gameState.lives <= 0) {
-                            handleGameOver();
-                        }
-                    }
                 } else if (input.classList.contains(CONSTANTS.CSS_CLASSES.RETRYING)) {
                     input.classList.remove(CONSTANTS.CSS_CLASSES.RETRYING);
                     input.classList.add(CONSTANTS.CSS_CLASSES.INCORRECT);
@@ -672,13 +664,6 @@
                     input.value = input.dataset.answer;
                     input.disabled = true;
 
-                    if (gameState.gameMode === CONSTANTS.MODES.HARD_CORE) {
-                        gameState.lives--;
-                        updateLivesUI();
-                        if (gameState.lives <= 0) {
-                            handleGameOver();
-                        }
-                    }
                 } else {
                     input.classList.add(CONSTANTS.CSS_CLASSES.RETRYING);
                     input.value = '';

--- a/index.html
+++ b/index.html
@@ -1773,7 +1773,7 @@
                 </div>
             </div>
             <div id="hard-core-description" class="notice-text hidden">
-                <p>3번 틀리면 게임이 즉시 종료됩니다.<br>(제한시간 30초, 정답 시 +3초)</p>
+                <p>제한시간 60초, 정답 시 +5초가 주어집니다.</p>
             </div>
             <button id="start-game-btn" class="btn">시작</button>
         </div>


### PR DESCRIPTION
## Summary
- increase hard-core time limit to 60 seconds
- add 5 second bonus per answer
- remove lives mechanic from hard-core mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687512af2528832c87f2d3fd36aba253