### PR TITLE
Add sub-level support sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,8 +481,13 @@
       <h2>교육과정의 성격</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
+          <div class="outline-title">1. 설계의 원칙</div>
           <div class="overview-question">이 교육과정은 <input data-answer="초·중등교육법" aria-label="초·중등교육법" placeholder="정답"> 제23조제2항에 의거하여 고시한 것으로, 초·중등학교의 교육 목적을 달성하기 위해 초·중등학교에서 운영하여야 할 학교 교육과정의 <input data-answer="공통적이고 일반적인" aria-label="공통적이고 일반적인" placeholder="정답"> 기준을 <input data-answer="국가" aria-label="국가" placeholder="정답"> 수준에서 제시한 것이다.</div>
           <div class="overview-question">[가] 국가 수준의 <input data-answer="공통성" aria-label="공통성" placeholder="정답">을 바탕으로 지역, 학교, 개인 수준의 <input data-answer="다양성" aria-label="다양성" placeholder="정답">을 추구할 수 있도록 학교 교육과정의 기준과 내용에 관한 기본사항을 제시한다.</div>
+          <div class="overview-question">[나] 학교 교육과정이 학생을 중심에 두고 <input data-answer="주도성" aria-label="주도성" placeholder="정답">과 <input data-answer="자율성" aria-label="자율성" placeholder="정답">, <input data-answer="창의성" aria-label="창의성" placeholder="정답">의 신장 등 학습자 성장을 지원할 수 있도록 교육과정의 기준과 내용을 제시한다.</div>
+          <div class="overview-question">[다] 학교의 전반적인 교육 체제를 <input data-answer="교육과정" aria-label="교육과정" placeholder="정답"> 중심으로 운영할 수 있도록 교육과정의 기준과 내용을 제시한다.</div>
+          <div class="overview-question">[라] 학교 교육과정이 추구하는 교육 목적의 실현을 위해 <input data-answer="학교" aria-label="학교" placeholder="정답">와 <input data-answer="시·도 교육청" aria-label="시·도 교육청" placeholder="정답">, <input data-answer="지역사회" aria-label="지역사회" placeholder="정답">, <input data-answer="학생·학부모·교원" aria-label="학생·학부모·교원" placeholder="정답">이 함께 협력적으로 참여하는 데 필요한 사항을 제시한다.</div>
+          <div class="overview-question">[마] 학교 교육의 <input data-answer="질적 수준" aria-label="질적 수준" placeholder="정답">을 <input data-answer="국가" aria-label="국가" placeholder="정답">와 <input data-answer="시·도 교육청" aria-label="시·도 교육청" placeholder="정답">, <input data-answer="학교" aria-label="학교" placeholder="정답"> 수준에서 관리하고 개선하기 위해 기반으로 삼아야 할 교육과정의 기준과 내용을 제시한다.</div>
         </div>
       </td></tr></tbody></table></div></div>
     </section>
@@ -491,7 +496,14 @@
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
           <div class="overview-question">이에 그동안의 교육과정 발전 방향을 계승하면서 미래 사회를 살아갈 학생들이 <input data-answer="주도적으로 삶을 이끌어가는 능력" aria-label="주도적으로 삶을 이끌어가는 능력" placeholder="정답">을 함양할 수 있도록 교육과정을 구성한다.</div>
+          <div class="overview-question">이 교육과정은 우리나라 교육과정이 추구해 온 교육 이념과 인간상을 바탕으로, 미래 사회가 요구하는 <input data-answer="핵심역량" aria-label="핵심역량" placeholder="정답">을 함양하여 <input data-answer="포용성과 창의성을 갖춘 주도적인 사람" aria-label="포용성과 창의성을 갖춘 주도적인 사람" placeholder="정답">으로 성장하게 하는 데 중점을 둔다. 이를 위한 교육과정 구성의 중점은 다음과 같다.</div>
           <div class="overview-question">[가] 디지털 전환, 기후·생태환경 변화 등에 따른 미래 사회의 불확실성에 <input data-answer="능동적으로 대응할 수 있는 능력" aria-label="능동적으로 대응할 수 있는 능력" placeholder="정답">과 자신의 삶과 학습을 스스로 이끌어가는 <input data-answer="주도성" aria-label="주도성" placeholder="정답">을 함양한다.</div>
+          <div class="overview-question">[나] 학생 개개인의 인격적 성장을 지원하고, 사회 구성원 모두의 행복을 위해 서로 존중하고 배려하며 협력하는 <input data-answer="공동체 의식" aria-label="공동체 의식" placeholder="정답">을 함양한다.</div>
+          <div class="overview-question">[다] 모든 학생이 학습의 기초인 <input data-answer="언어·수리·디지털 기초소양" aria-label="언어·수리·디지털 기초소양" placeholder="정답">을 갖출 수 있도록 하여 <input data-answer="학교 교육과 평생 학습" aria-label="학교 교육과 평생 학습" placeholder="정답">에서 학습을 지속할 수 있게 한다.</div>
+          <div class="overview-question">[라] 학생들이 자신의 <input data-answer="진로" aria-label="진로" placeholder="정답">와 <input data-answer="학습" aria-label="학습" placeholder="정답">을 주도적으로 설계하고, 적절한 시기에 학습할 수 있도록 <input data-answer="학습자 맞춤형 교육과정" aria-label="학습자 맞춤형 교육과정" placeholder="정답"> 체제를 구축한다.</div>
+          <div class="overview-question">[마] 교과 교육에서 <input data-answer="깊이 있는 학습" aria-label="깊이 있는 학습" placeholder="정답">을 통해 역량을 함양할 수 있도록 <input data-answer="교과 간 연계와 통합" aria-label="교과 간 연계와 통합" placeholder="정답">, <input data-answer="학생의 삶과 연계된 학습" aria-label="학생의 삶과 연계된 학습" placeholder="정답">, <input data-answer="학습에 대한 성찰" aria-label="학습에 대한 성찰" placeholder="정답"> 등을 강화한다.</div>
+          <div class="overview-question">[바] <input data-answer="다양한 학생 참여형" aria-label="다양한 학생 참여형" placeholder="정답"> 수업을 활성화하고, 문제 해결 및 사고의 <input data-answer="과정을 중시하는 평가" aria-label="과정을 중시하는 평가" placeholder="정답">를 통해 학습의 질을 개선한다.</div>
+          <div class="overview-question">[사] 교육과정 <input data-answer="자율화·분권화" aria-label="자율화·분권화" placeholder="정답">를 기반으로 <input data-answer="학교" aria-label="학교" placeholder="정답">, <input data-answer="교사" aria-label="교사" placeholder="정답">, <input data-answer="학부모" aria-label="학부모" placeholder="정답">, <input data-answer="시·도 교육청" aria-label="시·도 교육청" placeholder="정답">, <input data-answer="교육부" aria-label="교육부" placeholder="정답"> 등 교육 주체들 간의 협조 체제를 구축하여 <input data-answer="학습자의 특성과 학교 여건" aria-label="학습자의 특성과 학교 여건" placeholder="정답">에 적합한 학습이 이루어질 수 있도록 한다.</div>
         </div>
       </td></tr></tbody></table></div></div>
     </section>
@@ -499,7 +511,86 @@
       <h2>II. 학교 교육과정 설계와 운영</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
