### PR TITLE
Fix layout for English assessment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2068,12 +2068,12 @@
       <table><tbody>
         <tr>
           <th>평가의 요건</th>
-          <td class="two-col-answers">
-            <input class="fit-answer" data-answer="Practicality" aria-label="Practicality" placeholder="정답" style="width:14ch;">
-            <input class="fit-answer" data-answer="Reliability" aria-label="Reliability" placeholder="정답" style="width:13ch;">
-            <input class="fit-answer" data-answer="Authenticity" aria-label="Authenticity" placeholder="정답" style="width:14ch;">
-            <input class="fit-answer" data-answer="Validity" aria-label="Validity" placeholder="정답" style="width:10ch;">
-            <input class="fit-answer" data-answer="Washback" aria-label="Washback" placeholder="정답" style="width:10ch;">
+          <td class="inline-answers">
+            <span class="inline-item"><input class="fit-answer" data-answer="Practicality" aria-label="Practicality" placeholder="정답" style="width:14ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Reliability" aria-label="Reliability" placeholder="정답" style="width:13ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Authenticity" aria-label="Authenticity" placeholder="정답" style="width:14ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Validity" aria-label="Validity" placeholder="정답" style="width:10ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Washback" aria-label="Washback" placeholder="정답" style="width:10ch;"></span>
           </td>
         </tr>
       </tbody></table>
@@ -2082,11 +2082,11 @@
       <table><tbody>
         <tr>
           <th>목적에 따른 분류</th>
-          <td class="two-col-answers">
-            <input class="fit-answer" data-answer="Proficiency" aria-label="Proficiency" placeholder="정답" style="width:13ch;"> test
-            <input class="fit-answer" data-answer="Placement" aria-label="Placement" placeholder="정답" style="width:11ch;"> test
-            <input class="fit-answer" data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답" style="width:12ch;"> test
-            <input class="fit-answer" data-answer="Achievement" aria-label="Achievement" placeholder="정답" style="width:13ch;"> test
+          <td class="inline-answers">
+            <span class="inline-item"><input class="fit-answer" data-answer="Proficiency" aria-label="Proficiency" placeholder="정답" style="width:13ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Placement" aria-label="Placement" placeholder="정답" style="width:11ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답" style="width:12ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Achievement" aria-label="Achievement" placeholder="정답" style="width:13ch;"> test</span>
           </td>
         </tr>
       </tbody></table>
@@ -2095,9 +2095,9 @@
       <table><tbody>
         <tr>
           <th>시기에 따른 분류</th>
-          <td class="two-col-answers">
-            <input class="fit-answer" data-answer="Summative" aria-label="Summative" placeholder="정답" style="width:11ch;"> assessment
-            <input class="fit-answer" data-answer="Formative" aria-label="Formative" placeholder="정답" style="width:11ch;"> assessment
+          <td class="inline-answers">
+            <span class="inline-item"><input class="fit-answer" data-answer="Summative" aria-label="Summative" placeholder="정답" style="width:11ch;"> assessment</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Formative" aria-label="Formative" placeholder="정답" style="width:11ch;"> assessment</span>
           </td>
         </tr>
       </tbody></table>
@@ -2106,11 +2106,11 @@
       <table><tbody>
         <tr>
           <th>방식에 따른 분류</th>
-          <td class="two-col-answers">
-            <input class="fit-answer" data-answer="Indirect" aria-label="Indirect" placeholder="정답" style="width:10ch;"> /
-            <input class="fit-answer" data-answer="Direct" aria-label="Direct" placeholder="정답" style="width:8ch;"> test
-            <input class="fit-answer" data-answer="Integrative" aria-label="Integrative" placeholder="정답" style="width:13ch;"> /
-            <input class="fit-answer" data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답" style="width:16ch;"> test
+          <td class="inline-answers">
+            <span class="inline-item"><input class="fit-answer" data-answer="Indirect" aria-label="Indirect" placeholder="정답" style="width:10ch;"> /</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Direct" aria-label="Direct" placeholder="정답" style="width:8ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Integrative" aria-label="Integrative" placeholder="정답" style="width:13ch;"> /</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답" style="width:16ch;"> test</span>
           </td>
         </tr>
       </tbody></table>
@@ -2119,10 +2119,10 @@
       <table><tbody>
         <tr>
           <th>수행평가</th>
-          <td class="two-col-answers">
-            <input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =
-            <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =
-            <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment
+          <td class="inline-answers">
+            <span class="inline-item"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
           </td>
         </tr>
       </tbody></table>
@@ -2131,13 +2131,10 @@
       <table><tbody>
         <tr>
           <th>주체에 따른 분류</th>
-          <td class="two-col-answers">
-            교사:
-            <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;">
-            나:
-            <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;">
-            동료:
-            <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;">
+          <td class="inline-answers">
+            <span class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;"></span>
+            <span class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;"></span>
+            <span class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;"></span>
           </td>
         </tr>
       </tbody></table>
@@ -2146,9 +2143,9 @@
       <table><tbody>
         <tr>
           <th>수단에 따른 분류</th>
-          <td class="two-col-answers">
-            <input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;">
-            <input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;">
+          <td class="inline-answers">
+            <span class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;"></span>
           </td>
         </tr>
       </tbody></table>

--- a/styles.css
+++ b/styles.css
@@ -944,6 +944,13 @@ td input.activity-input:not(:first-child) {
   width: auto;
 }
 
+.inline-answers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
 /* Creative subject readability tweaks */
 #creative-quiz-main .creative-block {
   margin-bottom: 2rem;


### PR DESCRIPTION
## Summary
- tighten spacing in the English assessment section
- add a reusable `.inline-answers` style

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a458d6d78832cab869111dd0aae3a