### PR TITLE
Fix design section numbering

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,7 +481,6 @@
       <h2>교육과정의 성격</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
-          <div class="outline-title">1. 설계의 원칙</div>
           <div class="overview-question">이 교육과정은 <input data-answer="초·중등교육법" aria-label="초·중등교육법" placeholder="정답"> 제23조제2항에 의거하여 고시한 것으로, 초·중등학교의 교육 목적을 달성하기 위해 초·중등학교에서 운영하여야 할 학교 교육과정의 <input data-answer="공통적이고 일반적인" aria-label="공통적이고 일반적인" placeholder="정답"> 기준을 <input data-answer="국가" aria-label="국가" placeholder="정답"> 수준에서 제시한 것이다.</div>
           <div class="overview-question">[가] 국가 수준의 <input data-answer="공통성" aria-label="공통성" placeholder="정답">을 바탕으로 지역, 학교, 개인 수준의 <input data-answer="다양성" aria-label="다양성" placeholder="정답">을 추구할 수 있도록 학교 교육과정의 기준과 내용에 관한 기본사항을 제시한다.</div>
           <div class="overview-question">[나] 학교 교육과정이 학생을 중심에 두고 <input data-answer="주도성" aria-label="주도성" placeholder="정답">과 <input data-answer="자율성" aria-label="자율성" placeholder="정답">, <input data-answer="창의성" aria-label="창의성" placeholder="정답">의 신장 등 학습자 성장을 지원할 수 있도록 교육과정의 기준과 내용을 제시한다.</div>
@@ -534,13 +533,14 @@
       <h2>II. 학교 교육과정 설계와 운영</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
