### PR TITLE
Fix evaluation summary fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,7 +535,7 @@
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
           <div class="overview-question">학습자의 발달 수준에 적합한 <input data-answer="폭넓고 균형 있는" aria-label="폭넓고 균형 있는" placeholder="정답"> 교육과정을 통해 다양한 영역의 세계를 탐색해보는 기회를 제공하고, 학습자의 <input data-answer="전인적" aria-label="전인적" placeholder="정답"> 성장·발달이 가능하도록 학교 교육과정을 설계하여 운영한다.</div>
-          <div class="overview-question">(①) <input data-answer="학생 실태와 요구" aria-label="학생 실태와 요구" placeholder="정답">, <input data-answer="교원 조직" aria-label="교원 조직" placeholder="정답">과 <input data-answer="교육 시설·설비 등 학교 실태" aria-label="교육 시설·설비 등 학교 실태" placeholder="정답">, <input data-answer="학부모 의견" aria-label="학부모 의견" placeholder="정답"> 및 <input data-answer="지역사회 실정" aria-label="지역사회 실정" placeholder="정답"> 등 학교의 교육 여건과 환경을 종합적으로 고려하여 학습자에게 적합한 학습 경험을 제공한다.</div>
+          <div class="overview-question"><input data-answer="학생 실태와 요구" aria-label="학생 실태와 요구" placeholder="정답">, <input data-answer="교원 조직" aria-label="교원 조직" placeholder="정답">과 <input data-answer="교육 시설·설비 등 학교 실태" aria-label="교육 시설·설비 등 학교 실태" placeholder="정답">, <input data-answer="학부모 의견" aria-label="학부모 의견" placeholder="정답"> 및 <input data-answer="지역사회 실정" aria-label="지역사회 실정" placeholder="정답"> 등 학교의 교육 여건과 환경을 종합적으로 고려하여 학습자에게 적합한 학습 경험을 제공한다.</div>
           <div class="overview-question">학교는 <input data-answer="학생의 필요와 요구" aria-label="학생의 필요와 요구" placeholder="정답">에 따라 학교의 특성을 고려하여 다양한 교육 활동을 설계하여 운영할 수 있다.</div>
           <div class="overview-question">학교 교육 기간을 포함한 평생 학습에 필요한 <input data-answer="기초소양" aria-label="기초소양" placeholder="정답">과 <input data-answer="자기주도 학습 능력" aria-label="자기주도 학습 능력" placeholder="정답">을 갖출 수 있도록 지원하며 학습 격차를 줄이도록 노력한다.</div>
           <div class="overview-question">학생들의 자발적인 참여를 원칙으로 하여 학교와 시·도 교육청은 학생과 학부모의 요구에 따라 <input data-answer="방과 후" aria-label="방과 후" placeholder="정답"> 활동 또는 <input data-answer="방학 중" aria-label="방학 중" placeholder="정답"> 활동을 운영·지원할 수 있다.</div>
@@ -571,7 +571,7 @@
         </div>
         <div class="creative-block">
           <div class="outline-title">3. 평가</div>
-          <div class="overview-question">[가] 평가는 학생 개개인의 <input data-answer="교육 목표 도달" aria-label="교육 목표 도달" placeholder="정답"> 정도를 확인하고, 학습의 부족한 부분을 보충하며, <input data-answer="교수·학습의 질" aria-label="교수·학습의 질" placeholder="정답">을 개선하는 데 주안점을 둔다.</div>
+          <div class="overview-question">[가] 평가는 학생 개개인의 <input data-answer="교육 목표 도달" aria-label="교육 목표 도달" placeholder="정답"> 정도를 확인하고, <input data-answer="학습의 부족한 부분" aria-label="학습의 부족한 부분" placeholder="정답">을 보충하며, <input data-answer="교수·학습의 질" aria-label="교수·학습의 질" placeholder="정답">을 개선하는 데 주안점을 둔다.</div>
           <div class="overview-question">1) 학교는 학생에게 평가 결과에 대한 적절한 정보를 제공하고 <input data-answer="추수 지도" aria-label="추수 지도" placeholder="정답">를 실시하여 학생이 자신의 학습을 지속적으로 성찰하고 개선할 수 있도록 한다.</div>
           <div class="overview-question">2) 학교와 교사는 학생 평가 결과를 활용하여 <input data-answer="수업의 질" aria-label="수업의 질" placeholder="정답">을 지속적으로 개선한다.</div>
           <div class="overview-question">[나] 학교와 교사는 <input data-answer="성취기준" aria-label="성취기준" placeholder="정답">에 근거하여 교수·학습과 평가 활동이 <input data-answer="일관성" aria-label="일관성" placeholder="정답"> 있게 이루어지도록 한다.</div>


### PR DESCRIPTION
## Summary
- add missing input for '학습의 부족한 부분' so all three evaluation aspects can be filled

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877b636369c832c880f5cdbaf40b94a