### PR TITLE
Improve 창체 section readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -981,21 +981,25 @@
       <div class="tab" data-target="areas">영역과 활동</div>
       <div class="tab" data-target="planning">설계와 운영</div>
     </div>
-    <section id="character-goal" class="active">
-      <h2>성격 및 목표</h2>
-      <div class="grade-container"><div><table><tbody><tr><td>
-        <div class="inline-item">가. 성격</div>
-        <div class="inline-item">창의적 체험활동은 <input data-answer="교과" aria-label="교과" placeholder="정답">와의 상호 보완적인 관계 속에서 학생의 <input data-answer="전인적인 성장" aria-label="전인적인 성장" placeholder="정답">을 위하여 학교가 자율적으로 설계·운영할 수 있는 <input data-answer="경험과 실천" aria-label="경험과 실천" placeholder="정답"> 중심의 교육과정 영역이다.</div>
-        <div class="inline-item">창의적 체험활동은 초·중등학교 학생들이 자신의 삶과 연계된 다양한 활동에 참여함으로써 개인의 소질과 잠재력을 계발할 뿐만 아니라 <input data-answer="창의성" aria-label="창의성" placeholder="정답">과 <input data-answer="포용성" aria-label="포용성" placeholder="정답">을 지닌 민주시민으로서의 삶의 태도를 기르는 것을 목표로 한다.</div>
-        <div class="inline-item">[첫째] 창의적 체험활동은 <input data-answer="역량 함양" aria-label="역량 함양" placeholder="정답">을 위한 <input data-answer="학습자" aria-label="학습자" placeholder="정답"> 주도의 교육과정이다. 창의적 체험활동은 자율·자치활동, 동아리 활동, 진로 활동의 3개 영역으로 구성되며, 각 영역의 활동은 학생의 자기관리 역량, 지식정보처리 역량, 창의적 사고 역량, 심미적 감성 역량, 협력적 소통 역량, 공동체 역량의 증진을 도모한다.</div>
-        <div class="inline-item">[둘째] 창의적 체험활동은 <input data-answer="교과와의 연계" aria-label="교과와의 연계" placeholder="정답">, 학교급 간 및 학년 간, 그리고 영역 및 활동 간의 <input data-answer="연계와 통합" aria-label="연계와 통합" placeholder="정답">을 추구한다. 학교는 학생의 발달 단계와 교육적 요구 등을 고려하여 학생 개인별 또는 집단별로 <input data-answer="영역 및 활동을 선택하여 집중적" aria-label="영역 및 활동을 선택하여 집중적" placeholder="정답">으로 운영할 수 있다.</div>
-        <div class="inline-item">[셋째] 창의적 체험활동은 학교급별 특성을 반영하여 설계한다. 학교는 학생의 흥미와 관심, 교육적 필요와 요구, 지역 사회의 특성 등을 고려하여 <input data-answer="특정 영역과 활동" aria-label="특정 영역과 활동" placeholder="정답">에 중점을 두고 융통성 있게 설계할 수 있다. 학교는 학교급별 목표와 운영의 중점을 고려하고 학교의 <input data-answer="자율성" aria-label="자율성" placeholder="정답">과 <input data-answer="특수성" aria-label="특수성" placeholder="정답">을 반영하여 창의적 체험활동을 설계·운영한다.</div>
-        <div class="inline-item">[넷째] 학교는 창의적 체험활동 교육과정을 설계하고 운영함에 있어 <input data-answer="자율성" aria-label="자율성" placeholder="정답">을 발휘한다. 창의적 체험활동의 설계 주체는 <input data-answer="학교" aria-label="학교" placeholder="정답">, <input data-answer="교사" aria-label="교사" placeholder="정답">, <input data-answer="학생" aria-label="학생" placeholder="정답">이다. 창의적 체험활동에서는 교사와 학생이, 학생과 학생이 공동으로 계획을 수립하고 역할을 분담하여 실천한다. 이를 위해 국가 및 지역 수준에서는 학교와 지역의 특색을 고려하여 전문성을 갖춘 인적·물적 자원을 충분히 제공할 수 있는 기반을 마련한다.</div>
-        <div class="inline-item">나. 목표</div>
-        <div class="inline-item">창의적 체험활동은 학생들이 창의적인 다양한 활동에 주도적으로 참여함으로써 개인의 <input data-answer="소질과 잠재력" aria-label="소질과 잠재력" placeholder="정답">을 계발·신장하여 창의적인 삶의 태도를 기르고 <input data-answer="공동체 의식" aria-label="공동체 의식" placeholder="정답">을 함양하도록 하는 데 목표가 있다.</div>
-        <div class="inline-item">(1) 초등학교에서는 자신의 <input data-answer="개성과 소질" aria-label="개성과 소질" placeholder="정답">을 탐색하고 발견하여 공동체 생활에 필요한 <input data-answer="기본 생활 습관" aria-label="기본 생활 습관" placeholder="정답">과 <input data-answer="시민의식" aria-label="시민의식" placeholder="정답">을 기른다.</div>
-      </td></tr></tbody></table></div></div>
-    </section>
+      <section id="character-goal" class="active">
+        <h2>성격 및 목표</h2>
+        <div class="grade-container"><div><table><tbody><tr><td>
+          <div class="creative-block">
+            <div class="outline-title">가. 성격</div>
+            <div class="creative-question">창의적 체험활동은 <input data-answer="교과" aria-label="교과" placeholder="정답">와의 상호 보완적인 관계 속에서 학생의 <input data-answer="전인적인 성장" aria-label="전인적인 성장" placeholder="정답">을 위하여 학교가 자율적으로 설계·운영할 수 있는 <input data-answer="경험과 실천" aria-label="경험과 실천" placeholder="정답"> 중심의 교육과정 영역이다.</div>
+            <div class="creative-question">창의적 체험활동은 초·중등학교 학생들이 자신의 삶과 연계된 다양한 활동에 참여함으로써 개인의 소질과 잠재력을 계발할 뿐만 아니라 <input data-answer="창의성" aria-label="창의성" placeholder="정답">과 <input data-answer="포용성" aria-label="포용성" placeholder="정답">을 지닌 민주시민으로서의 삶의 태도를 기르는 것을 목표로 한다.</div>
+            <div class="creative-question">[첫째] 창의적 체험활동은 <input data-answer="역량 함양" aria-label="역량 함양" placeholder="정답">을 위한 <input data-answer="학습자" aria-label="학습자" placeholder="정답"> 주도의 교육과정이다. 창의적 체험활동은 자율·자치활동, 동아리 활동, 진로 활동의 3개 영역으로 구성되며, 각 영역의 활동은 학생의 자기관리 역량, 지식정보처리 역량, 창의적 사고 역량, 심미적 감성 역량, 협력적 소통 역량, 공동체 역량의 증진을 도모한다.</div>
+            <div class="creative-question">[둘째] 창의적 체험활동은 <input data-answer="교과와의 연계" aria-label="교과와의 연계" placeholder="정답">, 학교급 간 및 학년 간, 그리고 영역 및 활동 간의 <input data-answer="연계와 통합" aria-label="연계와 통합" placeholder="정답">을 추구한다. 학교는 학생의 발달 단계와 교육적 요구 등을 고려하여 학생 개인별 또는 집단별로 <input data-answer="영역 및 활동을 선택하여 집중적" aria-label="영역 및 활동을 선택하여 집중적" placeholder="정답">으로 운영할 수 있다.</div>
+            <div class="creative-question">[셋째] 창의적 체험활동은 학교급별 특성을 반영하여 설계한다. 학교는 학생의 흥미와 관심, 교육적 필요와 요구, 지역 사회의 특성 등을 고려하여 <input data-answer="특정 영역과 활동" aria-label="특정 영역과 활동" placeholder="정답">에 중점을 두고 융통성 있게 설계할 수 있다. 학교는 학교급별 목표와 운영의 중점을 고려하고 학교의 <input data-answer="자율성" aria-label="자율성" placeholder="정답">과 <input data-answer="특수성" aria-label="특수성" placeholder="정답">을 반영하여 창의적 체험활동을 설계·운영한다.</div>
+            <div class="creative-question">[넷째] 학교는 창의적 체험활동 교육과정을 설계하고 운영함에 있어 <input data-answer="자율성" aria-label="자율성" placeholder="정답">을 발휘한다. 창의적 체험활동의 설계 주체는 <input data-answer="학교" aria-label="학교" placeholder="정답">, <input data-answer="교사" aria-label="교사" placeholder="정답">, <input data-answer="학생" aria-label="학생" placeholder="정답">이다. 창의적 체험활동에서는 교사와 학생이, 학생과 학생이 공동으로 계획을 수립하고 역할을 분담하여 실천한다. 이를 위해 국가 및 지역 수준에서는 학교와 지역의 특색을 고려하여 전문성을 갖춘 인적·물적 자원을 충분히 제공할 수 있는 기반을 마련한다.</div>
+          </div>
+          <div class="creative-block">
+            <div class="outline-title">나. 목표</div>
+            <div class="creative-question">창의적 체험활동은 학생들이 창의적인 다양한 활동에 주도적으로 참여함으로써 개인의 <input data-answer="소질과 잠재력" aria-label="소질과 잠재력" placeholder="정답">을 계발·신장하여 창의적인 삶의 태도를 기르고 <input data-answer="공동체 의식" aria-label="공동체 의식" placeholder="정답">을 함양하도록 하는 데 목표가 있다.</div>
+            <div class="creative-question">(1) 초등학교에서는 자신의 <input data-answer="개성과 소질" aria-label="개성과 소질" placeholder="정답">을 탐색하고 발견하여 공동체 생활에 필요한 <input data-answer="기본 생활 습관" aria-label="기본 생활 습관" placeholder="정답">과 <input data-answer="시민의식" aria-label="시민의식" placeholder="정답">을 기른다.</div>
+          </div>
+        </td></tr></tbody></table></div></div>
+      </section>
     <section id="areas">
       <h2>영역과 활동</h2>
       <p>준비 중</p>

