### PR TITLE
Fix assessment input widths

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -940,7 +940,7 @@ td input.activity-input:not(:first-child) {
   gap: 0.5rem;
 }
 .inline-item input {
-  flex: 1;
+  flex: 0 0 auto;
   width: auto;
 }
 


### PR DESCRIPTION
## Summary
- fix width of inline inputs in English assessment section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a68507d08832c8a83795af3d6dfcd