### PR TITLE
Fix English assessment layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2121,26 +2121,30 @@
     </div>
     <div>
       <div class="grade-title">수행평가</div>
-      <ul class="assessment-list">
-        <li class="inline-answers">
-          <span class="inline-item"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =</span>
-          <span class="inline-item"><input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =</span>
-          <span class="inline-item"><input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
-        </li>
-        <li>주체에 따른 분류
-          <ul class="sub-list">
-            <li class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;"></li>
-            <li class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;"></li>
-            <li class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;"></li>
-          </ul>
-        </li>
-        <li>수단에 따른 분류
-          <ul class="sub-list">
-            <li class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;"></li>
-            <li class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;"></li>
-          </ul>
-        </li>
-      </ul>
+      <table><tbody>
+        <tr>
+          <td class="inline-answers">
+            <span class="inline-item"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
+          </td>
+        </tr>
+        <tr>
+          <th>주체에 따른 분류</th>
+          <td class="inline-answers">
+            <span class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;"></span>
+            <span class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;"></span>
+            <span class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;"></span>
+          </td>
+        </tr>
+        <tr>
+          <th>수단에 따른 분류</th>
+          <td class="inline-answers">
+            <span class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;"></span>
+          </td>
+        </tr>
+      </tbody></table>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- update the "수행평가" section in the English assessment area
- align markup with other assessment sections for consistent UI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a4fee7bf4832c987e15e16425e311