--- a/styles.css
+++ b/styles.css
@@ -941,15 +941,34 @@ td input.activity-input:not(:first-child) {
 }
 
 /* Creative subject readability tweaks */
-#creative-quiz-main .inline-item {
+#creative-quiz-main .creative-block {
+  margin-bottom: 2rem;
+  padding: 1rem;
+  background: var(--bg-light);
+  border: 2px solid var(--secondary);
+  border-radius: 8px;
+}
+#creative-quiz-main .outline-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: var(--accent);
+}
+#creative-quiz-main .creative-question {
+  display: flex;
   flex-wrap: wrap;
   line-height: 1.6;
-  font-size: 1.8rem;
+  font-size: 2rem;
   gap: 0.6rem;
-  margin-bottom: 1rem;
+  padding-bottom: 0.8rem;
+  border-bottom: 2px dashed var(--secondary);
+  margin-bottom: 0.8rem;
 }
-#creative-quiz-main .inline-item input {
+#creative-quiz-main .creative-question:last-child {
+  border-bottom: none;
+}
+#creative-quiz-main .creative-question input {
   flex: 0 0 auto;
-  font-size: 1.8rem;
+  font-size: 2rem;
   min-width: 6rem;
 }


### PR DESCRIPTION
## Summary
- restructure 창체 section for better block separation
- add new styles for creative questions and titles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877881fa240832caaab1ee5f2db1027