-          <div class="overview-question">학습자의 발달 수준에 적합한 <input data-answer="폭넓고 균형 있는" aria-label="폭넓고 균형 있는" placeholder="정답"> 교육과정을 통해 다양한 영역의 세계를 탐색해보는 기회를 제공하고, 학습자의 <input data-answer="전인적" aria-label="전인적" placeholder="정답"> 성장·발달이 가능하도록 학교 교육과정을 설계하여 운영한다.</div>
-          <div class="overview-question"><input data-answer="학생 실태와 요구" aria-label="학생 실태와 요구" placeholder="정답">, <input data-answer="교원 조직" aria-label="교원 조직" placeholder="정답">과 <input data-answer="교육 시설·설비 등 학교 실태" aria-label="교육 시설·설비 등 학교 실태" placeholder="정답">, <input data-answer="학부모 의견" aria-label="학부모 의견" placeholder="정답"> 및 <input data-answer="지역사회 실정" aria-label="지역사회 실정" placeholder="정답"> 등 학교의 교육 여건과 환경을 종합적으로 고려하여 학습자에게 적합한 학습 경험을 제공한다.</div>
-          <div class="overview-question">학교는 <input data-answer="학생의 필요와 요구" aria-label="학생의 필요와 요구" placeholder="정답">에 따라 학교의 특성을 고려하여 다양한 교육 활동을 설계하여 운영할 수 있다.</div>
-          <div class="overview-question">학교 교육 기간을 포함한 평생 학습에 필요한 <input data-answer="기초소양" aria-label="기초소양" placeholder="정답">과 <input data-answer="자기주도 학습 능력" aria-label="자기주도 학습 능력" placeholder="정답">을 갖출 수 있도록 지원하며 학습 격차를 줄이도록 노력한다.</div>
-          <div class="overview-question">학생들의 자발적인 참여를 원칙으로 하여 학교와 시·도 교육청은 학생과 학부모의 요구에 따라 <input data-answer="방과 후" aria-label="방과 후" placeholder="정답"> 활동 또는 <input data-answer="방학 중" aria-label="방학 중" placeholder="정답"> 활동을 운영·지원할 수 있다.</div>
-          <div class="overview-question">학교는 학교 교육과정의 효율적인 설계와 운영을 위하여 <input data-answer="지역사회의 인적" aria-label="지역사회의 인적" placeholder="정답">, <input data-answer="물적 자원" aria-label="물적 자원" placeholder="정답">을 계획적으로 활용한다.</div>
-          <div class="overview-question">학교는 <input data-answer="가정 및 지역과 연계" aria-label="가정 및 지역과 연계" placeholder="정답">하여 학생이 건전한 생활 태도와 행동 양식을 가지고 학습할 수 있도록 지도한다.</div>
+          <div class="outline-title">1. 설계의 원칙</div>
+          <div class="overview-question">1) 학습자의 발달 수준에 적합한 <input data-answer="폭넓고 균형 있는" aria-label="폭넓고 균형 있는" placeholder="정답"> 교육과정을 통해 다양한 영역의 세계를 탐색해보는 기회를 제공하고, 학습자의 <input data-answer="전인적" aria-label="전인적" placeholder="정답"> 성장·발달이 가능하도록 학교 교육과정을 설계하여 운영한다.</div>
+          <div class="overview-question">2) <input data-answer="학생 실태와 요구" aria-label="학생 실태와 요구" placeholder="정답">, <input data-answer="교원 조직" aria-label="교원 조직" placeholder="정답">과 <input data-answer="교육 시설·설비 등 학교 실태" aria-label="교육 시설·설비 등 학교 실태" placeholder="정답">, <input data-answer="학부모 의견" aria-label="학부모 의견" placeholder="정답"> 및 <input data-answer="지역사회 실정" aria-label="지역사회 실정" placeholder="정답"> 등 학교의 교육 여건과 환경을 종합적으로 고려하여 학습자에게 적합한 학습 경험을 제공한다.</div>
+          <div class="overview-question">3) 학교는 <input data-answer="학생의 필요와 요구" aria-label="학생의 필요와 요구" placeholder="정답">에 따라 학교의 특성을 고려하여 다양한 교육 활동을 설계하여 운영할 수 있다.</div>
+          <div class="overview-question">4) 학교 교육 기간을 포함한 평생 학습에 필요한 <input data-answer="기초소양" aria-label="기초소양" placeholder="정답">과 <input data-answer="자기주도 학습 능력" aria-label="자기주도 학습 능력" placeholder="정답">을 갖출 수 있도록 지원하며 학습 격차를 줄이도록 노력한다.</div>
+          <div class="overview-question">5) 학생들의 자발적인 참여를 원칙으로 하여 학교와 시·도 교육청은 학생과 학부모의 요구에 따라 <input data-answer="방과 후" aria-label="방과 후" placeholder="정답"> 활동 또는 <input data-answer="방학 중" aria-label="방학 중" placeholder="정답"> 활동을 운영·지원할 수 있다.</div>
+          <div class="overview-question">6) 학교는 학교 교육과정의 효율적인 설계와 운영을 위하여 <input data-answer="지역사회의 인적" aria-label="지역사회의 인적" placeholder="정답">, <input data-answer="물적 자원" aria-label="물적 자원" placeholder="정답">을 계획적으로 활용한다.</div>
+          <div class="overview-question">7) 학교는 <input data-answer="가정 및 지역과 연계" aria-label="가정 및 지역과 연계" placeholder="정답">하여 학생이 건전한 생활 태도와 행동 양식을 가지고 학습할 수 있도록 지도한다.</div>
           <div class="overview-question">나. 학교 교육과정은 <input data-answer="모든 교원" aria-label="모든 교원" placeholder="정답">이 전문성을 발휘하여 참여하는 민주적인 절차와 과정을 거쳐 설계·운영하며, 지속적인 개선을 위해 노력한다.</div>
           <div class="overview-question">1) <input data-answer="교육과정의 합리적 설계와 효율적 운영" aria-label="교육과정의 합리적 설계와 효율적 운영" placeholder="정답">을 위해 교원, 교육 전문가, 학부모 등이 참여하는 <input data-answer="학교 교육과정 위원회" aria-label="학교 교육과정 위원회" placeholder="정답">를 구성·운영하며, 이 위원회는 <input data-answer="학교장의 교육과정 운영 및 의사결정에 관한 자문" aria-label="학교장의 교육과정 운영 및 의사결정에 관한 자문" placeholder="정답"> 역할을 담당한다. 단, 특성화 고등학교와 산업수요 맞춤형 고등학교의 경우에는 산업계 전문가가 참여할 수 있고, 통합교육이 이루어지는 학교의 경우에는 <input data-answer="특수교사" aria-label="특수교사" placeholder="정답">가 참여할 것을 권장한다.</div>
           <div class="overview-question">2) 학교는 학습 공동체 문화를 조성하고 <input data-answer="동학년 모임" aria-label="동학년 모임" placeholder="정답">, <input data-answer="교과별 모임" aria-label="교과별 모임" placeholder="정답">, <input data-answer="현장 연구" aria-label="현장 연구" placeholder="정답">, <input data-answer="자체 연수" aria-label="자체 연수" placeholder="정답"> 등을 통해서 교사들의 교육 활동 개선이 이루어질 수 있도록 한다.</div>


### PR DESCRIPTION
## Summary
- add missing outline title for '설계의 원칙'
- insert numbering for each question in the design section
- remove extraneous outline title from the nature section

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877bd252110832c9512f8d5992b9f1e