### PR TITLE
Add subcategory labels in English assessment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2123,23 +2123,27 @@
       <div class="grade-title">수행평가</div>
       <table><tbody>
         <tr>
-            <td class="inline-answers">
-              <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:21ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:15ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:13ch;"> assessment</span>
-            </td>
-        </tr>
-        <tr>
-          <th>주체에 따른 분류</th>
-          <td class="inline-answers">
-            <span class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:15ch;"></span>
-            <span class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:19ch;"></span>
-            <span class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:19ch;"></span>
-          </td>
-        </tr>
-        <tr>
-          <th>수단에 따른 분류</th>
-          <td class="inline-answers">
-              <span class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:13ch;"></span>
-              <span class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:13ch;"></span>
+          <td>
+            <ul class="assessment-list">
+              <li>
+                <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:21ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:15ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:13ch;"> assessment</span>
+              </li>
+              <li>
+                <span class="sub-title">주체에 따른 분류</span>
+                <ul class="sub-list">
+                  <li class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:15ch;"></li>
+                  <li class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:19ch;"></li>
+                  <li class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:19ch;"></li>
+                </ul>
+              </li>
+              <li>
+                <span class="sub-title">수단에 따른 분류</span>
+                <ul class="sub-list">
+                  <li class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:13ch;"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:13ch;"></li>
+                </ul>
+              </li>
+            </ul>
           </td>
         </tr>
       </tbody></table>


### PR DESCRIPTION
## Summary
- restructure English assessment section to use bullet lists
- add subcategory labels for actor and method divisions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a5bbe9060832ca07905416d0047cd