### PR TITLE
Add science model subject

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@
                 ETHICS: 'ethics',
                 PRACTICAL: 'practical',
                 SOCIAL: 'social',
+                SCIENCE: 'science',
                 COMPETENCY: "competency",
                 RANDOM: 'random'
             },
@@ -446,6 +447,7 @@
                 [CONSTANTS.SUBJECTS.ETHICS]: '도덕',
                 [CONSTANTS.SUBJECTS.PRACTICAL]: '실과',
                 [CONSTANTS.SUBJECTS.SOCIAL]: '사회',
+                [CONSTANTS.SUBJECTS.SCIENCE]: '과학',
                 [CONSTANTS.SUBJECTS.COMPETENCY]: '역량'
             };
             headerTitle.textContent = subjectMap[gameState.selectedSubject] || '퀴즈';

--- a/index.html
+++ b/index.html
@@ -842,6 +842,92 @@
       </td></tr></tbody></table></div></div>
     </section>
   </main>
+  <main id="science-quiz-main" class="hidden">
+    <div class="tabs">
+      <div class="tab active" data-target="experience-learning">경험 학습 모형</div>
+      <div class="tab" data-target="discovery-learning">발견 학습 모형</div>
+      <div class="tab" data-target="inquiry-learning">탐구 학습 모형</div>
+      <div class="tab" data-target="learning-cycle">순환 학습 모형</div>
+      <div class="tab" data-target="poe">POE</div>
+      <div class="tab" data-target="five-e">5E</div>
+      <div class="tab" data-target="conceptual-change">개념 변화 학습 모형</div>
+      <div class="tab" data-target="sts-learning">STS 학습 모형</div>
+    </div>
+    <section id="experience-learning" class="active">
+      <h2>경험 학습 모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="자유 탐색" aria-label="자유 탐색" placeholder="단계명">
+        <input data-answer="탐색 결과 발표" aria-label="탐색 결과 발표" placeholder="단계명">
+        <input data-answer="교사의 안내에 따른 탐색" aria-label="교사의 안내에 따른 탐색" placeholder="단계명">
+        <input data-answer="탐색 결과 정리" aria-label="탐색 결과 정리" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="discovery-learning">
+      <h2>발견 학습 모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="탐색 및 문제 파악" aria-label="탐색 및 문제 파악" placeholder="단계명">
+        <input data-answer="자료 제시 및 관찰 탐색" aria-label="자료 제시 및 관찰 탐색" placeholder="단계명">
+        <input data-answer="추가 자료 제시 및 관찰 탐색" aria-label="추가 자료 제시 및 관찰 탐색" placeholder="단계명">
+        <input data-answer="규칙성 발견 및 개념 정리" aria-label="규칙성 발견 및 개념 정리" placeholder="단계명">
+        <input data-answer="적용 및 응용" aria-label="적용 및 응용" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="inquiry-learning">
+      <h2>탐구 학습 모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="탐색 및 문제 파악" aria-label="탐색 및 문제 파악" placeholder="단계명">
+        <input data-answer="가설 설정" aria-label="가설 설정" placeholder="단계명">
+        <input data-answer="실험 설계" aria-label="실험 설계" placeholder="단계명">
+        <input data-answer="실험" aria-label="실험" placeholder="단계명">
+        <input data-answer="가설 검증" aria-label="가설 검증" placeholder="단계명">
+        <input data-answer="적용 및 새로운 문제 발견" aria-label="적용 및 새로운 문제 발견" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="learning-cycle">
+      <h2>순환 학습 모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="탐색" aria-label="탐색" placeholder="단계명">
+        <input data-answer="개념 도입" aria-label="개념 도입" placeholder="단계명">
+        <input data-answer="개념 적용" aria-label="개념 적용" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="poe">
+      <h2>POE</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="예상" aria-label="예상" placeholder="단계명">
+        <input data-answer="관찰" aria-label="관찰" placeholder="단계명">
+        <input data-answer="설명" aria-label="설명" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="five-e">
+      <h2>5E</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="참여" aria-label="참여" placeholder="단계명">
+        <input data-answer="탐색" aria-label="탐색" placeholder="단계명">
+        <input data-answer="설명" aria-label="설명" placeholder="단계명">
+        <input data-answer="정교화" aria-label="정교화" placeholder="단계명">
+        <input data-answer="평가" aria-label="평가" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="conceptual-change">
+      <h2>개념 변화 학습 모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="개념 표현" aria-label="개념 표현" placeholder="단계명">
+        <input data-answer="개념 재구성" aria-label="개념 재구성" placeholder="단계명">
+        <input data-answer="개념 응용" aria-label="개념 응용" placeholder="단계명">
+        <input data-answer="개념 변화 검토" aria-label="개념 변화 검토" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="sts-learning">
+      <h2>STS 학습 모형</h2>
+      <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
+        <input data-answer="문제 소개" aria-label="문제 소개" placeholder="단계명">
+        <input data-answer="탐색" aria-label="탐색" placeholder="단계명">
+        <input data-answer="설명 및 해결방안 제시" aria-label="설명 및 해결방안 제시" placeholder="단계명">
+        <input data-answer="실행" aria-label="실행" placeholder="단계명">
+      </td></tr></tbody></table></div></div>
+    </section>
+  </main>
   <main id="korean-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="listening-speaking">듣기·말하기</div>
@@ -1757,6 +1843,7 @@
                 <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
                 <button class="btn subject-btn" data-subject="practical" data-topic="model">실과</button>
                 <button class="btn subject-btn" data-subject="social" data-topic="model">사회</button>
+                <button class="btn subject-btn" data-subject="science" data-topic="model">과학</button>
                 <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum model">랜덤</button>
             </div>
             <h2>게임 모드</h2>


### PR DESCRIPTION
## Summary
- add Science as a selectable subject under the model topic
- define constant and Korean label for Science
- create Science quiz with model-based learning activities

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68751e6da8e4832cb5351a54b8c8e201