### PR TITLE
Remove braces and align inputs in PE section

### DIFF
--- a/index.html
+++ b/index.html
@@ -942,19 +942,19 @@
           <input data-answer="창의성과 인성 함양을 위한 통합적 교수⋅학습" aria-label="창의성과 인성 함양을 위한 통합적 교수⋅학습" placeholder="정답">
         </td></tr>
         <tr><th>방법</th><td>
-          (가) {<input data-answer="교육과정의 운영" aria-label="교육과정의 운영" placeholder="정답">}
-          ① {<input data-answer="학년군 단위 교육과정의 운영" aria-label="학년군 단위 교육과정의 운영" placeholder="정답">}
-          ② {<input data-answer="연간 교육과정 운영" aria-label="연간 교육과정 운영" placeholder="정답">}
-          ③ {<input data-answer="온⋅오프라인 연계 교육과정의 운영" aria-label="온⋅오프라인 연계 교육과정의 운영" placeholder="정답">}
-          (나) {<input data-answer="단원의 운영" aria-label="단원의 운영" placeholder="정답">}
-          ① {<input data-answer="영역의 특성을 고려한 단원 목표와 학습 활동의 선정" aria-label="영역의 특성을 고려한 단원 목표와 학습 활동의 선정" placeholder="정답">}
-          ② {<input data-answer="학습자 수준을 고려한 교수⋅학습 활동의 다양화" aria-label="학습자 수준을 고려한 교수⋅학습 활동의 다양화" placeholder="정답">}
-          ③ {<input data-answer="체육 시설 및 교육환경을 고려한 교수⋅학습" aria-label="체육 시설 및 교육환경을 고려한 교수⋅학습" placeholder="정답">}
-          ④ {<input data-answer="차시별 수업 내용의 엄선과 위계적 조직" aria-label="차시별 수업 내용의 엄선과 위계적 조직" placeholder="정답">}
-          (다) {<input data-answer="수업의 운영" aria-label="수업의 운영" placeholder="정답">}
-          ① {<input data-answer="학습 활동의 재구성" aria-label="학습 활동의 재구성" placeholder="정답">}
-          ② {<input data-answer="학습 기회의 형평성 제고" aria-label="학습 기회의 형평성 제고" placeholder="정답">}
-          ③ {<input data-answer="학습자의 효율적 관리와 안전한 수업 분위기 조성" aria-label="학습자의 효율적 관리와 안전한 수업 분위기 조성" placeholder="정답">}
+          <div class="inline-item">(가) <input data-answer="교육과정의 운영" aria-label="교육과정의 운영" placeholder="정답"></div>
+          <div class="inline-item">① <input data-answer="학년군 단위 교육과정의 운영" aria-label="학년군 단위 교육과정의 운영" placeholder="정답"></div>
+          <div class="inline-item">② <input data-answer="연간 교육과정 운영" aria-label="연간 교육과정 운영" placeholder="정답"></div>
+          <div class="inline-item">③ <input data-answer="온⋅오프라인 연계 교육과정의 운영" aria-label="온⋅오프라인 연계 교육과정의 운영" placeholder="정답"></div>
+          <div class="inline-item">(나) <input data-answer="단원의 운영" aria-label="단원의 운영" placeholder="정답"></div>
+          <div class="inline-item">① <input data-answer="영역의 특성을 고려한 단원 목표와 학습 활동의 선정" aria-label="영역의 특성을 고려한 단원 목표와 학습 활동의 선정" placeholder="정답"></div>
+          <div class="inline-item">② <input data-answer="학습자 수준을 고려한 교수⋅학습 활동의 다양화" aria-label="학습자 수준을 고려한 교수⋅학습 활동의 다양화" placeholder="정답"></div>
+          <div class="inline-item">③ <input data-answer="체육 시설 및 교육환경을 고려한 교수⋅학습" aria-label="체육 시설 및 교육환경을 고려한 교수⋅학습" placeholder="정답"></div>
+          <div class="inline-item">④ <input data-answer="차시별 수업 내용의 엄선과 위계적 조직" aria-label="차시별 수업 내용의 엄선과 위계적 조직" placeholder="정답"></div>
+          <div class="inline-item">(다) <input data-answer="수업의 운영" aria-label="수업의 운영" placeholder="정답"></div>
+          <div class="inline-item">① <input data-answer="학습 활동의 재구성" aria-label="학습 활동의 재구성" placeholder="정답"></div>
+          <div class="inline-item">② <input data-answer="학습 기회의 형평성 제고" aria-label="학습 기회의 형평성 제고" placeholder="정답"></div>
+          <div class="inline-item">③ <input data-answer="학습자의 효율적 관리와 안전한 수업 분위기 조성" aria-label="학습자의 효율적 관리와 안전한 수업 분위기 조성" placeholder="정답"></div>
         </td></tr>
       </tbody></table></div></div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -930,3 +930,12 @@ td input.activity-input:not(:first-child) {
     color: var(--bg-dark);
 }
 
+.inline-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.inline-item input {
+  flex: 1;
+  width: auto;
+}


### PR DESCRIPTION
## Summary
- remove literal braces in the PE back teaching methods table
- add `.inline-item` style so symbols and blanks stay on the same line

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68756e064dd0832cbcd94aa63241e6bc