-          <div class="overview-question">학습자의 발달 수준에 적합한 <input data-answer="폭넓고 균형 있는" aria-label="폭넓고 균형 있는" placeholder="정답"> 교육과정을 통해 다양한 영역의 세계를 탐색해보는 기회를 제공한다.</div>
+          <div class="overview-question">학습자의 발달 수준에 적합한 <input data-answer="폭넓고 균형 있는" aria-label="폭넓고 균형 있는" placeholder="정답"> 교육과정을 통해 다양한 영역의 세계를 탐색해보는 기회를 제공하고, 학습자의 <input data-answer="전인적" aria-label="전인적" placeholder="정답"> 성장·발달이 가능하도록 학교 교육과정을 설계하여 운영한다.</div>
+          <div class="overview-question">(①) <input data-answer="학생 실태와 요구" aria-label="학생 실태와 요구" placeholder="정답">, <input data-answer="교원 조직" aria-label="교원 조직" placeholder="정답">과 <input data-answer="교육 시설·설비 등 학교 실태" aria-label="교육 시설·설비 등 학교 실태" placeholder="정답">, <input data-answer="학부모 의견" aria-label="학부모 의견" placeholder="정답"> 및 <input data-answer="지역사회 실정" aria-label="지역사회 실정" placeholder="정답"> 등 학교의 교육 여건과 환경을 종합적으로 고려하여 학습자에게 적합한 학습 경험을 제공한다.</div>
+          <div class="overview-question">학교는 <input data-answer="학생의 필요와 요구" aria-label="학생의 필요와 요구" placeholder="정답">에 따라 학교의 특성을 고려하여 다양한 교육 활동을 설계하여 운영할 수 있다.</div>
+          <div class="overview-question">학교 교육 기간을 포함한 평생 학습에 필요한 <input data-answer="기초소양" aria-label="기초소양" placeholder="정답">과 <input data-answer="자기주도 학습 능력" aria-label="자기주도 학습 능력" placeholder="정답">을 갖출 수 있도록 지원하며 학습 격차를 줄이도록 노력한다.</div>
+          <div class="overview-question">학생들의 자발적인 참여를 원칙으로 하여 학교와 시·도 교육청은 학생과 학부모의 요구에 따라 <input data-answer="방과 후" aria-label="방과 후" placeholder="정답"> 활동 또는 <input data-answer="방학 중" aria-label="방학 중" placeholder="정답"> 활동을 운영·지원할 수 있다.</div>
+          <div class="overview-question">학교는 학교 교육과정의 효율적인 설계와 운영을 위하여 <input data-answer="지역사회의 인적" aria-label="지역사회의 인적" placeholder="정답">, <input data-answer="물적 자원" aria-label="물적 자원" placeholder="정답">을 계획적으로 활용한다.</div>
+          <div class="overview-question">학교는 <input data-answer="가정 및 지역과 연계" aria-label="가정 및 지역과 연계" placeholder="정답">하여 학생이 건전한 생활 태도와 행동 양식을 가지고 학습할 수 있도록 지도한다.</div>
+          <div class="overview-question">나. 학교 교육과정은 <input data-answer="모든 교원" aria-label="모든 교원" placeholder="정답">이 전문성을 발휘하여 참여하는 민주적인 절차와 과정을 거쳐 설계·운영하며, 지속적인 개선을 위해 노력한다.</div>
+          <div class="overview-question">1) <input data-answer="교육과정의 합리적 설계와 효율적 운영" aria-label="교육과정의 합리적 설계와 효율적 운영" placeholder="정답">을 위해 교원, 교육 전문가, 학부모 등이 참여하는 <input data-answer="학교 교육과정 위원회" aria-label="학교 교육과정 위원회" placeholder="정답">를 구성·운영하며, 이 위원회는 <input data-answer="학교장의 교육과정 운영 및 의사결정에 관한 자문" aria-label="학교장의 교육과정 운영 및 의사결정에 관한 자문" placeholder="정답"> 역할을 담당한다. 단, 특성화 고등학교와 산업수요 맞춤형 고등학교의 경우에는 산업계 전문가가 참여할 수 있고, 통합교육이 이루어지는 학교의 경우에는 <input data-answer="특수교사" aria-label="특수교사" placeholder="정답">가 참여할 것을 권장한다.</div>
+          <div class="overview-question">2) 학교는 학습 공동체 문화를 조성하고 <input data-answer="동학년 모임" aria-label="동학년 모임" placeholder="정답">, <input data-answer="교과별 모임" aria-label="교과별 모임" placeholder="정답">, <input data-answer="현장 연구" aria-label="현장 연구" placeholder="정답">, <input data-answer="자체 연수" aria-label="자체 연수" placeholder="정답"> 등을 통해서 교사들의 교육 활동 개선이 이루어질 수 있도록 한다.</div>
+          <div class="overview-question">3) 학교는 학교 교육과정 설계·운영의 적절성과 효과성 등을 <input data-answer="자체 평가" aria-label="자체 평가" placeholder="정답">하여 문제점과 개선점을 추출하고, 다음 학년도의 교육과정 설계·운영에 그 결과를 반영한다.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">2. 추구하는 인간상과 핵심역량</div>
+          <div class="overview-question">우리나라의 교육은 <input data-answer="홍익인간" aria-label="홍익인간" placeholder="정답">의 이념 아래 모든 국민으로 하여금 인격을 도야하고, 자주적 생활 능력과 민주시민으로서 필요한 자질을 갖추어 인간다운 삶을 영위하며, 민주 국가의 발전과 인류 공영의 이상을 실현할 수 있도록 함을 목적으로 한다. 이러한 교육 이념과 교육 목적을 바탕으로, 이 교육과정이 추구하는 인간상은 다음과 같다.</div>
+          <div class="overview-question">[가] 전인적 성장을 바탕으로 자아정체성을 확립하고 자신의 진로와 삶을 스스로 개척하는 <input data-answer="자기주도적인" aria-label="자기주도적인" placeholder="정답"> 사람.</div>
+          <div class="overview-question">[나] 폭넓은 기초 능력을 바탕으로 진취적 발상과 도전을 통해 새로운 가치를 창출하는 <input data-answer="창의적인" aria-label="창의적인" placeholder="정답"> 사람.</div>
+          <div class="overview-question">[다] 문화적 소양과 다원적 가치에 대한 이해를 바탕으로 인류 문화를 향유하고 발전시키는 <input data-answer="교양 있는" aria-label="교양 있는" placeholder="정답"> 사람.</div>
+          <div class="overview-question">[라] 공동체 의식을 바탕으로 다양성을 이해하고 서로 존중하며 세계와 소통하는 민주시민으로서 배려와 나눔, 협력을 실천하는 <input data-answer="더불어 사는" aria-label="더불어 사는" placeholder="정답"> 사람.</div>
+          <div class="overview-question">[가] 자아정체성과 자신감을 가지고 자신의 삶과 진로를 스스로 설계하며 이에 필요한 기초 능력과 자질을 갖추어 자기주도적으로 살아갈 수 있는 <input data-answer="자기관리" aria-label="자기관리" placeholder="정답"> 역량.</div>
+          <div class="overview-question">[나] 문제를 합리적으로 해결하기 위하여 다양한 영역의 지식과 정보를 깊이 있게 이해하고 비판적으로 탐구하며 활용할 수 있는 <input data-answer="지식정보처리" aria-label="지식정보처리" placeholder="정답"> 역량.</div>
+          <div class="overview-question">[다] 폭넓은 기초 지식을 바탕으로 다양한 전문 분야의 지식, 기술, 경험을 융합적으로 활용하여 새로운 것을 창출하는 <input data-answer="창의적 사고" aria-label="창의적 사고" placeholder="정답"> 역량.</div>
+          <div class="overview-question">[라] 인간에 대한 공감적 이해와 문화적 감수성을 바탕으로 삶의 의미와 가치를 성찰하고 향유하는 <input data-answer="심미적 감성" aria-label="심미적 감성" placeholder="정답"> 역량.</div>
+          <div class="overview-question">[마] 다른 사람의 관점을 존중하고 경청하는 가운데 자신의 생각과 감정을 효과적으로 표현하며 상호협력적인 관계에서 공동의 목적을 구현하는 <input data-answer="협력적 소통" aria-label="협력적 소통" placeholder="정답"> 역량.</div>
+          <div class="overview-question">[바] 지역·국가·세계 공동체의 구성원에게 요구되는 개방적·포용적 가치와 태도로 지속 가능한 인류 공동체 발전에 적극적이고 책임감 있게 참여하는 <input data-answer="공동체" aria-label="공동체" placeholder="정답"> 역량.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">3. 학교급별 교육목표</div>
+          <div class="overview-question">초등학교 교육은 학생의 일상생활과 학습에 필요한 <input data-answer="기본 습관" aria-label="기본 습관" placeholder="정답"> 및 <input data-answer="기초 능력" aria-label="기초 능력" placeholder="정답">을 기르고 <input data-answer="바른 인성" aria-label="바른 인성" placeholder="정답">을 함양하는 데 중점을 둔다.</div>
+          <div class="overview-question">1) 자신의 소중함을 알고 <input data-answer="건강한 생활 습관" aria-label="건강한 생활 습관" placeholder="정답">을 기르며, <input data-answer="풍부한 학습 경험" aria-label="풍부한 학습 경험" placeholder="정답">을 통해 자신의 꿈을 키운다.</div>
+          <div class="overview-question">2) 학습과 생활에서 문제를 발견하고 해결하는 <input data-answer="기초 능력" aria-label="기초 능력" placeholder="정답">을 기르고, 이를 새롭게 경험할 수 있는 <input data-answer="상상력" aria-label="상상력" placeholder="정답">을 키운다.</div>
+          <div class="overview-question">3) 다양한 문화 활동을 즐기며 자연과 생활 속에서 <input data-answer="아름다움과 행복" aria-label="아름다움과 행복" placeholder="정답">을 느낄 수 있는 <input data-answer="심성" aria-label="심성" placeholder="정답">을 기른다.</div>
+          <div class="overview-question">4) 일상생활과 학습에 필요한 <input data-answer="규칙과 질서" aria-label="규칙과 질서" placeholder="정답">를 지키고 <input data-answer="서로 돕고 배려하는 태도" aria-label="서로 돕고 배려하는 태도" placeholder="정답">를 기른다.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">2. 교수·학습평가</div>
+          <div class="overview-question">[가] 학교는 학생들이 <input data-answer="깊이 있는 학습" aria-label="깊이 있는 학습" placeholder="정답">을 통해 <input data-answer="핵심역량" aria-label="핵심역량" placeholder="정답">을 함양할 수 있도록 교수·학습을 설계하여 운영한다.</div>
+          <div class="overview-question">1) <input data-answer="단편적 지식의 암기" aria-label="단편적 지식의 암기" placeholder="정답">를 지양하고 각 교과목의 <input data-answer="핵심 아이디어" aria-label="핵심 아이디어" placeholder="정답">를 중심으로 <input data-answer="지식·이해" aria-label="지식·이해" placeholder="정답">, <input data-answer="과정·기능" aria-label="과정·기능" placeholder="정답">, <input data-answer="가치·태도" aria-label="가치·태도" placeholder="정답">의 내용 요소를 유기적으로 연계하며 학생의 발달 단계에 따라 학습 경험의 폭과 깊이를 확장할 수 있도록 수업을 설계한다.</div>
+          <div class="overview-question">2) <input data-answer="교과 내 영역 간, 교과 간 내용 연계성" aria-label="교과 내 영역 간, 교과 간 내용 연계성" placeholder="정답">을 고려하여 수업을 설계하고 지도함으로써 학생들이 <input data-answer="융합적" aria-label="융합적" placeholder="정답">으로 사고하고 창의적으로 문제를 해결하는 능력을 함양할 수 있도록 한다.</div>
+          <div class="overview-question">3) 학습 내용을 <input data-answer="실생활 맥락" aria-label="실생활 맥락" placeholder="정답"> 속에서 이해하고 적용하는 기회를 제공함으로써 학교에서의 학습이 학생의 <input data-answer="삶에 의미 있는 학습" aria-label="삶에 의미 있는 학습" placeholder="정답"> 경험이 되도록 한다.</div>
+          <div class="overview-question">4) 학생이 여러 교과의 고유한 탐구 방법을 익히고 자신의 <input data-answer="학습 과정과 학습 전략" aria-label="학습 과정과 학습 전략" placeholder="정답">을 점검하며 개선하는 기회를 제공하여 스스로 탐구하고 학습할 수 있는 <input data-answer="자기주도 학습 능력" aria-label="자기주도 학습 능력" placeholder="정답">을 함양할 수 있도록 한다.</div>
+          <div class="overview-question">5) 교과의 깊이 있는 학습에 기반이 되는 <input data-answer="언어·수리·디지털 기초소양" aria-label="언어·수리·디지털 기초소양" placeholder="정답">을 모든 교과를 통해 함양할 수 있도록 수업을 설계한다.</div>
+          <div class="overview-question">[나] 학교는 학생들이 수업에 <input data-answer="능동적으로 참여" aria-label="능동적으로 참여" placeholder="정답">하고 <input data-answer="학습의 즐거움" aria-label="학습의 즐거움" placeholder="정답">을 경험할 수 있도록 교수·학습을 설계하여 운영한다.</div>
+          <div class="overview-question">1) 학습 주제에서 다루는 탐구 질문에 관심과 호기심을 가지고 스스로 문제를 해결하는 <input data-answer="학생 참여형 수업" aria-label="학생 참여형 수업" placeholder="정답">을 활성화하며, <input data-answer="토의·토론 학습" aria-label="토의·토론 학습" placeholder="정답">을 통해 자신의 생각을 표현하는 기회를 가질 수 있도록 한다.</div>
+          <div class="overview-question">2) 실험, 실습, 관찰, 조사, 견학 등의 <input data-answer="체험 및 탐구 활동 경험" aria-label="체험 및 탐구 활동 경험" placeholder="정답">이 충분히 이루어질 수 있도록 한다.</div>
+          <div class="overview-question">3) <input data-answer="개별 학습 활동" aria-label="개별 학습 활동" placeholder="정답">과 함께 <input data-answer="소집단 협동 학습 활동" aria-label="소집단 협동 학습 활동" placeholder="정답">을 통하여 협력적으로 문제를 해결하는 경험을 충분히 갖도록 한다.</div>
+          <div class="overview-question">[다] 교과의 특성과 학생의 <input data-answer="능력" aria-label="능력" placeholder="정답">, <input data-answer="적성" aria-label="적성" placeholder="정답">, <input data-answer="진로" aria-label="진로" placeholder="정답">를 고려하여 학습 활동과 방법을 다양화하고, 학교의 여건과 학생의 특성에 따라 <input data-answer="다양한 학습 집단" aria-label="다양한 학습 집단" placeholder="정답">을 구성하여 <input data-answer="학생 맞춤형 수업" aria-label="학생 맞춤형 수업" placeholder="정답">을 활성화한다.</div>
+          <div class="overview-question">1) 학생의 선행 경험, 선행 지식, 오개념 등 학습의 출발점을 파악하고 학생의 특성을 고려하여 <input data-answer="학습 소재" aria-label="학습 소재" placeholder="정답">, <input data-answer="자료" aria-label="자료" placeholder="정답">, <input data-answer="활동" aria-label="활동" placeholder="정답">을 다양화한다.</div>
+          <div class="overview-question">2) <input data-answer="정보통신기술 매체" aria-label="정보통신기술 매체" placeholder="정답">를 활용하여 교수·학습 방법을 다양화하고, 학생 맞춤형 학습을 위해 <input data-answer="지능정보기술" aria-label="지능정보기술" placeholder="정답">을 활용할 수 있다.</div>
+          <div class="overview-question">3) 다문화 가정 배경, 가족 구성, 장애 유무 등 학습자의 개인적·사회문화적 배경의 <input data-answer="다양성" aria-label="다양성" placeholder="정답">을 이해하고 존중하며, 이를 수업에 반영할 때 편견과 고정 관념, 차별을 야기하지 않도록 유의한다.</div>
+          <div class="overview-question">4) 학교는 학생 개개인의 학습 상황을 확인하여 학생의 <input data-answer="학습 결손" aria-label="학습 결손" placeholder="정답">을 예방하도록 노력하며, <input data-answer="학습 결손" aria-label="학습 결손" placeholder="정답">이 발생한 경우 <input data-answer="보충 학습 기회" aria-label="보충 학습 기회" placeholder="정답">를 제공한다.</div>
+          <div class="overview-question">[라] 교사와 학생 간, 학생과 학생 간 <input data-answer="상호 신뢰와 협력" aria-label="상호 신뢰와 협력" placeholder="정답">이 가능한 유연하고 안전한 교수·학습 환경을 지원하고, <input data-answer="디지털 기반" aria-label="디지털 기반" placeholder="정답"> 학습이 가능하도록 교육공간과 환경을 조성한다.</div>
+          <div class="overview-question">1) <input data-answer="각 교과의 특성" aria-label="각 교과의 특성" placeholder="정답">에 맞는 다양한 학습이 이루어질 수 있도록 <input data-answer="교과 교실" aria-label="교과 교실" placeholder="정답"> 운영을 활성화하며, 고등학교는 학점 기반 교육과정 운영을 위해 유연한 학습공간을 활용한다.</div>
+          <div class="overview-question">2) 학교는 <input data-answer="교과용 도서" aria-label="교과용 도서" placeholder="정답">이외에 <input data-answer="시·도 교육청" aria-label="시·도 교육청" placeholder="정답">이나 <input data-answer="학교" aria-label="학교" placeholder="정답"> 등에서 개발한 다양한 교수·학습 자료를 활용할 수 있다.</div>
+          <div class="overview-question">3) 다양한 <input data-answer="지능정보기술" aria-label="지능정보기술" placeholder="정답"> 및 도구를 활용하여 효율적인 학습을 지원할 수 있도록 디지털 학습 환경을 구축한다.</div>
+          <div class="overview-question">5) <input data-answer="특수교육" aria-label="특수교육" placeholder="정답"> 대상 학생 등 교육적 요구가 다양한 학생들을 위해 필요할 경우 의사소통 지원, 행동 지원, 보조공학 지원 등을 제공한다.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">3. 평가</div>
+          <div class="overview-question">[가] 평가는 학생 개개인의 <input data-answer="교육 목표 도달" aria-label="교육 목표 도달" placeholder="정답"> 정도를 확인하고, 학습의 부족한 부분을 보충하며, <input data-answer="교수·학습의 질" aria-label="교수·학습의 질" placeholder="정답">을 개선하는 데 주안점을 둔다.</div>
+          <div class="overview-question">1) 학교는 학생에게 평가 결과에 대한 적절한 정보를 제공하고 <input data-answer="추수 지도" aria-label="추수 지도" placeholder="정답">를 실시하여 학생이 자신의 학습을 지속적으로 성찰하고 개선할 수 있도록 한다.</div>
+          <div class="overview-question">2) 학교와 교사는 학생 평가 결과를 활용하여 <input data-answer="수업의 질" aria-label="수업의 질" placeholder="정답">을 지속적으로 개선한다.</div>
+          <div class="overview-question">[나] 학교와 교사는 <input data-answer="성취기준" aria-label="성취기준" placeholder="정답">에 근거하여 교수·학습과 평가 활동이 <input data-answer="일관성" aria-label="일관성" placeholder="정답"> 있게 이루어지도록 한다.</div>
+          <div class="overview-question">1) <input data-answer="학습의 결과" aria-label="학습의 결과" placeholder="정답">만이 아니라 결과에 이르기까지의 <input data-answer="학습 과정" aria-label="학습 과정" placeholder="정답">을 확인하고 환류하여, 학습자의 성공적인 학습과 사고 능력 함양을 지원한다.</div>
+          <div class="overview-question">2) 학교는 학생의 <input data-answer="인지적·정의적" aria-label="인지적·정의적" placeholder="정답"> 측면에 대한 평가가 균형 있게 이루어질 수 있도록 하며, 학생이 자신의 학습 과정과 결과를 <input data-answer="스스로 평가" aria-label="스스로 평가" placeholder="정답">할 수 있는 기회를 제공한다.</div>
+          <div class="overview-question">3) 학교는 교과목별 <input data-answer="성취기준" aria-label="성취기준" placeholder="정답">과 <input data-answer="평가기준" aria-label="평가기준" placeholder="정답">에 따라 성취수준을 설정하여 교수·학습 및 평가 계획에 반영한다.</div>
+          <div class="overview-question">4) 학생에게 <input data-answer="배울 기회를 주지 않은 내용과 기능" aria-label="배울 기회를 주지 않은 내용과 기능" placeholder="정답">은 평가하지 않는다.</div>
+          <div class="overview-question">1) <input data-answer="수행평가" aria-label="수행평가" placeholder="정답">를 내실화하고 <input data-answer="서술형" aria-label="서술형" placeholder="정답">과 <input data-answer="논술형" aria-label="논술형" placeholder="정답"> 평가의 비중을 확대한다.</div>
+          <div class="overview-question">2) <input data-answer="정의적" aria-label="정의적" placeholder="정답"> 측면이나 <input data-answer="기능적" aria-label="기능적" placeholder="정답">이 중시되는 평가에서는 교과목의 성격을 고려하여 타당하고 합리적인 기준과 척도를 마련하여 평가를 실시한다.</div>
+          <div class="overview-question">3) 학교의 여건과 교육활동의 특성을 고려하여 다양한 <input data-answer="지능정보기술" aria-label="지능정보기술" placeholder="정답">을 활용함으로써 <input data-answer="학생 맞춤형 평가" aria-label="학생 맞춤형 평가" placeholder="정답">를 활성화한다.</div>
+          <div class="overview-question">4) 개별 학생의 <input data-answer="발달 수준 및 특성" aria-label="발달 수준 및 특성" placeholder="정답">을 고려하여 <input data-answer="평가 계획" aria-label="평가 계획" placeholder="정답">을 조정할 수 있으며, 특수학급 및 일반학급에 재학하고 있는 특수교육 대상 학생을 위해 필요한 경우 <input data-answer="평가 방법" aria-label="평가 방법" placeholder="정답">을 조정할 수 있다.</div>
+          <div class="overview-question">5) 창의적 체험활동은 내용과 특성을 고려하여 평가의 주안점을 <input data-answer="학교" aria-label="학교" placeholder="정답">에서 결정하여 평가한다.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">4. 모든 학생을 위한 교육기회의 제공</div>
+          <div class="overview-question">[가] 교육 활동 전반을 통하여 남녀의 역할, 학력과 직업, 장애, 종교, 이전 거주지, 인종, 민족, 언어 등에 관한 <input data-answer="고정 관념" aria-label="고정 관념" placeholder="정답">이나 <input data-answer="편견" aria-label="편견" placeholder="정답">을 가지지 않도록 지도한다.</div>
+          <div class="overview-question">[다] <input data-answer="학습 부진" aria-label="학습 부진" placeholder="정답"> 학생, 특정 분야에서 탁월한 재능을 보이는 학생, <input data-answer="특수교육 대상" aria-label="특수교육 대상" placeholder="정답"> 학생, 귀국 학생, <input data-answer="다문화 가정" aria-label="다문화 가정" placeholder="정답"> 학생 등이 학교에서 충실한 학습 경험을 누릴 수 있도록 필요한 지원을 한다.</div>
+          <div class="overview-question">[라] 특수교육 대상 학생을 위해 <input data-answer="특수학급" aria-label="특수학급" placeholder="정답">을 설치·운영하는 경우, 학생의 장애 특성 및 정도를 고려하여, 이 교육과정을 조정하여 운영하거나 <input data-answer="특수교육" aria-label="특수교육" placeholder="정답"> 교과용 도서 및 <input data-answer="통합교육" aria-label="통합교육" placeholder="정답">용 교수·학습 자료를 활용할 수 있다.</div>
+          <div class="overview-question">[마] 다문화 가정 학생을 위한 <input data-answer="특별 학급" aria-label="특별 학급" placeholder="정답">을 설치·운영하는 경우, 다문화 가정 학생의 한국어 능력을 고려하여 이 교육과정을 조정하여 운영하거나, <input data-answer="한국어 교육과정" aria-label="한국어 교육과정" placeholder="정답"> 및 교수·학습 자료를 활용할 수 있다. <input data-answer="주당 10" aria-label="주당 10" placeholder="정답">시간 내외에서 운영할 수 있다.</div>
+          <div class="overview-question">[바] 학교가 종교 과목을 개설할 때는 <input data-answer="종교 이외의 과목과 함께 복수" aria-label="종교 이외의 과목과 함께 복수" placeholder="정답">로 과목을 편성하여 학생에게 선택의 기회를 주어야 한다. 다만, 학생의 학교 선택권이 허용되는 종립 학교의 경우 학생·학부모의 동의를 얻어 단수로 개설할 수 있다.</div>
         </div>
       </td></tr></tbody></table></div></div>
     </section>
