### PR TITLE
Add 창체 subject with character-goal content

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,7 @@
                 SOCIAL: 'social',
                 SCIENCE: 'science',
                 PE_BACK: 'pe-back',
+                CREATIVE: 'creative',
                 COMPETENCY: "competency",
                 RANDOM: 'random'
             },
@@ -455,6 +456,7 @@
                 [CONSTANTS.SUBJECTS.SOCIAL]: '사회',
                 [CONSTANTS.SUBJECTS.SCIENCE]: '과학',
                 [CONSTANTS.SUBJECTS.PE_BACK]: '체육(뒷교)',
+                [CONSTANTS.SUBJECTS.CREATIVE]: '창체',
                 [CONSTANTS.SUBJECTS.COMPETENCY]: '역량'
             };
             headerTitle.textContent = subjectMap[gameState.selectedSubject] || '퀴즈';

--- a/index.html
+++ b/index.html
@@ -1700,8 +1700,32 @@
             </table>
           </div>
         </div>
-      </section>
+  </section>
+  </section>
+</main>
+  <main id="creative-quiz-main" class="hidden">
+    <div class="tabs">
+      <div class="tab active" data-target="character-goal">성격 및 목표</div>
+      <div class="tab" data-target="area-activity">영역과 활동</div>
+      <div class="tab" data-target="plan-operate">설계와 운영</div>
+    </div>
+    <section id="character-goal" class="active">
+      <h2>성격 및 목표</h2>
+      <div class="text-content">
+        <p>가. 성격<br>
+        창의적 체험활동은 <input data-answer="교과" aria-label="교과" placeholder="정답">와의 상호 보완적인 관계 속에서 학생의 <input data-answer="전인적인 성장" aria-label="전인적인 성장" placeholder="정답">을 위하여 학교가 자율적으로 설계·운영할 수 있는 <input data-answer="경험과 실천" aria-label="경험과 실천" placeholder="정답"> 중심의 교육과정 영역이다.</p>
+        <p>창의적 체험활동은 초·중등학교 학생들이 자신의 삶과 연계된 다양한 활동에 참여함으로써 개인의 소질과 잠재력을 계발할 뿐만 아니라 <input data-answer="창의성" aria-label="창의성" placeholder="정답">과 <input data-answer="포용성" aria-label="포용성" placeholder="정답">을 지닌 민주시민으로서의 삶의 태도를 기르는 것을 목표로 한다.</p>
+        <p>[첫째] 창의적 체험활동은 <input data-answer="역량 함양" aria-label="역량 함양" placeholder="정답">을 위한 <input data-answer="학습자" aria-label="학습자" placeholder="정답"> 주도의 교육과정이다. 창의적 체험활동은 자율·자치활동, 동아리 활동, 진로 활동의 3개 영역으로 구성되며, 각 영역의 활동은 학생의 자기관리 역량, 지식정보처리 역량, 창의적 사고 역량, 심미적 감성 역량, 협력적 소통 역량, 공동체 역량의 증진을 도모한다.</p>
+        <p>[둘째] 창의적 체험활동은 <input data-answer="교과와의 연계" aria-label="교과와의 연계" placeholder="정답">, 학교급 간 및 학년 간, 그리고 영역 및 활동 간의 <input data-answer="연계와 통합" aria-label="연계와 통합" placeholder="정답">을 추구한다. 학교는 학생의 발달 단계와 교육적 요구 등을 고려하여 학생 개인별 또는 집단별로 <input data-answer="영역 및 활동을 선택하여 집중적" aria-label="영역 및 활동을 선택하여 집중적" placeholder="정답">으로 운영할 수 있다.</p>
+        <p>[셋째] 창의적 체험활동은 학교급별 특성을 반영하여 설계한다. 학교는 학생의 흥미와 관심, 교육적 필요와 요구, 지역 사회의 특성 등을 고려하여 <input data-answer="특정 영역과 활동" aria-label="특정 영역과 활동" placeholder="정답">에 중점을 두고 융통성 있게 설계할 수 있다. 학교는 학교급별 목표와 운영의 중점을 고려하고 학교의 <input data-answer="자율성" aria-label="자율성" placeholder="정답">과 <input data-answer="특수성" aria-label="특수성" placeholder="정답">을 반영하여 창의적 체험활동을 설계·운영한다.</p>
+        <p>[넷째] 학교는 창의적 체험활동 교육과정을 설계하고 운영함에 있어 <input data-answer="자율성" aria-label="자율성" placeholder="정답">을 발휘한다. 창의적 체험활동의 설계 주체는 <input data-answer="학교" aria-label="학교" placeholder="정답">, <input data-answer="교사" aria-label="교사" placeholder="정답">, <input data-answer="학생" aria-label="학생" placeholder="정답">이다. 창의적 체험활동에서는 교사와 학생이, 학생과 학생이 공동으로 계획을 수립하고 역할을 분담하여 실천한다. 이를 위해 국가 및 지역 수준에서는 학교와 지역의 특색을 고려하여 전문성을 갖춘 인적·물적 자원을 충분히 제공할 수 있는 기반을 마련한다.</p>
+        <p>나. 목표<br>
+        창의적 체험활동은 학생들이 창의적인 다양한 활동에 주도적으로 참여함으로써 개인의 <input data-answer="소질과 잠재력" aria-label="소질과 잠재력" placeholder="정답">을 계발·신장하여 창의적인 삶의 태도를 기르고 <input data-answer="공동체 의식" aria-label="공동체 의식" placeholder="정답">을 함양하도록 하는 데 목표가 있다.</p>
+        <p>(1) 초등학교에서는 자신의 <input data-answer="개성과 소질" aria-label="개성과 소질" placeholder="정답">을 탐색하고 발견하여 공동체 생활에 필요한 <input data-answer="기본 생활 습관" aria-label="기본 생활 습관" placeholder="정답">과 <input data-answer="시민의식" aria-label="시민의식" placeholder="정답">을 기른다.</p>
+      </div>
     </section>
+    <section id="area-activity"></section>
+    <section id="plan-operate"></section>
   </main>
 <!-- competency main start -->
 <main id="competency-quiz-main" class="hidden competency-ui">
@@ -1893,6 +1917,7 @@
                 <button class="btn subject-btn" data-subject="social" data-topic="model">사회</button>
                 <button class="btn subject-btn" data-subject="science" data-topic="model">과학</button>
                 <button class="btn subject-btn" data-subject="pe-back" data-topic="course">체육(뒷교)</button>
+                <button class="btn subject-btn" data-subject="creative" data-topic="course">창체</button>
                 <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model">랜덤</button>
             </div>
             <h2>게임 모드</h2>


### PR DESCRIPTION
## Summary
- add `CREATIVE` subject constant and display name
- create `creative-quiz-main` section for 창체 subject with 성격 및 목표 text
- add 창체 to subject selector in the 교육과정 topic

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68777b95af84832cbe3d45aec13cf10a