### PR TITLE
Fix missing overview question title

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,6 +495,7 @@
       <h2>I. 교육과정 구성의 방향</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
+          <div class="outline-title">1. 교육과정 구성의 중점</div>
           <div class="overview-question">이에 그동안의 교육과정 발전 방향을 계승하면서 미래 사회를 살아갈 학생들이 <input data-answer="주도적으로 삶을 이끌어가는 능력" aria-label="주도적으로 삶을 이끌어가는 능력" placeholder="정답">을 함양할 수 있도록 교육과정을 구성한다.</div>
           <div class="overview-question">이 교육과정은 우리나라 교육과정이 추구해 온 교육 이념과 인간상을 바탕으로, 미래 사회가 요구하는 <input data-answer="핵심역량" aria-label="핵심역량" placeholder="정답">을 함양하여 <input data-answer="포용성과 창의성을 갖춘 주도적인 사람" aria-label="포용성과 창의성을 갖춘 주도적인 사람" placeholder="정답">으로 성장하게 하는 데 중점을 둔다. 이를 위한 교육과정 구성의 중점은 다음과 같다.</div>
           <div class="overview-question">[가] 디지털 전환, 기후·생태환경 변화 등에 따른 미래 사회의 불확실성에 <input data-answer="능동적으로 대응할 수 있는 능력" aria-label="능동적으로 대응할 수 있는 능력" placeholder="정답">과 자신의 삶과 학습을 스스로 이끌어가는 <input data-answer="주도성" aria-label="주도성" placeholder="정답">을 함양한다.</div>
@@ -504,24 +505,6 @@
           <div class="overview-question">[마] 교과 교육에서 <input data-answer="깊이 있는 학습" aria-label="깊이 있는 학습" placeholder="정답">을 통해 역량을 함양할 수 있도록 <input data-answer="교과 간 연계와 통합" aria-label="교과 간 연계와 통합" placeholder="정답">, <input data-answer="학생의 삶과 연계된 학습" aria-label="학생의 삶과 연계된 학습" placeholder="정답">, <input data-answer="학습에 대한 성찰" aria-label="학습에 대한 성찰" placeholder="정답"> 등을 강화한다.</div>
           <div class="overview-question">[바] <input data-answer="다양한 학생 참여형" aria-label="다양한 학생 참여형" placeholder="정답"> 수업을 활성화하고, 문제 해결 및 사고의 <input data-answer="과정을 중시하는 평가" aria-label="과정을 중시하는 평가" placeholder="정답">를 통해 학습의 질을 개선한다.</div>
           <div class="overview-question">[사] 교육과정 <input data-answer="자율화·분권화" aria-label="자율화·분권화" placeholder="정답">를 기반으로 <input data-answer="학교" aria-label="학교" placeholder="정답">, <input data-answer="교사" aria-label="교사" placeholder="정답">, <input data-answer="학부모" aria-label="학부모" placeholder="정답">, <input data-answer="시·도 교육청" aria-label="시·도 교육청" placeholder="정답">, <input data-answer="교육부" aria-label="교육부" placeholder="정답"> 등 교육 주체들 간의 협조 체제를 구축하여 <input data-answer="학습자의 특성과 학교 여건" aria-label="학습자의 특성과 학교 여건" placeholder="정답">에 적합한 학습이 이루어질 수 있도록 한다.</div>
