### PR TITLE
Improve readability for '창체' fill-in sections

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -939,3 +939,17 @@ td input.activity-input:not(:first-child) {
   flex: 1;
   width: auto;
 }
+
+/* Creative subject readability tweaks */
+#creative-quiz-main .inline-item {
+  flex-wrap: wrap;
+  line-height: 1.6;
+  font-size: 1.8rem;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+#creative-quiz-main .inline-item input {
+  flex: 0 0 auto;
+  font-size: 1.8rem;
+  min-width: 6rem;
+}


### PR DESCRIPTION
## Summary
- enhance text readability within the creative subject section
- keep blank input style but allow wrapping and larger fonts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687786368610832ca677977b3fa086e1