### PR TITLE
Improve assessment section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2061,18 +2061,100 @@
         <tr><th>개념</th><td><input data-answer="교사언어" aria-label="교사언어" placeholder="정답"></td></tr>
       </tbody></table></div></div>
     </section>
-    <section id="assessment">
-      <h2>평가</h2>
-      <div class="grade-container"><div><table><tbody>
-        <tr><th>평가의 요건</th><td class="two-col-answers"><input data-answer="Practicality" aria-label="Practicality" placeholder="정답"> <input data-answer="Reliability" aria-label="Reliability" placeholder="정답"> <input data-answer="Authenticity" aria-label="Authenticity" placeholder="정답"> <input data-answer="Validity" aria-label="Validity" placeholder="정답"> <input data-answer="Washback" aria-label="Washback" placeholder="정답"></td></tr>
-        <tr><th>목적에 따른 분류</th><td class="two-col-answers"><input data-answer="Proficiency" aria-label="Proficiency" placeholder="정답"> test <input data-answer="Placement" aria-label="Placement" placeholder="정답"> test <input data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답"> test <input data-answer="Achievement" aria-label="Achievement" placeholder="정답"> test</td></tr>
-        <tr><th>시기에 따른 분류</th><td class="two-col-answers"><input data-answer="Summative" aria-label="Summative" placeholder="정답"> assessment <input data-answer="Formative" aria-label="Formative" placeholder="정답"> assessment</td></tr>
-        <tr><th>방식에 따른 분류</th><td class="two-col-answers"><input data-answer="Indirect" aria-label="Indirect" placeholder="정답"> / <input data-answer="Direct" aria-label="Direct" placeholder="정답"> test <input data-answer="Integrative" aria-label="Integrative" placeholder="정답"> / <input data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답"> test</td></tr>
-        <tr><th>수행평가</th><td class="two-col-answers"><input data-answer="Performance-based" aria-label="Performance-based" placeholder="정답"> assessment = <input data-answer="Alternative" aria-label="Alternative" placeholder="정답"> assessment = <input data-answer="Authentic" aria-label="Authentic" placeholder="정답"> assessment</td></tr>
-        <tr><th>주체에 따른 분류</th><td class="two-col-answers">교사: <input data-answer="Observation" aria-label="Observation" placeholder="정답"> 나: <input data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답"> 동료: <input data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답"></td></tr>
-        <tr><th>수단에 따른 분류</th><td class="two-col-answers"><input data-answer="Interview" aria-label="Interview" placeholder="정답"> <input data-answer="Portfolio" aria-label="Portfolio" placeholder="정답"></td></tr>
-      </tbody></table></div></div>
-    </section>
+<section id="assessment">
+  <h2>평가</h2>
+  <div class="grade-container">
+    <div>
+      <table><tbody>
+        <tr>
+          <th>평가의 요건</th>
+          <td class="two-col-answers">
+            <input class="fit-answer" data-answer="Practicality" aria-label="Practicality" placeholder="정답" style="width:14ch;">
+            <input class="fit-answer" data-answer="Reliability" aria-label="Reliability" placeholder="정답" style="width:13ch;">
+            <input class="fit-answer" data-answer="Authenticity" aria-label="Authenticity" placeholder="정답" style="width:14ch;">
+            <input class="fit-answer" data-answer="Validity" aria-label="Validity" placeholder="정답" style="width:10ch;">
+            <input class="fit-answer" data-answer="Washback" aria-label="Washback" placeholder="정답" style="width:10ch;">
+          </td>
+        </tr>
+      </tbody></table>
+    </div>
+    <div>
+      <table><tbody>
+        <tr>
+          <th>목적에 따른 분류</th>
+          <td class="two-col-answers">
+            <input class="fit-answer" data-answer="Proficiency" aria-label="Proficiency" placeholder="정답" style="width:13ch;"> test
+            <input class="fit-answer" data-answer="Placement" aria-label="Placement" placeholder="정답" style="width:11ch;"> test
+            <input class="fit-answer" data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답" style="width:12ch;"> test
+            <input class="fit-answer" data-answer="Achievement" aria-label="Achievement" placeholder="정답" style="width:13ch;"> test
+          </td>
+        </tr>
+      </tbody></table>
+    </div>
+    <div>
+      <table><tbody>
+        <tr>
+          <th>시기에 따른 분류</th>
+          <td class="two-col-answers">
+            <input class="fit-answer" data-answer="Summative" aria-label="Summative" placeholder="정답" style="width:11ch;"> assessment
+            <input class="fit-answer" data-answer="Formative" aria-label="Formative" placeholder="정답" style="width:11ch;"> assessment
+          </td>
+        </tr>
+      </tbody></table>
+    </div>
+    <div>
+      <table><tbody>
+        <tr>
+          <th>방식에 따른 분류</th>
+          <td class="two-col-answers">
+            <input class="fit-answer" data-answer="Indirect" aria-label="Indirect" placeholder="정답" style="width:10ch;"> /
+            <input class="fit-answer" data-answer="Direct" aria-label="Direct" placeholder="정답" style="width:8ch;"> test
+            <input class="fit-answer" data-answer="Integrative" aria-label="Integrative" placeholder="정답" style="width:13ch;"> /
+            <input class="fit-answer" data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답" style="width:16ch;"> test
+          </td>
+        </tr>
+      </tbody></table>
+    </div>
+    <div>
+      <table><tbody>
+        <tr>
+          <th>수행평가</th>
+          <td class="two-col-answers">
+            <input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =
+            <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =
+            <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment
+          </td>
+        </tr>
+      </tbody></table>
+    </div>
+    <div>
+      <table><tbody>
+        <tr>
+          <th>주체에 따른 분류</th>
+          <td class="two-col-answers">
+            교사:
+            <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;">
+            나:
+            <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;">
+            동료:
+            <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;">
+          </td>
+        </tr>
+      </tbody></table>
+    </div>
+    <div>
+      <table><tbody>
+        <tr>
+          <th>수단에 따른 분류</th>
+          <td class="two-col-answers">
+            <input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;">
+            <input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;">
+          </td>
+        </tr>
+      </tbody></table>
+    </div>
+  </div>
+</section>
   </main>
 <!-- competency main start -->
 <main id="competency-quiz-main" class="hidden competency-ui">

--- a/styles.css
+++ b/styles.css
@@ -283,6 +283,10 @@
       transition: all 0.2s ease;
       border-radius: 8px;
     }
+    td input.fit-answer {
+      width: auto;
+      display: inline-block;
+    }
     td input:focus {
       outline: none;
       border-color: var(--primary);


### PR DESCRIPTION
## Summary
- add `.fit-answer` class for narrower answer inputs
- refactor assessment section into multiple blocks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a413bdbb4832c9640fe0f828b5544