### PR TITLE
Adjust English answer input widths

### DIFF
--- a/app.js
+++ b/app.js
@@ -235,7 +235,7 @@
             document.querySelectorAll('#english-quiz-main input[data-answer]')
                 .forEach(input => {
                     const answerLen = (input.dataset.answer || '').length;
-                    const size = Math.max(2, answerLen + 1);
+                    const size = Math.max(2, answerLen + 2);
                     input.setAttribute('size', size);
                     input.style.width = `${size}ch`;
                 });


### PR DESCRIPTION
## Summary
- widen the input fields for English basic theory quiz answers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a770101d8832c85d213f3bb35c3c6