-        </div>
-      </td></tr></tbody></table></div></div>
-    </section>
-    <section id="design">
-      <h2>II. 학교 교육과정 설계와 운영</h2>
-      <div class="grade-container"><div><table><tbody><tr><td>
-        <div class="creative-block">
-          <div class="overview-question">학습자의 발달 수준에 적합한 <input data-answer="폭넓고 균형 있는" aria-label="폭넓고 균형 있는" placeholder="정답"> 교육과정을 통해 다양한 영역의 세계를 탐색해보는 기회를 제공하고, 학습자의 <input data-answer="전인적" aria-label="전인적" placeholder="정답"> 성장·발달이 가능하도록 학교 교육과정을 설계하여 운영한다.</div>
-          <div class="overview-question">(①) <input data-answer="학생 실태와 요구" aria-label="학생 실태와 요구" placeholder="정답">, <input data-answer="교원 조직" aria-label="교원 조직" placeholder="정답">과 <input data-answer="교육 시설·설비 등 학교 실태" aria-label="교육 시설·설비 등 학교 실태" placeholder="정답">, <input data-answer="학부모 의견" aria-label="학부모 의견" placeholder="정답"> 및 <input data-answer="지역사회 실정" aria-label="지역사회 실정" placeholder="정답"> 등 학교의 교육 여건과 환경을 종합적으로 고려하여 학습자에게 적합한 학습 경험을 제공한다.</div>
-          <div class="overview-question">학교는 <input data-answer="학생의 필요와 요구" aria-label="학생의 필요와 요구" placeholder="정답">에 따라 학교의 특성을 고려하여 다양한 교육 활동을 설계하여 운영할 수 있다.</div>
-          <div class="overview-question">학교 교육 기간을 포함한 평생 학습에 필요한 <input data-answer="기초소양" aria-label="기초소양" placeholder="정답">과 <input data-answer="자기주도 학습 능력" aria-label="자기주도 학습 능력" placeholder="정답">을 갖출 수 있도록 지원하며 학습 격차를 줄이도록 노력한다.</div>
-          <div class="overview-question">학생들의 자발적인 참여를 원칙으로 하여 학교와 시·도 교육청은 학생과 학부모의 요구에 따라 <input data-answer="방과 후" aria-label="방과 후" placeholder="정답"> 활동 또는 <input data-answer="방학 중" aria-label="방학 중" placeholder="정답"> 활동을 운영·지원할 수 있다.</div>
-          <div class="overview-question">학교는 학교 교육과정의 효율적인 설계와 운영을 위하여 <input data-answer="지역사회의 인적" aria-label="지역사회의 인적" placeholder="정답">, <input data-answer="물적 자원" aria-label="물적 자원" placeholder="정답">을 계획적으로 활용한다.</div>
-          <div class="overview-question">학교는 <input data-answer="가정 및 지역과 연계" aria-label="가정 및 지역과 연계" placeholder="정답">하여 학생이 건전한 생활 태도와 행동 양식을 가지고 학습할 수 있도록 지도한다.</div>
-          <div class="overview-question">나. 학교 교육과정은 <input data-answer="모든 교원" aria-label="모든 교원" placeholder="정답">이 전문성을 발휘하여 참여하는 민주적인 절차와 과정을 거쳐 설계·운영하며, 지속적인 개선을 위해 노력한다.</div>
-          <div class="overview-question">1) <input data-answer="교육과정의 합리적 설계와 효율적 운영" aria-label="교육과정의 합리적 설계와 효율적 운영" placeholder="정답">을 위해 교원, 교육 전문가, 학부모 등이 참여하는 <input data-answer="학교 교육과정 위원회" aria-label="학교 교육과정 위원회" placeholder="정답">를 구성·운영하며, 이 위원회는 <input data-answer="학교장의 교육과정 운영 및 의사결정에 관한 자문" aria-label="학교장의 교육과정 운영 및 의사결정에 관한 자문" placeholder="정답"> 역할을 담당한다. 단, 특성화 고등학교와 산업수요 맞춤형 고등학교의 경우에는 산업계 전문가가 참여할 수 있고, 통합교육이 이루어지는 학교의 경우에는 <input data-answer="특수교사" aria-label="특수교사" placeholder="정답">가 참여할 것을 권장한다.</div>
-          <div class="overview-question">2) 학교는 학습 공동체 문화를 조성하고 <input data-answer="동학년 모임" aria-label="동학년 모임" placeholder="정답">, <input data-answer="교과별 모임" aria-label="교과별 모임" placeholder="정답">, <input data-answer="현장 연구" aria-label="현장 연구" placeholder="정답">, <input data-answer="자체 연수" aria-label="자체 연수" placeholder="정답"> 등을 통해서 교사들의 교육 활동 개선이 이루어질 수 있도록 한다.</div>
-          <div class="overview-question">3) 학교는 학교 교육과정 설계·운영의 적절성과 효과성 등을 <input data-answer="자체 평가" aria-label="자체 평가" placeholder="정답">하여 문제점과 개선점을 추출하고, 다음 학년도의 교육과정 설계·운영에 그 결과를 반영한다.</div>
         </div>
         <div class="creative-block">
           <div class="outline-title">2. 추구하는 인간상과 핵심역량</div>
@@ -544,6 +527,24 @@
           <div class="overview-question">2) 학습과 생활에서 문제를 발견하고 해결하는 <input data-answer="기초 능력" aria-label="기초 능력" placeholder="정답">을 기르고, 이를 새롭게 경험할 수 있는 <input data-answer="상상력" aria-label="상상력" placeholder="정답">을 키운다.</div>
           <div class="overview-question">3) 다양한 문화 활동을 즐기며 자연과 생활 속에서 <input data-answer="아름다움과 행복" aria-label="아름다움과 행복" placeholder="정답">을 느낄 수 있는 <input data-answer="심성" aria-label="심성" placeholder="정답">을 기른다.</div>
           <div class="overview-question">4) 일상생활과 학습에 필요한 <input data-answer="규칙과 질서" aria-label="규칙과 질서" placeholder="정답">를 지키고 <input data-answer="서로 돕고 배려하는 태도" aria-label="서로 돕고 배려하는 태도" placeholder="정답">를 기른다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="design">
