### PR TITLE
Add grade-title labels to assessment section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2065,9 +2065,9 @@
   <h2>평가</h2>
   <div class="grade-container">
     <div>
+      <div class="grade-title">평가의 요건</div>
       <table><tbody>
         <tr>
-          <th>평가의 요건</th>
           <td class="inline-answers">
             <span class="inline-item"><input class="fit-answer" data-answer="Practicality" aria-label="Practicality" placeholder="정답" style="width:14ch;"></span>
             <span class="inline-item"><input class="fit-answer" data-answer="Reliability" aria-label="Reliability" placeholder="정답" style="width:13ch;"></span>
@@ -2079,9 +2079,9 @@
       </tbody></table>
     </div>
     <div>
+      <div class="grade-title">목적에 따른 분류</div>
       <table><tbody>
         <tr>
-          <th>목적에 따른 분류</th>
           <td class="inline-answers">
             <span class="inline-item"><input class="fit-answer" data-answer="Proficiency" aria-label="Proficiency" placeholder="정답" style="width:13ch;"> test</span>
             <span class="inline-item"><input class="fit-answer" data-answer="Placement" aria-label="Placement" placeholder="정답" style="width:11ch;"> test</span>
@@ -2092,9 +2092,9 @@
       </tbody></table>
     </div>
     <div>
+      <div class="grade-title">시기에 따른 분류</div>
       <table><tbody>
         <tr>
-          <th>시기에 따른 분류</th>
           <td class="inline-answers">
             <span class="inline-item"><input class="fit-answer" data-answer="Summative" aria-label="Summative" placeholder="정답" style="width:11ch;"> assessment</span>
             <span class="inline-item"><input class="fit-answer" data-answer="Formative" aria-label="Formative" placeholder="정답" style="width:11ch;"> assessment</span>
@@ -2103,9 +2103,9 @@
       </tbody></table>
     </div>
     <div>
+      <div class="grade-title">방식에 따른 분류</div>
       <table><tbody>
         <tr>
-          <th>방식에 따른 분류</th>
           <td class="inline-answers">
             <span class="inline-item"><input class="fit-answer" data-answer="Indirect" aria-label="Indirect" placeholder="정답" style="width:10ch;"> /</span>
             <span class="inline-item"><input class="fit-answer" data-answer="Direct" aria-label="Direct" placeholder="정답" style="width:8ch;"> test</span>
@@ -2116,9 +2116,9 @@
       </tbody></table>
     </div>
     <div>
+      <div class="grade-title">수행평가</div>
       <table><tbody>
         <tr>
-          <th>수행평가</th>
           <td class="inline-answers">
             <span class="inline-item"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =</span>
             <span class="inline-item"><input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =</span>
@@ -2128,9 +2128,9 @@
       </tbody></table>
     </div>
     <div>
+      <div class="grade-title">주체에 따른 분류</div>
       <table><tbody>
         <tr>
-          <th>주체에 따른 분류</th>
           <td class="inline-answers">
             <span class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;"></span>
             <span class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;"></span>
@@ -2140,9 +2140,9 @@
       </tbody></table>
     </div>
     <div>
+      <div class="grade-title">수단에 따른 분류</div>
       <table><tbody>
         <tr>
-          <th>수단에 따른 분류</th>
           <td class="inline-answers">
             <span class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;"></span>
             <span class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;"></span>


### PR DESCRIPTION
## Summary
- label each assessment subsection with `.grade-title` above the tables
- remove table headers for cleaner layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a49feee28832cb975f5012d42af14