### PR TITLE
Improve creative course readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -986,12 +986,22 @@
         <div class="grade-container"><div><table><tbody><tr><td>
           <div class="creative-block">
             <div class="outline-title">가. 성격</div>
-            <div class="creative-question">창의적 체험활동은 <input data-answer="교과" aria-label="교과" placeholder="정답">와의 상호 보완적인 관계 속에서 학생의 <input data-answer="전인적인 성장" aria-label="전인적인 성장" placeholder="정답">을 위하여 학교가 자율적으로 설계·운영할 수 있는 <input data-answer="경험과 실천" aria-label="경험과 실천" placeholder="정답"> 중심의 교육과정 영역이다.</div>
-            <div class="creative-question">창의적 체험활동은 초·중등학교 학생들이 자신의 삶과 연계된 다양한 활동에 참여함으로써 개인의 소질과 잠재력을 계발할 뿐만 아니라 <input data-answer="창의성" aria-label="창의성" placeholder="정답">과 <input data-answer="포용성" aria-label="포용성" placeholder="정답">을 지닌 민주시민으로서의 삶의 태도를 기르는 것을 목표로 한다.</div>
-            <div class="creative-question">[첫째] 창의적 체험활동은 <input data-answer="역량 함양" aria-label="역량 함양" placeholder="정답">을 위한 <input data-answer="학습자" aria-label="학습자" placeholder="정답"> 주도의 교육과정이다. 창의적 체험활동은 자율·자치활동, 동아리 활동, 진로 활동의 3개 영역으로 구성되며, 각 영역의 활동은 학생의 자기관리 역량, 지식정보처리 역량, 창의적 사고 역량, 심미적 감성 역량, 협력적 소통 역량, 공동체 역량의 증진을 도모한다.</div>
-            <div class="creative-question">[둘째] 창의적 체험활동은 <input data-answer="교과와의 연계" aria-label="교과와의 연계" placeholder="정답">, 학교급 간 및 학년 간, 그리고 영역 및 활동 간의 <input data-answer="연계와 통합" aria-label="연계와 통합" placeholder="정답">을 추구한다. 학교는 학생의 발달 단계와 교육적 요구 등을 고려하여 학생 개인별 또는 집단별로 <input data-answer="영역 및 활동을 선택하여 집중적" aria-label="영역 및 활동을 선택하여 집중적" placeholder="정답">으로 운영할 수 있다.</div>
-            <div class="creative-question">[셋째] 창의적 체험활동은 학교급별 특성을 반영하여 설계한다. 학교는 학생의 흥미와 관심, 교육적 필요와 요구, 지역 사회의 특성 등을 고려하여 <input data-answer="특정 영역과 활동" aria-label="특정 영역과 활동" placeholder="정답">에 중점을 두고 융통성 있게 설계할 수 있다. 학교는 학교급별 목표와 운영의 중점을 고려하고 학교의 <input data-answer="자율성" aria-label="자율성" placeholder="정답">과 <input data-answer="특수성" aria-label="특수성" placeholder="정답">을 반영하여 창의적 체험활동을 설계·운영한다.</div>
-            <div class="creative-question">[넷째] 학교는 창의적 체험활동 교육과정을 설계하고 운영함에 있어 <input data-answer="자율성" aria-label="자율성" placeholder="정답">을 발휘한다. 창의적 체험활동의 설계 주체는 <input data-answer="학교" aria-label="학교" placeholder="정답">, <input data-answer="교사" aria-label="교사" placeholder="정답">, <input data-answer="학생" aria-label="학생" placeholder="정답">이다. 창의적 체험활동에서는 교사와 학생이, 학생과 학생이 공동으로 계획을 수립하고 역할을 분담하여 실천한다. 이를 위해 국가 및 지역 수준에서는 학교와 지역의 특색을 고려하여 전문성을 갖춘 인적·물적 자원을 충분히 제공할 수 있는 기반을 마련한다.</div>
+            <div class="creative-question">
+              창의적 체험활동은 <input data-answer="교과" aria-label="교과" placeholder="정답">와의 상호 보완적인 관계 속에서<br>
+              학생의 <input data-answer="전인적인 성장" aria-label="전인적인 성장" placeholder="정답">을 위하여<br>
+              학교가 자율적으로 설계·운영할 수 있는 <input data-answer="경험과 실천" aria-label="경험과 실천" placeholder="정답"> 중심의 교육과정 영역이다.
+            </div>
+            <div class="creative-question">
+              창의적 체험활동은 초·중등학교 학생들이 자신의 삶과 연계된 다양한 활동에 참여함으로써<br>
+              개인의 소질과 잠재력을 계발할 뿐만 아니라<br>
+              <input data-answer="창의성" aria-label="창의성" placeholder="정답">과 <input data-answer="포용성" aria-label="포용성" placeholder="정답">을 지닌 민주시민으로서의 삶의 태도를 기르는 것을 목표로 한다.
+            </div>
+            <ul class="creative-question">
+              <li>[첫째] 창의적 체험활동은 <input data-answer="역량 함양" aria-label="역량 함양" placeholder="정답">을 위한 <input data-answer="학습자" aria-label="학습자" placeholder="정답"> 주도의 교육과정이다. 창의적 체험활동은 자율·자치활동, 동아리 활동, 진로 활동의 3개 영역으로 구성되며, 각 영역의 활동은 학생의 자기관리 역량, 지식정보처리 역량, 창의적 사고 역량, 심미적 감성 역량, 협력적 소통 역량, 공동체 역량의 증진을 도모한다.</li>
+              <li>[둘째] 창의적 체험활동은 <input data-answer="교과와의 연계" aria-label="교과와의 연계" placeholder="정답">, 학교급 간 및 학년 간, 그리고 영역 및 활동 간의 <strong><input data-answer="연계와 통합" aria-label="연계와 통합" placeholder="정답"></strong>을 추구한다. 학교는 학생의 발달 단계와 교육적 요구 등을 고려하여 학생 개인별 또는 집단별로 <input data-answer="영역 및 활동을 선택하여 집중적" aria-label="영역 및 활동을 선택하여 집중적" placeholder="정답">으로 운영할 수 있다.</li>
+              <li>[셋째] 창의적 체험활동은 학교급별 특성을 반영하여 설계한다. 학교는 학생의 흥미와 관심, 교육적 필요와 요구, 지역 사회의 특성 등을 고려하여 <strong><input data-answer="특정 영역과 활동" aria-label="특정 영역과 활동" placeholder="정답"></strong>에 중점을 두고 융통성 있게 설계할 수 있다. 학교는 학교급별 목표와 운영의 중점을 고려하고 학교의 <strong><input data-answer="자율성" aria-label="자율성" placeholder="정답"></strong>과 <input data-answer="특수성" aria-label="특수성" placeholder="정답">을 반영하여 창의적 체험활동을 설계·운영한다.</li>
+              <li>[넷째] 학교는 창의적 체험활동 교육과정을 설계하고 운영함에 있어 <strong><input data-answer="자율성" aria-label="자율성" placeholder="정답"></strong>을 발휘한다. 창의적 체험활동의 설계 주체는 <input data-answer="학교" aria-label="학교" placeholder="정답">, <input data-answer="교사" aria-label="교사" placeholder="정답">, <input data-answer="학생" aria-label="학생" placeholder="정답">이다. 창의적 체험활동에서는 교사와 학생이, 학생과 학생이 공동으로 계획을 수립하고 역할을 분담하여 실천한다. 이를 위해 국가 및 지역 수준에서는 학교와 지역의 특색을 고려하여 전문성을 갖춘 인적·물적 자원을 충분히 제공할 수 있는 기반을 마련한다.</li>
+            </ul>
           </div>
           <div class="creative-block">
             <div class="outline-title">나. 목표</div>