+      <h2>II. 학교 교육과정 설계와 운영</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">학습자의 발달 수준에 적합한 <input data-answer="폭넓고 균형 있는" aria-label="폭넓고 균형 있는" placeholder="정답"> 교육과정을 통해 다양한 영역의 세계를 탐색해보는 기회를 제공하고, 학습자의 <input data-answer="전인적" aria-label="전인적" placeholder="정답"> 성장·발달이 가능하도록 학교 교육과정을 설계하여 운영한다.</div>
+          <div class="overview-question">(①) <input data-answer="학생 실태와 요구" aria-label="학생 실태와 요구" placeholder="정답">, <input data-answer="교원 조직" aria-label="교원 조직" placeholder="정답">과 <input data-answer="교육 시설·설비 등 학교 실태" aria-label="교육 시설·설비 등 학교 실태" placeholder="정답">, <input data-answer="학부모 의견" aria-label="학부모 의견" placeholder="정답"> 및 <input data-answer="지역사회 실정" aria-label="지역사회 실정" placeholder="정답"> 등 학교의 교육 여건과 환경을 종합적으로 고려하여 학습자에게 적합한 학습 경험을 제공한다.</div>
+          <div class="overview-question">학교는 <input data-answer="학생의 필요와 요구" aria-label="학생의 필요와 요구" placeholder="정답">에 따라 학교의 특성을 고려하여 다양한 교육 활동을 설계하여 운영할 수 있다.</div>
+          <div class="overview-question">학교 교육 기간을 포함한 평생 학습에 필요한 <input data-answer="기초소양" aria-label="기초소양" placeholder="정답">과 <input data-answer="자기주도 학습 능력" aria-label="자기주도 학습 능력" placeholder="정답">을 갖출 수 있도록 지원하며 학습 격차를 줄이도록 노력한다.</div>
+          <div class="overview-question">학생들의 자발적인 참여를 원칙으로 하여 학교와 시·도 교육청은 학생과 학부모의 요구에 따라 <input data-answer="방과 후" aria-label="방과 후" placeholder="정답"> 활동 또는 <input data-answer="방학 중" aria-label="방학 중" placeholder="정답"> 활동을 운영·지원할 수 있다.</div>
+          <div class="overview-question">학교는 학교 교육과정의 효율적인 설계와 운영을 위하여 <input data-answer="지역사회의 인적" aria-label="지역사회의 인적" placeholder="정답">, <input data-answer="물적 자원" aria-label="물적 자원" placeholder="정답">을 계획적으로 활용한다.</div>
+          <div class="overview-question">학교는 <input data-answer="가정 및 지역과 연계" aria-label="가정 및 지역과 연계" placeholder="정답">하여 학생이 건전한 생활 태도와 행동 양식을 가지고 학습할 수 있도록 지도한다.</div>
+          <div class="overview-question">나. 학교 교육과정은 <input data-answer="모든 교원" aria-label="모든 교원" placeholder="정답">이 전문성을 발휘하여 참여하는 민주적인 절차와 과정을 거쳐 설계·운영하며, 지속적인 개선을 위해 노력한다.</div>
+          <div class="overview-question">1) <input data-answer="교육과정의 합리적 설계와 효율적 운영" aria-label="교육과정의 합리적 설계와 효율적 운영" placeholder="정답">을 위해 교원, 교육 전문가, 학부모 등이 참여하는 <input data-answer="학교 교육과정 위원회" aria-label="학교 교육과정 위원회" placeholder="정답">를 구성·운영하며, 이 위원회는 <input data-answer="학교장의 교육과정 운영 및 의사결정에 관한 자문" aria-label="학교장의 교육과정 운영 및 의사결정에 관한 자문" placeholder="정답"> 역할을 담당한다. 단, 특성화 고등학교와 산업수요 맞춤형 고등학교의 경우에는 산업계 전문가가 참여할 수 있고, 통합교육이 이루어지는 학교의 경우에는 <input data-answer="특수교사" aria-label="특수교사" placeholder="정답">가 참여할 것을 권장한다.</div>
+          <div class="overview-question">2) 학교는 학습 공동체 문화를 조성하고 <input data-answer="동학년 모임" aria-label="동학년 모임" placeholder="정답">, <input data-answer="교과별 모임" aria-label="교과별 모임" placeholder="정답">, <input data-answer="현장 연구" aria-label="현장 연구" placeholder="정답">, <input data-answer="자체 연수" aria-label="자체 연수" placeholder="정답"> 등을 통해서 교사들의 교육 활동 개선이 이루어질 수 있도록 한다.</div>
+          <div class="overview-question">3) 학교는 학교 교육과정 설계·운영의 적절성과 효과성 등을 <input data-answer="자체 평가" aria-label="자체 평가" placeholder="정답">하여 문제점과 개선점을 추출하고, 다음 학년도의 교육과정 설계·운영에 그 결과를 반영한다.</div>
         </div>
         <div class="creative-block">
           <div class="outline-title">2. 교수·학습평가</div>


### PR DESCRIPTION
## Summary
- display all questions for the '총론' topic
- add an outline title for the 교육과정 구성의 중점 section
- include '추구하는 인간상과 핵심역량' and '학교급별 교육목표' under the correct section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877b02bd538832c8a9aab8bab9536fb