### PR TITLE
Add creative areas content and style tweak

### DIFF
--- a/index.html
+++ b/index.html
@@ -1002,7 +1002,12 @@
       </section>
     <section id="areas">
       <h2>영역과 활동</h2>
-      <p>준비 중</p>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="creative-question">창의적 체험활동은 <input data-answer="자율·자치활동" aria-label="자율·자치활동" placeholder="정답">, <input data-answer="동아리 활동" aria-label="동아리 활동" placeholder="정답">, <input data-answer="진로 활동" aria-label="진로 활동" placeholder="정답">의 세 영역으로 구성된다.</div>
+          <div class="creative-question">각 영역은 학교의 특성과 학생의 <input data-answer="발달 단계" aria-label="발달 단계" placeholder="정답">를 고려하여 자율적으로 운영되며, 다양한 활동 참여를 통해 <input data-answer="협동심" aria-label="협동심" placeholder="정답">을 기를 수 있다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
     </section>
     <section id="planning">
       <h2>설계와 운영</h2>

--- a/styles.css
+++ b/styles.css
@@ -959,6 +959,7 @@ td input.activity-input:not(:first-child) {
   flex-wrap: wrap;
   line-height: 1.6;
   font-size: 2rem;
+  font-weight: 500;
   gap: 0.6rem;
   padding-bottom: 0.8rem;
   border-bottom: 2px dashed var(--secondary);


### PR DESCRIPTION
## Summary
- add fill-in-the-blank questions for 창체 영역과 활동
- improve readability with heavier font weight in creative questions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68778bda6a50832cb74b4fcfe4f0acdd