@@ -1023,12 +1033,12 @@
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
           <div class="outline-title">가. 설계의 원칙</div>
-          <div class="creative-question">학교는 창의적 체험활동 교육과정 편성·운영 시 자율·자치활동, 동아리 활동, 진로 활동의 영역과 영역별 활동의 특성에 따라 <input data-answer="각각 운영" aria-label="각각 운영" placeholder="정답">하거나 각 영역 및 활동을 <input data-answer="연계·통합한 활동" aria-label="연계·통합한 활동" placeholder="정답">으로 설계할 수 있다.</div>
+          <div class="creative-question">학교는 창의적 체험활동 교육과정 편성·운영 시 자율·자치활동, 동아리 활동, 진로 활동의 영역과 영역별 활동의 특성에 따라 <input data-answer="각각 운영" aria-label="각각 운영" placeholder="정답">하거나 각 영역 및 활동을 <strong><input data-answer="연계·통합한 활동" aria-label="연계·통합한 활동" placeholder="정답"></strong>으로 설계할 수 있다.</div>
           <div class="creative-question">학교급별, 학년(군)별, 학기별로 학생의 특성과 요구에 따라 <input data-answer="일부 영역과 활동을 선택하여 집중적" aria-label="일부 영역과 활동을 선택하여 집중적" placeholder="정답">으로 편성·운영하는 등 영역 및 활동의 편성에 있어 다양한 운영 방식으로 설계할 수 있다.</div>
           <div class="creative-question">창의적 체험활동 교육과정 운영을 위한 시수 편성은 총론의 학교급별 교육과정 편성·운영 기준에 제시된 시간 배당 기준 등에 따른다. 초등학교와 중학교에서 학교는 자율적으로 교과(군)별 및 창의적 체험활동의 <input data-answer="20%" aria-label="20%" placeholder="정답"> 범위 내에서 시수를 증감하여 편성·운영할 수 있다.</div>
           <div class="creative-question">창의적 체험활동에 배당된 학교급별, 학년(군)별 시수를 <input data-answer="특정 학년이나 학기에 편중" aria-label="특정 학년이나 학기에 편중" placeholder="정답">하여 편성하지 않도록 한다. 초등학교 1학년은 <input data-answer="입학 초기 적응" aria-label="입학 초기 적응" placeholder="정답"> 활동으로 입학 후 3월 중 <input data-answer="34" aria-label="34" placeholder="정답">시간을 배정한다.</div>
           <div class="creative-question">학교는 초등학교, 중학교, 고등학교의 입학 초기 및 상급 학교(학년)로 진학하기 전 학기의 일부 시간을 활용하여 학교급 간 전환 시기의 연계와 생활 적응을 지원하기 위해 <input data-answer="진로 연계 교육" aria-label="진로 연계 교육" placeholder="정답">을 운영할 수 있다.</div>
