### PR TITLE
Improve assessment layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2126,7 +2126,7 @@
           <td>
             <ul class="assessment-list">
               <li>
-                <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
+                <span class="inline-item"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
               </li>
               <li>
                 <span class="sub-title">주체에 따른 분류</span>

--- a/styles.css
+++ b/styles.css
@@ -968,6 +968,17 @@ td input.activity-input:not(:first-child) {
   gap: 0.5rem;
 }
 
+#english-quiz-main .assessment-list {
+  margin: 0 auto;
+  list-style-position: inside;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 2rem;
+}
+#english-quiz-main td {
+  align-items: center;
+}
+
 /* Creative subject readability tweaks */
 #creative-quiz-main .creative-block {
   margin-bottom: 2rem;


### PR DESCRIPTION
## Summary
- remove nowrap style so assessment items wrap correctly
- layout assessment lists in a centered grid

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a6aa3b234832ca1ef79abc964a1ca