### PR TITLE
Fix Korean phrasing in curriculum table

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,7 @@
               <tr>
                 <th>과정 · 기능</th>
                 <td>
-                  <input data-answer="감각과 매체을 활용하여 탐색하기" aria-label="감각과 매체을 활용하여 탐색하기" placeholder="정답">
+                  <input data-answer="감각과 매체를 활용하여 탐색하기" aria-label="감각과 매체를 활용하여 탐색하기" placeholder="정답">
                   <input data-answer="대상과 상호 작용하며 의미 발견하기" aria-label="대상과 상호 작용하며 의미 발견하기" placeholder="정답">
                   <input data-answer="이미지를 해석하고 활용하기" aria-label="이미지를 해석하고 활용하기" placeholder="정답">
                 </td>


### PR DESCRIPTION
## Summary
- fix Korean typographical error for art curriculum phrase in `index.html`

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879d32662bc832caeb5f0f9b829d163