-          <div class="creative-question">교육적 필요에 따라 교과와의 <input data-answer="연계 및 통합" aria-label="연계 및 통합" placeholder="정답">이 원활하게 이루어지도록 설계하되 <input data-answer="교과 진도와 관련된 심화 보충형 학습" aria-label="교과 진도와 관련된 심화 보충형 학습" placeholder="정답">이 되지 않도록 한다.</div>
+          <div class="creative-question">교육적 필요에 따라 교과와의 <strong><input data-answer="연계 및 통합" aria-label="연계 및 통합" placeholder="정답"></strong>이 원활하게 이루어지도록 설계하되 <input data-answer="교과 진도와 관련된 심화 보충형 학습" aria-label="교과 진도와 관련된 심화 보충형 학습" placeholder="정답">이 되지 않도록 한다.</div>
           <div class="creative-question"><input data-answer="범교과 학습 주제" aria-label="범교과 학습 주제" placeholder="정답">의 경우 관련 있는 교과 교육과정에서 우선하여 교육하고 필요시 창의적 체험활동에서 다루도록 한다.</div>
           <div class="creative-question"><input data-answer="계기 교육" aria-label="계기 교육" placeholder="정답">을 창의적 체험활동을 통해 실시할 경우, 강의식이나 지식 전달 위주의 수업 방식이 아닌 <input data-answer="학생" aria-label="학생" placeholder="정답"> 중심의 창의적 체험활동 교육과정 운영이 될 수 있도록 한다.</div>
           <div class="creative-question">창의적 체험활동의 계획은 학생들의 <input data-answer="흥미와 소질" aria-label="흥미와 소질" placeholder="정답">, <input data-answer="학교와 지역의 실정" aria-label="학교와 지역의 실정" placeholder="정답">을 고려하여 수립하도록 한다.</div>

--- a/styles.css
+++ b/styles.css
@@ -956,12 +956,17 @@ td input.activity-input:not(:first-child) {
 }
 #creative-quiz-main .creative-question {
   display: block; /* allow natural inline flow around inputs */
-  line-height: 1.6;
+  line-height: 1.8; /* increased for readability */
   font-size: 2rem;
   font-weight: 500;
   padding-bottom: 2rem;
   border-bottom: 2px dashed var(--secondary);
-  margin-bottom: 2rem;
+  margin-bottom: 2.5rem; /* extra spacing between items */
+}
+
+#creative-quiz-main ul.creative-question {
+  list-style-type: disc;
+  padding-left: 2rem;
 }
 #creative-quiz-main .creative-question:last-child {
   border-bottom: none;
@@ -1001,4 +1006,8 @@ td input.activity-input:not(:first-child) {
 #creative-quiz-main .creative-question input.revealed {
   color: var(--revealed);
   border-color: var(--revealed);
+}
+
+#creative-quiz-main .creative-question strong {
+  color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- adjust `.creative-question` spacing and add highlight support
- break long sentences for 창체 course section
- convert numbered points into a list with highlighted keywords

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687796ced144832cb265b668da5bdfb8