### PR TITLE
Fix outline title color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -952,7 +952,7 @@ td input.activity-input:not(:first-child) {
   font-size: 2rem;
   font-weight: 700;
   margin-bottom: 1rem;
-  color: var(--accent);
+  color: var(--primary);
 }
 #creative-quiz-main .creative-question {
   display: flex;


### PR DESCRIPTION
## Summary
- increase visibility for outline titles in creative quiz section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687791c2ce88832cbe3fe01d8b0c6a7e