### PR TITLE
Fix English assessment block layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2120,35 +2120,14 @@
         <tr>
           <th>수행평가</th>
           <td class="two-col-answers">
-            <input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =
-            <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =
-            <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment
-          </td>
-        </tr>
-      </tbody></table>
-    </div>
-    <div>
-      <table><tbody>
-        <tr>
-          <th>주체에 따른 분류</th>
-          <td class="two-col-answers">
-            교사:
-            <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;">
-            나:
-            <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;">
-            동료:
-            <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;">
-          </td>
-        </tr>
-      </tbody></table>
-    </div>
-    <div>
-      <table><tbody>
-        <tr>
-          <th>수단에 따른 분류</th>
-          <td class="two-col-answers">
-            <input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;">
-            <input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;">
+            - <input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment<br>
+            -주체에 따른 분류<br>
+            --교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;"><br>
+            --나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;"><br>
+            --동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;"><br>
+            -수단에 따른 분류<br>
+            --<input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;"><br>
+            --<input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;">
           </td>
         </tr>
       </tbody></table>


### PR DESCRIPTION
## Summary
- restructure English assessment section into a single block
- keep punctuation directly after blanks without extra spacing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a43d8b6b8832c835b4109dd7c7d22