@@ -507,7 +598,58 @@
       <h2>III. 학교급별 교육과정 편성·운영의 기준</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
-          <div class="overview-question">초등학교 1학년부터 중학교 3학년까지의 <input data-answer="공통 교육과정" aria-label="공통 교육과정" placeholder="정답">과 고등학교 1학년부터 3학년까지의 학점 기반 선택 중심 교육과정으로 편성·운영한다.</div>
+          <div class="outline-title">1. 기본 사항</div>
+          <div class="overview-question">[가] 초등학교 1학년부터 중학교 3학년까지의 <input data-answer="공통 교육과정" aria-label="공통 교육과정" placeholder="정답">과 고등학교 1학년부터 3학년까지의 학점 기반 선택 중심 교육과정으로 편성·운영한다.</div>
+          <div class="overview-question">[나] 학교는 <input data-answer="학교 교육과정 편성·운영 계획" aria-label="학교 교육과정 편성·운영 계획" placeholder="정답">을 바탕으로 <input data-answer="학년(군)별" aria-label="학년(군)별" placeholder="정답"> 교육과정 및 <input data-answer="교과(군)별" aria-label="교과(군)별" placeholder="정답"> 교육과정을 편성할 수 있다.</div>
+          <div class="overview-question">[다] <input data-answer="학년 간 상호 연계와 협력" aria-label="학년 간 상호 연계와 협력" placeholder="정답">을 통해 학교 교육과정을 <input data-answer="유연하게 편성·운영" aria-label="유연하게 편성·운영" placeholder="정답">할 수 있도록 학년군을 설정한다.</div>
+          <div class="overview-question">[라] 공통 교육과정의 교과는 <input data-answer="교육 목적상의 근접성" aria-label="교육 목적상의 근접성" placeholder="정답">, <input data-answer="학문 탐구 대상 또는 방법상의 인접성" aria-label="학문 탐구 대상 또는 방법상의 인접성" placeholder="정답">, <input data-answer="생활양식에서의 연관성" aria-label="생활양식에서의 연관성" placeholder="정답"> 등을 고려하여 <input data-answer="교과(군)" aria-label="교과(군)" placeholder="정답">로 재분류한다.</div>
+          <div class="overview-question">[바] 교과와 창의적 체험활동의 내용 배열은 반드시 따라야 할 학습 순서를 의미하는 것은 아니며, <input data-answer="학생의 관심과 요구" aria-label="학생의 관심과 요구" placeholder="정답">, <input data-answer="학교의 실정과 교사의 필요" aria-label="학교의 실정과 교사의 필요" placeholder="정답">, <input data-answer="계절 및 지역의 특성" aria-label="계절 및 지역의 특성" placeholder="정답"> 등에 따라 각 교과목의 학년군별 목표 달성을 위해 <input data-answer="지도 내용의 순서와 비중" aria-label="지도 내용의 순서와 비중" placeholder="정답">, <input data-answer="교과 내 또는 교과 간 연계 지도 방법" aria-label="교과 내 또는 교과 간 연계 지도 방법" placeholder="정답"> 등을 조정하여 운영할 수 있다.</div>
+          <div class="overview-question">[사] <input data-answer="학업 부담을 적정화" aria-label="학업 부담을 적정화" placeholder="정답">하고 <input data-answer="의미 있는 학습 활동" aria-label="의미 있는 학습 활동" placeholder="정답">이 이루어질 수 있도록 학기당 이수 교과목 수를 조정하여 <input data-answer="집중이수" aria-label="집중이수" placeholder="정답">를 실시할 수 있다.</div>
+          <div class="overview-question">[아] 학교는 <input data-answer="학교급 간 전환기의 학생들" aria-label="학교급 간 전환기의 학생들" placeholder="정답">이 <input data-answer="상급 학교" aria-label="상급 학교" placeholder="정답">의 <input data-answer="생활 및 학습" aria-label="생활 및 학습" placeholder="정답">을 준비하는 데 필요한 교육을 지원하기 위해 <input data-answer="진로연계교육" aria-label="진로연계교육" placeholder="정답">을 운영할 수 있다.</div>
+          <div class="overview-question">[자] <input data-answer="범교과 학습 주제" aria-label="범교과 학습 주제" placeholder="정답">는 교과와 창의적 체험활동 등 교육 활동 전반에 걸쳐 <input data-answer="통합적" aria-label="통합적" placeholder="정답">으로 다루도록 하고, <input data-answer="지역사회 및 가정과 연계" aria-label="지역사회 및 가정과 연계" placeholder="정답">하여 지도한다.</div>
+          <div class="overview-question">[차] 학교는 가정과 학교, 사회에서의 위험 상황을 알고 대처할 수 있도록 <input data-answer="체험" aria-label="체험" placeholder="정답"> 중심의 <input data-answer="안전교육" aria-label="안전교육" placeholder="정답">을 <input data-answer="관련 교과와 창의적 체험활동" aria-label="관련 교과와 창의적 체험활동" placeholder="정답">과 연계하여 운영한다.</div>
+          <div class="overview-question">[카] 학교는 필요에 따라 <input data-answer="계기 교육" aria-label="계기 교육" placeholder="정답">을 실시할 수 있으며, 이 경우 <input data-answer="계기 교육" aria-label="계기 교육" placeholder="정답"> 지침에 따른다.</div>
+          <div class="overview-question">[타] 학교는 필요에 따라 <input data-answer="원격수업" aria-label="원격수업" placeholder="정답">을 실시할 수 있으며, 이 경우 <input data-answer="원격수업" aria-label="원격수업" placeholder="정답"> 운영 기준은 관련 법령과 지침에 따른다.</div>
+          <div class="overview-question">[파] <input data-answer="시·도 교육청과 학교" aria-label="시·도 교육청과 학교" placeholder="정답">는 필요에 따라 이 교육과정에 제시되어 있는 과목 외에 <input data-answer="새로운 과목을 개설" aria-label="새로운 과목을 개설" placeholder="정답">할 수 있다. 이 경우 <input data-answer="시·도 교육감" aria-label="시·도 교육감" placeholder="정답">이 정하는 지침에 따라 사전에 필요한 절차를 거쳐야 한다.</div>
+          <div class="overview-question">[하] <input data-answer="특수교육" aria-label="특수교육" placeholder="정답"> 대상 학생에 대해서는 이 교육과정 해당 학년군의 편제와 시간(학점 배당)을 따르되, 학생의 교육적 요구를 고려하여 <input data-answer="특수교육" aria-label="특수교육" placeholder="정답"> 교육과정의 교과(군) 내용과 연계하거나 대체하여 수업을 설계·운영할 수 있다.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">2. 초등학교</div>
+          <div class="overview-question">가) 초등학교 교육과정은 <input data-answer="교과(군)" aria-label="교과(군)" placeholder="정답">와 <input data-answer="창의적 체험활동" aria-label="창의적 체험활동" placeholder="정답">으로 편성한다.</div>
+          <div class="overview-question">나) 교과(군)는 <input data-answer="-국어, 사회/도덕, 수학, 과학/실과, 체육, 예술(음악/미술), 영어" aria-label="-국어, 사회/도덕, 수학, 과학/실과, 체육, 예술(음악/미술), 영어" placeholder="정답">로 한다. 다만, 1, 2학년의 교과는 <input data-answer="-국어, 수학, 바른 생활, 슬기로운 생활, 즐거운 생활" aria-label="-국어, 수학, 바른 생활, 슬기로운 생활, 즐거운 생활" placeholder="정답">로 한다.</div>
+          <div class="overview-question">다) 창의적 체험활동은 <input data-answer="자율·자치 활동" aria-label="자율·자치 활동" placeholder="정답">, <input data-answer="동아리 활동" aria-label="동아리 활동" placeholder="정답">, <input data-answer="진로 활동" aria-label="진로 활동" placeholder="정답">으로 한다.</div>
+          <div class="overview-question">2015 개정 교육과정과 비교하여 교과(군) 시수에 변화가 있는 학년군과 시수 변화가 있는 교과(군)는? <input data-answer="1~2학년군 국어(+34), 바른 생활(+16), 슬기로운 생활(+32), 즐거운 생활(+16)" aria-label="1~2학년군 국어(+34), 바른 생활(+16), 슬기로운 생활(+32), 즐거운 생활(+16)" placeholder="정답"></div>
+          <div class="overview-question">① 1시간의 수업은 <input data-answer="40분" aria-label="40분" placeholder="정답">을 원칙으로 하되, <input data-answer="기후 및 계절" aria-label="기후 및 계절" placeholder="정답">, <input data-answer="학생의 발달 정도" aria-label="학생의 발달 정도" placeholder="정답">, <input data-answer="학습 내용의 성격" aria-label="학습 내용의 성격" placeholder="정답">, <input data-answer="학교 실정" aria-label="학교 실정" placeholder="정답"> 등을 고려하여 <input data-answer="탄력적" aria-label="탄력적" placeholder="정답">으로 편성·운영할 수 있다.</div>
+          <div class="overview-question">② 학년군의 교과(군)별 및 창의적 체험활동 시간 배당은 <input data-answer="연간 34주" aria-label="연간 34주" placeholder="정답">를 기준으로 <input data-answer="2년간" aria-label="2년간" placeholder="정답">의 <input data-answer="기준 수업 시수" aria-label="기준 수업 시수" placeholder="정답">를 나타낸 것이다.</div>
+          <div class="overview-question">③ 학년군별 총 수업 시간 수는 <input data-answer="최소 수업 시수" aria-label="최소 수업 시수" placeholder="정답">를 나타낸 것이다.</div>
+          <div class="overview-question">④ 실과의 수업 시간은 <input data-answer="5~6학년 과학/실과" aria-label="5~6학년 과학/실과" placeholder="정답">의 수업 시수에만 포함된다.</div>
+          <div class="overview-question">⑤ 정보교육은 <input data-answer="실과" aria-label="실과" placeholder="정답">의 정보영역 시수와 <input data-answer="학교자율시간" aria-label="학교자율시간" placeholder="정답"> 등을 활용하여 <input data-answer="34시간" aria-label="34시간" placeholder="정답"> 이상 편성·운영한다.</div>
+          <div class="overview-question">[1] 학교는 학년(군)별 교과(군)와 창의적 체험활동의 수업 시수를 <input data-answer="학년별, 학기별로 자율적으로 편성" aria-label="학년별, 학기별로 자율적으로 편성" placeholder="정답">할 수 있다.</div>
+          <div class="overview-question">나) 학교는 모든 교육 활동을 통해 학생이 <input data-answer="기본 생활 습관" aria-label="기본 생활 습관" placeholder="정답">, <input data-answer="기초 학습 능력" aria-label="기초 학습 능력" placeholder="정답">, <input data-answer="바른 인성" aria-label="바른 인성" placeholder="정답">을 함양할 수 있도록 교육과정을 편성·운영한다.</div>
+          <div class="overview-question">다) 학교는 학교의 특성, 학생·교사·학부모의 요구 및 필요에 따라 자율적으로 <input data-answer="교과(군)별 및 창의적 체험활동" aria-label="교과(군)별 및 창의적 체험활동" placeholder="정답">의 <input data-answer="20%" aria-label="20%" placeholder="정답"> 범위 내에서 시수를 증감하여 편성·운영할 수 있다. 단, <input data-answer="체육, 예술(음악/미술) 교과" aria-label="체육, 예술(음악/미술) 교과" placeholder="정답">는 기준 수업 시수를 <input data-answer="감축" aria-label="감축" placeholder="정답">하여 편성·운영할 수 없다.</div>
+          <div class="overview-question">라) 학교는 <input data-answer="교육의 효과" aria-label="교육의 효과" placeholder="정답">를 높이기 위하여 필요한 경우 학년별, 학기별로 <input data-answer="교과 집중이수" aria-label="교과 집중이수" placeholder="정답">를 실시할 수 있다.</div>
+          <div class="overview-question">마) 학교는 창의적 체험활동의 <input data-answer="영역" aria-label="영역" placeholder="정답">을 학생들의 발달 수준, 학교의 여건 등을 고려하여 <input data-answer="학년(군)별로 자율적" aria-label="학년(군)별로 자율적" placeholder="정답">으로 편성·운영한다.</div>
+          <div class="overview-question">가) 학교는 각 교과의 기초적, 기본적 요소들이 체계적으로 학습되도록 교육과정을 편성·운영한다. 특히 <input data-answer="국어사용 능력" aria-label="국어사용 능력" placeholder="정답">과 <input data-answer="수리 능력" aria-label="수리 능력" placeholder="정답">의 기초가 부족한 학생들을 대상으로 <input data-answer="기초 학습 능력 향상" aria-label="기초 학습 능력 향상" placeholder="정답">을 위한 별도의 프로그램을 편성·운영할 수 있다.</div>
+          <div class="overview-question">나) <input data-answer="전입 학생" aria-label="전입 학생" placeholder="정답">이 특정 교과를 이수하지 못할 경우, 시·도 교육청과 학교에서는 <input data-answer="보충 학습 과정" aria-label="보충 학습 과정" placeholder="정답"> 등을 통해 <input data-answer="학습 결손" aria-label="학습 결손" placeholder="정답">이 발생하지 않도록 한다.</div>
+          <div class="overview-question">다) 학년을 달리하는 학생을 대상으로 <input data-answer="복식 학급" aria-label="복식 학급" placeholder="정답">을 편성·운영하는 경우에는 교육 내용의 <input data-answer="학년별 순서" aria-label="학년별 순서" placeholder="정답">를 조정하거나 <input data-answer="공통 주제" aria-label="공통 주제" placeholder="정답">를 중심으로 교재를 재구성하여 활용할 수 있다.</div>
+          <div class="overview-question">[3] 학교는 <input data-answer="3~6학년" aria-label="3~6학년" placeholder="정답">별로 지역과 연계하거나 다양하고 특색 있는 교육과정 운영을 위해 <input data-answer="학교자율시간" aria-label="학교자율시간" placeholder="정답">을 편성·운영한다.</div>
+          <div class="overview-question">가) 학교자율시간을 활용하여 이 교육과정에 제시되어 있는 교과 외에 <input data-answer="새로운 과목이나 활동" aria-label="새로운 과목이나 활동" placeholder="정답">을 개설할 수 있으며, 이 경우 시·도 교육감이 정하는 지침에 따라 사전에 필요한 절차를 거쳐야 한다.</div>
+          <div class="overview-question">나) 학교자율시간에 운영하는 과목과 활동의 내용은 지역과 학교의 여건 및 학생의 필요에 따라 <input data-answer="학교" aria-label="학교" placeholder="정답">가 결정하되, 다양한 과목과 활동으로 개설하여 운영한다.</div>
+          <div class="overview-question">다) 학교자율시간은 학교 여건에 따라 연간 34주를 기준으로 한 교과별 및 창의적 체험활동 수업 시간의 <input data-answer="학기별 1주" aria-label="학기별 1주" placeholder="정답">의 수업 시간을 확보하여 운영한다.</div>
+          <div class="overview-question">[4] 학교는 <input data-answer="입학 초기" aria-label="입학 초기" placeholder="정답"> 및 <input data-answer="상급 학교(학년)으로 진학" aria-label="상급 학교(학년)으로 진학" placeholder="정답">하기 전 학기의 일부 시간을 활용하여 학교급 간 연계 및 진로 교육을 강화하는 <input data-answer="진로연계교육" aria-label="진로연계교육" placeholder="정답">을 편성·운영한다.</div>
+          <div class="overview-question">가) 학교는 1학년 학생의 <input data-answer="학교생활 적응" aria-label="학교생활 적응" placeholder="정답"> 및 <input data-answer="한글 해득 교육" aria-label="한글 해득 교육" placeholder="정답"> 등의 <input data-answer="입학 초기 적응 프로그램" aria-label="입학 초기 적응 프로그램" placeholder="정답">을 교과와 창의적 체험활동 시간을 활용하여 진로연계교육으로 운영한다.</div>
+          <div class="overview-question">나) 학교는 <input data-answer="중학교의 생활" aria-label="중학교의 생활" placeholder="정답"> 및 <input data-answer="학습 준비" aria-label="학습 준비" placeholder="정답">, <input data-answer="진로 탐색" aria-label="진로 탐색" placeholder="정답"> 등의 프로그램을 교과와 창의적 체험활동 시간을 활용하여 진로연계교육을 자율적으로 운영한다.</div>
+          <div class="overview-question">다) 학교는 진로연계교육의 중점을 <input data-answer="학생의 역량 함양" aria-label="학생의 역량 함양" placeholder="정답"> 및 <input data-answer="자기주도적 학습 능력 향상" aria-label="자기주도적 학습 능력 향상" placeholder="정답">에 두고, 교과별 학습 내용 및 학습 방법의 학교급 간 연계, 교과와 연계한 진로 활동 등을 통해 학생의 학습과 성장을 지원한다.</div>
+          <div class="overview-question">가) 학교는 1~2학년 학생에게 <input data-answer="실내·외 놀이" aria-label="실내·외 놀이" placeholder="정답"> 및 <input data-answer="신체 활동의 기회" aria-label="신체 활동의 기회" placeholder="정답">를 충분히 제공한다.</div>
+          <div class="overview-question">나) 1~2학년의 안전교육은 바른 생활·슬기로운 생활·즐거운 생활 교과의 <input data-answer="64시간" aria-label="64시간" placeholder="정답">을 포함하여 <input data-answer="교과" aria-label="교과" placeholder="정답"> 및 <input data-answer="창의적 체험활동" aria-label="창의적 체험활동" placeholder="정답">을 활용하여 편성·운영한다.</div>
+          <div class="overview-question">다) <input data-answer="정보통신 활용 교육" aria-label="정보통신 활용 교육" placeholder="정답">, <input data-answer="보건 교육" aria-label="보건 교육" placeholder="정답">, <input data-answer="한자 교육" aria-label="한자 교육" placeholder="정답"> 등은 관련 교과와 창의적 체험활동 시간을 활용하여 체계적인 지도가 이루어질 수 있도록 한다.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">5. 특수한 학교</div>
+          <div class="overview-question">[나] 국가가 설립 운영하는 학교의 교육과정은 해당 <input data-answer="시·도 교육청" aria-label="시·도 교육청" placeholder="정답">의 편성·운영 지침을 참고하여 <input data-answer="학교장" aria-label="학교장" placeholder="정답">이 편성한다.</div>
+          <div class="overview-question">[바] 자율학교, 재외한국학교 등 법령에 따라 교육과정 편성·운영의 자율성이 부여되는 학교와 특성화 중학교의 경우에는 학교의 설립 목적 및 특성에 따른 교육이 가능하도록 교육과정 편성·운영의 자율권을 부여하고, 이와 관련한 구체적인 사항은 <input data-answer="시·도 교육감" aria-label="시·도 교육감" placeholder="정답">(재외한국학교의 경우 <input data-answer="교육부 장관" aria-label="교육부 장관" placeholder="정답">)이 정하는 지침에 따른다.</div>
+          <div class="overview-question">[사] 효율적인 학교 운영을 위해 <input data-answer="통합하여 운영" aria-label="통합하여 운영" placeholder="정답">하는 학교의 경우에는 이 교육과정을 따르되, 학교의 실정과 학생의 특성에 맞는 학교 교육과정을 운영할 수 있도록 교육과정 편성·운영의 자율권을 부여하고 이와 관련된 구체적인 사항은 <input data-answer="시·도 교육감" aria-label="시·도 교육감" placeholder="정답">이 정하는 지침에 따른다.</div>
+          <div class="overview-question">[아] 교육과정의 연구 등을 위해 새로운 방식으로 교육과정을 편성·운영하고자 하는 학교는 <input data-answer="교육부 장관" aria-label="교육부 장관" placeholder="정답">의 승인을 받아 이 교육과정의 기준과는 다르게 학교 교육과정을 편성·운영할 수 있다.</div>
         </div>
       </td></tr></tbody></table></div></div>
     </section>
