### PR TITLE
Fix inline layout for English assessment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2123,11 +2123,13 @@
       <div class="grade-title">수행평가</div>
       <table><tbody>
         <tr>
-          <td class="inline-answers">
-            <span class="inline-item"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
-          </td>
+            <td class="inline-answers">
+              <span class="inline-item">
+                <input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment =
+                <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment =
+                <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment
+              </span>
+            </td>
         </tr>
         <tr>
           <th>주체에 따른 분류</th>


### PR DESCRIPTION
## Summary
- keep the performance-based assessment line together in the English assessment section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a51985bb4832cbac3a563a9948831