### PR TITLE
Add English assessment blanks

### DIFF
--- a/index.html
+++ b/index.html
@@ -2065,6 +2065,13 @@
       <h2>평가</h2>
       <div class="grade-container"><div><table><tbody>
         <tr><th>개념</th><td><input data-answer="평가" aria-label="평가" placeholder="정답"></td></tr>
+        <tr><th>평가의 요건</th><td class="two-col-answers">(<input data-answer="Practicality" aria-label="Practicality" placeholder="정답">) (<input data-answer="Reliability" aria-label="Reliability" placeholder="정답">) (<input data-answer="Authenticity" aria-label="Authenticity" placeholder="정답">) (<input data-answer="Validity" aria-label="Validity" placeholder="정답">) (<input data-answer="Washback" aria-label="Washback" placeholder="정답">)</td></tr>
+        <tr><th>목적에 따른 분류</th><td class="two-col-answers">(<input data-answer="Proficiency" aria-label="Proficiency" placeholder="정답">) test (<input data-answer="Placement" aria-label="Placement" placeholder="정답">) test (<input data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답">) test (<input data-answer="Achievement" aria-label="Achievement" placeholder="정답">) test</td></tr>
+        <tr><th>시기에 따른 분류</th><td class="two-col-answers">(<input data-answer="Summative" aria-label="Summative" placeholder="정답">) assessment (<input data-answer="Formative" aria-label="Formative" placeholder="정답">) assessment</td></tr>
+        <tr><th>방식에 따른 분류</th><td class="two-col-answers">(<input data-answer="Indirect" aria-label="Indirect" placeholder="정답">) / (<input data-answer="Direct" aria-label="Direct" placeholder="정답">) test (<input data-answer="Integrative" aria-label="Integrative" placeholder="정답">) / (<input data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답">) test</td></tr>
+        <tr><th>수행평가</th><td class="two-col-answers">(<input data-answer="Performance-based" aria-label="Performance-based" placeholder="정답">) assessment = (<input data-answer="Alternative" aria-label="Alternative" placeholder="정답">) assessment = (<input data-answer="Authentic" aria-label="Authentic" placeholder="정답">) assessment</td></tr>
+        <tr><th>주체에 따른 분류</th><td class="two-col-answers">교사: (<input data-answer="Observation" aria-label="Observation" placeholder="정답">) 나: (<input data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답">) 동료: (<input data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답">)</td></tr>
+        <tr><th>수단에 따른 분류</th><td class="two-col-answers">(<input data-answer="Interview" aria-label="Interview" placeholder="정답">) (<input data-answer="Portfolio" aria-label="Portfolio" placeholder="정답">)</td></tr>
       </tbody></table></div></div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- refine blanks in the English assessment section to explicitly show categories

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a39a6b06c832c88fb1ba05b3e7c9e