### PR TITLE
Refine English assessment section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2121,28 +2121,26 @@
     </div>
     <div>
       <div class="grade-title">수행평가</div>
-      <table><tbody>
-        <tr>
-            <td class="inline-answers">
-              <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:21ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:15ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:13ch;"> assessment</span>
-            </td>
-        </tr>
-        <tr>
-          <th>주체에 따른 분류</th>
-          <td class="inline-answers">
-            <span class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:15ch;"></span>
-            <span class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:19ch;"></span>
-            <span class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:19ch;"></span>
-          </td>
-        </tr>
-        <tr>
-          <th>수단에 따른 분류</th>
-          <td class="inline-answers">
-              <span class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:13ch;"></span>
-              <span class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:13ch;"></span>
-          </td>
-        </tr>
-      </tbody></table>
+      <ul class="assessment-list">
+        <li class="inline-answers">
+          <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:21ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:15ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:13ch;"> assessment</span>
+        </li>
+        <li>
+          주체에 따른 분류
+          <ul class="sub-list">
+            <li>교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:15ch;"></li>
+            <li>나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:19ch;"></li>
+            <li>동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:19ch;"></li>
+          </ul>
+        </li>
+        <li>
+          수단에 따른 분류
+          <ul class="sub-list">
+            <li><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:13ch;"></li>
+            <li><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:13ch;"></li>
+          </ul>
+        </li>
+      </ul>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- replace table-based layout for performing assessment section with bullet lists
- add nested bullet labels for classifying by subject and method

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a59d41620832cb8ac91ac9fd9df72