### PR TITLE
Add basic theory topic with English subject

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@
                 WISE: 'wise',
                 JOY: 'joy',
                 PE: 'pe',
+                ENGLISH: 'english',
                 ETHICS: 'ethics',
                 PRACTICAL: 'practical',
                 SOCIAL: 'social',
@@ -38,7 +39,8 @@
                 CURRICULUM: 'curriculum',
                 COMPETENCY: 'competency',
                 MODEL: 'model',
-                COURSE: 'course'
+                COURSE: 'course',
+                BASIC: 'basic'
             },
             MODES: {
                 NORMAL: 'normal',
@@ -236,7 +238,8 @@
             if (
                 topic === CONSTANTS.TOPICS.CURRICULUM ||
                 topic === CONSTANTS.TOPICS.MODEL ||
-                topic === CONSTANTS.TOPICS.COURSE
+                topic === CONSTANTS.TOPICS.COURSE ||
+                topic === CONSTANTS.TOPICS.BASIC
             ) {
                 subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
                 subjectButtons.forEach(btn => {
@@ -483,6 +486,7 @@
                 [CONSTANTS.SUBJECTS.WISE]: '슬기로운 생활',
                 [CONSTANTS.SUBJECTS.JOY]: '즐거운 생활',
                 [CONSTANTS.SUBJECTS.PE]: '체육',
+                [CONSTANTS.SUBJECTS.ENGLISH]: '영어',
                 [CONSTANTS.SUBJECTS.ETHICS]: '도덕',
                 [CONSTANTS.SUBJECTS.PRACTICAL]: '실과',
                 [CONSTANTS.SUBJECTS.SOCIAL]: '사회',
@@ -757,7 +761,8 @@
             if (
                 topic === CONSTANTS.TOPICS.CURRICULUM ||
                 topic === CONSTANTS.TOPICS.MODEL ||
-                topic === CONSTANTS.TOPICS.COURSE
+                topic === CONSTANTS.TOPICS.COURSE ||
+                topic === CONSTANTS.TOPICS.BASIC
             ) {
                 subjectSelector.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
                 document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
@@ -766,6 +771,8 @@
                     defaultSubject = CONSTANTS.SUBJECTS.ETHICS;
                 } else if (topic === CONSTANTS.TOPICS.COURSE) {
                     defaultSubject = CONSTANTS.SUBJECTS.PE_BACK;
+                } else if (topic === CONSTANTS.TOPICS.BASIC) {
+                    defaultSubject = CONSTANTS.SUBJECTS.ENGLISH;
                 } else {
                     defaultSubject = CONSTANTS.SUBJECTS.MUSIC;
                 }

--- a/index.html
+++ b/index.html
@@ -2006,6 +2006,17 @@
           </div>
         </div>
       </section>
+  </section>
+  </main>
+  <main id="english-quiz-main" class="hidden">
+    <div class="tabs">
+      <div class="tab active" data-target="basics">기본이론</div>
+    </div>
+    <section id="basics" class="active">
+      <h2>기본이론</h2>
+      <div class="grade-container"><div><table><tbody>
+        <tr><th>개념</th><td><input data-answer="영어 알파벳" aria-label="영어 알파벳" placeholder="정답"></td></tr>
+      </tbody></table></div></div>
     </section>
   </main>
 <!-- competency main start -->
@@ -2183,6 +2194,7 @@
                 <button class="btn topic-btn" data-topic="competency">역량</button>
                 <button class="btn topic-btn" data-topic="model">모형</button>
                 <button class="btn topic-btn" data-topic="course">교육과정</button>
+                <button class="btn topic-btn" data-topic="basic">기본이론</button>
             </div>
             <h2>과목 선택</h2>
             <div class="subject-selector">
@@ -2193,6 +2205,7 @@
                 <button class="btn subject-btn" data-subject="wise" data-topic="curriculum">슬기로운 생활</button>
                 <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐거운 생활</button>
                 <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
+                <button class="btn subject-btn" data-subject="english" data-topic="basic">영어</button>
                 <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
                 <button class="btn subject-btn" data-subject="practical" data-topic="model">실과</button>
                 <button class="btn subject-btn" data-subject="social" data-topic="model">사회</button>
@@ -2200,7 +2213,7 @@
                 <button class="btn subject-btn" data-subject="pe-back" data-topic="course">체육(뒷교)</button>
                 <button class="btn subject-btn" data-subject="creative" data-topic="course">창체</button>
                 <button class="btn subject-btn" data-subject="overview" data-topic="course">총론</button>
-                <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model">랜덤</button>
+                <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model basic">랜덤</button>
             </div>
             <h2>게임 모드</h2>
             <div class="mode-selector">


### PR DESCRIPTION
## Summary
- add `ENGLISH` subject and `BASIC` topic constants
- show subject selector when `기본이론` topic is chosen
- include `영어` in the start modal and update random button
- implement minimal English quiz section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879ffe41e78832ca715dd81f96db578