@@ -515,7 +657,37 @@
       <h2>IV. 학교 교육과정 지원</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
+          <div class="outline-title">1. 교육과정의 질 관리</div>
+          <div class="sub-title">가. 국가 수준의 지원</div>
           <div class="overview-question">이 교육과정의 질 관리를 위하여 주기적으로 <input data-answer="학업 성취도 평가" aria-label="학업 성취도 평가" placeholder="정답">, <input data-answer="교육과정 편성·운영에 관한 평가" aria-label="교육과정 편성·운영에 관한 평가" placeholder="정답">, <input data-answer="학교와 교육 기관 평가" aria-label="학교와 교육 기관 평가" placeholder="정답">를 실시하고 그 결과를 교육과정 개선에 활용한다.</div>
+          <div class="sub-title">나. 교육청 수준의 지원</div>
+          <div class="overview-question">시·도의 특성과 교육적 요구를 구현하기 위하여 <input data-answer="시·도 교육청 교육과정 위원회" aria-label="시·도 교육청 교육과정 위원회" placeholder="정답">를 조직하여 운영한다.</div>
+          <div class="overview-question">가) 이 위원회는 교육과정 편성·운영에 관한 <input data-answer="조사 연구와 자문 기능" aria-label="조사 연구와 자문 기능" placeholder="정답">을 담당한다.</div>
+          <div class="overview-question"><input data-answer="학교 교육과정의 질 관리" aria-label="학교 교육과정의 질 관리" placeholder="정답">를 위해 각급 학교의 교육과정 편성·운영 실태를 정기적으로 파악하고, 교육과정 운영 지원 실태를 점검하여 효과적인 교육과정 운영과 개선에 필요한 지원을 한다.</div>
+          <div class="overview-question">가) 학교 교육과정 편성·운영 체제의 적절성 및 실효성을 높이기 위하여 <input data-answer="학업 성취도 평가" aria-label="학업 성취도 평가" placeholder="정답">, <input data-answer="학교 교육과정 평가" aria-label="학교 교육과정 평가" placeholder="정답"> 등을 실시하고 그 결과를 교육과정 개선에 활용한다.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">2. 학습자 맞춤교육 강화</div>
+          <div class="sub-title">가. 국가 수준의 지원</div>
+          <div class="overview-question">나) 학교가 교과 교육과정의 목표에 부합되는 평가를 실시할 수 있도록 교과별로 <input data-answer="성취기준에 따른 평가기준" aria-label="성취기준에 따른 평가기준" placeholder="정답">을 개발·보급한다.</div>
+          <div class="sub-title">나. 교육청 수준의 지원</div>
+          <div class="overview-question">다) 학교가 이 교육과정에 제시되어 있는 과목 외에 <input data-answer="새로운 교과목을 개설·운영" aria-label="새로운 교과목을 개설·운영" placeholder="정답">할 수 있도록 관련 지침을 마련한다.</div>
+          <div class="overview-question">라) <input data-answer="통합운영학교" aria-label="통합운영학교" placeholder="정답"> 관련 규정 및 지침을 정비하고, <input data-answer="통합운영학교" aria-label="통합운영학교" placeholder="정답">에 맞는 교육과정 운영이 이루어질 수 있도록 지원한다.</div>
+          <div class="overview-question">마) 지역사회와 학교의 여건에 따라 초등학교 저학년 학생을 <input data-answer="학교에서 돌볼 수 있는" aria-label="학교에서 돌볼 수 있는" placeholder="정답"> 기능을 강화하고, 이에 대해 행·재정적 지원을 한다.</div>
+          <div class="overview-question">바) <input data-answer="학교급 전환" aria-label="학교급 전환" placeholder="정답"> 시기 진로연계교육을 위한 자료를 개발·보급하고, 각 학교급 교육과정에 대한 교사의 이해 증진 및 학교급 간 협력 관계 구축을 위한 지원을 확대한다.</div>
+          <div class="overview-question">사) <input data-answer="인문학적 소양" aria-label="인문학적 소양" placeholder="정답"> 및 <input data-answer="통합적 읽기 능력" aria-label="통합적 읽기 능력" placeholder="정답"> 함양을 위해 독서 활동을 활성화하도록 다양한 지원을 한다.</div>
+          <div class="overview-question">학습자의 다양성을 존중하고 학습 소외 및 교육 격차를 방지할 수 있도록 <input data-answer="맞춤형 교육" aria-label="맞춤형 교육" placeholder="정답">을 지원한다.</div>
+        </div>
+        <div class="creative-block">
+          <div class="outline-title">3. 학교의 교육 환경 조성</div>
+          <div class="sub-title">가. 국가 수준의 지원</div>
+          <div class="overview-question"><input data-answer="교육과정 자율화·분권화" aria-label="교육과정 자율화·분권화" placeholder="정답">를 바탕으로 교육 주체들이 각각의 역할과 책임을 충실하게 수행할 수 있는 협조 체제를 구축하고 지원한다.</div>
+          <div class="overview-question">디지털 교육 환경 변화에 부합하는 미래형 교수·학습 방법과 평가체제 구축을 위해 교원의 <input data-answer="에듀테크" aria-label="에듀테크" placeholder="정답"> 활용 역량 함양을 지원한다.</div>
+          <div class="sub-title">나. 교육청 수준의 지원</div>
+          <div class="overview-question">가) 수준별 수업을 효율적으로 운영하도록 지원하며, 기초학력 향상과 학습 결손 보충이 가능하도록 <input data-answer="보충 수업" aria-label="보충 수업" placeholder="정답">을 운영하는 데 필요한 행·재정적 지원을 한다.</div>
+          <div class="overview-question">학교가 지역사회의 관계 기관과 적극적으로 연계·협력해서 교과, 창의적 체험활동, 학교스포츠클럽활동, 자유학기 등을 내실 있게 운영할 수 있도록 지원하며, 관내 학교가 활용할 수 있는 우수한 <input data-answer="지역 자원" aria-label="지역 자원" placeholder="정답">을 발굴하여 안내한다.</div>
+          <div class="overview-question">나) 학교 교육과정의 효율적인 편성·운영을 지원하기 위해 <input data-answer="교육과정 컨설팅 지원단" aria-label="교육과정 컨설팅 지원단" placeholder="정답"> 등 지원 기구를 운영하며 교육과정 편성·운영을 위한 각종 자료를 개발하여 보급한다.</div>
+          <div class="overview-question">온오프라인 연계를 통한 효과적인 교수·학습과 평가가 이루어질 수 있도록 하며, <input data-answer="지능정보기술" aria-label="지능정보기술" placeholder="정답">을 활용한 맞춤형 수업과 평가가 가능하도록 지원한다.</div>
         </div>
       </td></tr></tbody></table></div></div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -967,6 +967,12 @@ td input.activity-input:not(:first-child) {
   margin-bottom: 1rem;
   color: var(--primary);
 }
+#overview-quiz-main .sub-title {
+  font-size: 1.8rem;
+  font-weight: 600;
+  margin: 1rem 0;
+  color: var(--accent);
+}
 #creative-quiz-main .creative-question {
   display: block; /* allow natural inline flow around inputs */
   line-height: 1.8; /* more breathing room for multi-line questions */


### PR DESCRIPTION
## Summary
- clarify national vs regional support in the curriculum assistance section
- style new sub-titles for overview questions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877a5bae118832c90157148993c8775