### PR TITLE
Fix blank widths in English assessment section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2069,11 +2069,11 @@
       <table><tbody>
         <tr>
           <td class="inline-answers">
-            <span class="inline-item"><input class="fit-answer" data-answer="Practicality" aria-label="Practicality" placeholder="정답" style="width:16ch;"></span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Reliability" aria-label="Reliability" placeholder="정답" style="width:15ch;"></span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Authenticity" aria-label="Authenticity" placeholder="정답" style="width:16ch;"></span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Validity" aria-label="Validity" placeholder="정답" style="width:12ch;"></span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Washback" aria-label="Washback" placeholder="정답" style="width:12ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Practicality" aria-label="Practicality" placeholder="정답" style="width:14ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Reliability" aria-label="Reliability" placeholder="정답" style="width:13ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Authenticity" aria-label="Authenticity" placeholder="정답" style="width:14ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Validity" aria-label="Validity" placeholder="정답" style="width:10ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Washback" aria-label="Washback" placeholder="정답" style="width:10ch;"></span>
           </td>
         </tr>
       </tbody></table>
@@ -2083,10 +2083,10 @@
       <table><tbody>
         <tr>
           <td class="inline-answers">
-            <span class="inline-item"><input class="fit-answer" data-answer="Proficiency" aria-label="Proficiency" placeholder="정답" style="width:15ch;"> test</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Placement" aria-label="Placement" placeholder="정답" style="width:13ch;"> test</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답" style="width:14ch;"> test</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Achievement" aria-label="Achievement" placeholder="정답" style="width:15ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Proficiency" aria-label="Proficiency" placeholder="정답" style="width:13ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Placement" aria-label="Placement" placeholder="정답" style="width:11ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답" style="width:12ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Achievement" aria-label="Achievement" placeholder="정답" style="width:13ch;"> test</span>
           </td>
         </tr>
       </tbody></table>
@@ -2096,8 +2096,8 @@
       <table><tbody>
         <tr>
           <td class="inline-answers">
-            <span class="inline-item"><input class="fit-answer" data-answer="Summative" aria-label="Summative" placeholder="정답" style="width:13ch;"> assessment</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Formative" aria-label="Formative" placeholder="정답" style="width:13ch;"> assessment</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Summative" aria-label="Summative" placeholder="정답" style="width:11ch;"> assessment</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Formative" aria-label="Formative" placeholder="정답" style="width:11ch;"> assessment</span>
           </td>
         </tr>
       </tbody></table>
@@ -2108,12 +2108,12 @@
         <tr>
           <td class="inline-answers">
             <span class="inline-item">
-              <input class="fit-answer" data-answer="Indirect" aria-label="Indirect" placeholder="정답" style="width:12ch;"> /
-              <input class="fit-answer" data-answer="Direct" aria-label="Direct" placeholder="정답" style="width:10ch;"> test
+              <input class="fit-answer" data-answer="Indirect" aria-label="Indirect" placeholder="정답" style="width:10ch;"> /
+              <input class="fit-answer" data-answer="Direct" aria-label="Direct" placeholder="정답" style="width:8ch;"> test
             </span>
             <span class="inline-item">
-              <input class="fit-answer" data-answer="Integrative" aria-label="Integrative" placeholder="정답" style="width:15ch;"> /
-              <input class="fit-answer" data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답" style="width:18ch;"> test
+              <input class="fit-answer" data-answer="Integrative" aria-label="Integrative" placeholder="정답" style="width:13ch;"> /
+              <input class="fit-answer" data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답" style="width:16ch;"> test
             </span>
           </td>
         </tr>
@@ -2126,21 +2126,21 @@
           <td>
             <ul class="assessment-list">
               <li>
-                <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:20ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:14ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:12ch;"> assessment</span>
+                <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
               </li>
               <li>
                 <span class="sub-title">주체에 따른 분류</span>
                 <ul class="sub-list">
-                  <li class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:14ch;"></li>
-                  <li class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:18ch;"></li>
-                  <li class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:18ch;"></li>
+                  <li class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;"></li>
+                  <li class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;"></li>
+                  <li class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;"></li>
                 </ul>
               </li>
               <li>
                 <span class="sub-title">수단에 따른 분류</span>
                 <ul class="sub-list">
-                  <li class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:12ch;"></li>
-                  <li class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:12ch;"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;"></li>
                 </ul>
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- unify blank widths in the English assessment section so that each input is slightly longer than its answer

## Testing
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a6629b5e0832c8e280b4e869879df