### PR TITLE
Fix input widths for English quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -2065,7 +2065,7 @@
               <td>
                 <ul class="assessment-list">
                   <li class="inline-item">인지적: <input class="fit-answer" data-answer="scaffolding" aria-label="scaffolding" placeholder="정답"></li>
-                  <li class="inline-item">언어적: <input class="fit-answer" data-answer="comprehensible input" aria-label="comprehensible input" placeholder="정답"></li>
+                  <li class="inline-item">언어적: <input class="fit-answer" data-answer="comprehensible input" aria-label="comprehensible input" placeholder="정답" style="width:20ch;"></li>
                   <li class="inline-item">정의적</li>
                 </ul>
               </td>
@@ -2084,7 +2084,7 @@
                   <li class="inline-item"><input class="fit-answer" data-answer="명확한 발음" aria-label="명확한 발음" placeholder="정답"></li>
                   <li class="inline-item"><input class="fit-answer" data-answer="반복적" aria-label="반복적" placeholder="정답"></li>
                   <li class="inline-item"><input class="fit-answer" data-answer="천천히" aria-label="천천히" placeholder="정답"></li>
-                  <li class="inline-item"><input class="fit-answer" data-answer="non-verbal communication aids" aria-label="non-verbal communication aids" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="non-verbal communication aids" aria-label="non-verbal communication aids" placeholder="정답" style="width:26ch;"></li>
                 </ul>
               </td>
             </tr>
@@ -2098,14 +2098,14 @@
                 <ul class="assessment-list">
                   <li>교사가 답을 알고 있는가?
                     <ul class="sub-list">
-                      <li class="inline-item">(O): <input class="fit-answer" data-answer="display question" aria-label="display question" placeholder="정답"></li>
-                      <li class="inline-item">(X): <input class="fit-answer" data-answer="referential question" aria-label="referential question" placeholder="정답"></li>
+                      <li class="inline-item">(O): <input class="fit-answer" data-answer="display question" aria-label="display question" placeholder="정답" style="width:20ch;"></li>
+                      <li class="inline-item">(X): <input class="fit-answer" data-answer="referential question" aria-label="referential question" placeholder="정답" style="width:20ch;"></li>
                     </ul>
                   </li>
                   <li>질문의 답이 정해져 있는가?
                     <ul class="sub-list">
-                      <li class="inline-item">(O): <input class="fit-answer" data-answer="closed question" aria-label="closed question" placeholder="정답"></li>
-                      <li class="inline-item">(X): <input class="fit-answer" data-answer="open question" aria-label="open question" placeholder="정답"></li>
+                      <li class="inline-item">(O): <input class="fit-answer" data-answer="closed question" aria-label="closed question" placeholder="정답" style="width:18ch;"></li>
+                      <li class="inline-item">(X): <input class="fit-answer" data-answer="open question" aria-label="open question" placeholder="정답" style="width:18ch;"></li>
                     </ul>
                   </li>
                 </ul>
@@ -2119,7 +2119,7 @@
             <tr>
               <td>
                 <ul class="assessment-list">
-                  <li>뜻: <input class="fit-answer" data-answer="Teaching English in English" aria-label="Teaching English in English" placeholder="정답"></li>
+                  <li>뜻: <input class="fit-answer" data-answer="Teaching English in English" aria-label="Teaching English in English" placeholder="정답" style="width:26ch;"></li>
                   <li>필요성
                     <ul class="sub-list">
                       <li class="inline-item"><input class="fit-answer" data-answer="input" aria-label="input" placeholder="정답">↑</li>

--- a/styles.css
+++ b/styles.css
@@ -286,6 +286,7 @@
     td input.fit-answer {
       width: auto;
       display: inline-block;
+      min-width: 14ch;
     }
     td input:focus {
       outline: none;


### PR DESCRIPTION
## Summary
- widen `fit-answer` inputs so long answers don't cut off
- expand long English answer blanks in the basic theory section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a7d141af4832c9995652ffdfaa2c5