### PR TITLE
Adjust assessment inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2130,16 +2130,16 @@
         <tr>
           <th>주체에 따른 분류</th>
           <td class="inline-answers">
-            <span class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:15ch;"></span>
-            <span class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:19ch;"></span>
-            <span class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:19ch;"></span>
+            <span class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답"></span>
+            <span class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답"></span>
+            <span class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답"></span>
           </td>
         </tr>
         <tr>
           <th>수단에 따른 분류</th>
           <td class="inline-answers">
-              <span class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:13ch;"></span>
-              <span class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:13ch;"></span>
+              <span class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답"></span>
+              <span class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답"></span>
           </td>
         </tr>
       </tbody></table>

--- a/styles.css
+++ b/styles.css
@@ -950,6 +950,10 @@ td input.activity-input:not(:first-child) {
   gap: 1rem;
   align-items: center;
 }
+.inline-answers input.fit-answer {
+  width: auto;
+  min-width: 8ch;
+}
 
 .assessment-list {
   list-style-type: disc;


### PR DESCRIPTION
## Summary
- remove inline width styles in `assessment` section inputs
- set default width for assessment answers in CSS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a584de0c4832c97e12edeed114c34