### PR TITLE
Allow optional '의' particle

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,9 +169,16 @@
         }
 
         function normalizeAnswer(str) {
-            const pattern = gameState.selectedTopic === CONSTANTS.TOPICS.MODEL
-                ? /[\s⋅·의]+/g
-                : /[\s⋅·]+/g;
+            const ignoreParticleEui =
+                gameState.selectedTopic === CONSTANTS.TOPICS.MODEL ||
+                (
+                    gameState.selectedTopic === CONSTANTS.TOPICS.CURRICULUM &&
+                    (
+                        gameState.selectedSubject === CONSTANTS.SUBJECTS.OVERVIEW ||
+                        gameState.selectedSubject === CONSTANTS.SUBJECTS.CREATIVE
+                    )
+                );
+            const pattern = ignoreParticleEui ? /[\s⋅·의]+/g : /[\s⋅·]+/g;
             return str
                 .replace(/\([^)]*\)/g, '')
                 .trim()


### PR DESCRIPTION
## Summary
- normalize answers to ignore the particle `의` when in the Curriculum topic for Overview or Creative subjects

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877cc67f468832ca280208c8025ea9b