### PR TITLE
Fix wrapping for performance assessment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2124,7 +2124,7 @@
       <table><tbody>
         <tr>
             <td class="inline-answers">
-              <span class="inline-item"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
+              <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
## Summary
- prevent line wrapping inside the English performance assessment row

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a53ef3434832cb87382f00240cf51