### PR TITLE
Adjust English input widths

### DIFF
--- a/app.js
+++ b/app.js
@@ -235,7 +235,7 @@
             document.querySelectorAll('#english-quiz-main input[data-answer]')
                 .forEach(input => {
                     const answerLen = (input.dataset.answer || '').length;
-                    const desired = Math.max(2, answerLen + 3);
+                    const desired = Math.max(2, Math.ceil(answerLen * 1.3) + 4);
                     const inlineWidth = parseInt(input.style.width) || 0;
                     const attrSize = parseInt(input.getAttribute('size')) || 0;
                     const current = Math.max(inlineWidth, attrSize);

--- a/index.html
+++ b/index.html
@@ -2065,7 +2065,7 @@
               <td>
                 <ul class="assessment-list">
                   <li class="inline-item">인지적: <input class="fit-answer" data-answer="scaffolding" aria-label="scaffolding" placeholder="정답"></li>
-                  <li class="inline-item">언어적: <input class="fit-answer" data-answer="comprehensible input" aria-label="comprehensible input" placeholder="정답" style="width:20ch;"></li>
+                  <li class="inline-item">언어적: <input class="fit-answer" data-answer="comprehensible input" aria-label="comprehensible input" placeholder="정답" style="min-width:20ch;"></li>
                   <li class="inline-item">정의적</li>
                 </ul>
               </td>
@@ -2084,7 +2084,7 @@
                   <li class="inline-item"><input class="fit-answer" data-answer="명확한 발음" aria-label="명확한 발음" placeholder="정답"></li>
                   <li class="inline-item"><input class="fit-answer" data-answer="반복적" aria-label="반복적" placeholder="정답"></li>
                   <li class="inline-item"><input class="fit-answer" data-answer="천천히" aria-label="천천히" placeholder="정답"></li>
-                  <li class="inline-item"><input class="fit-answer" data-answer="non-verbal communication aids" aria-label="non-verbal communication aids" placeholder="정답" style="width:26ch;"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="non-verbal communication aids" aria-label="non-verbal communication aids" placeholder="정답" style="min-width:26ch;"></li>
                 </ul>
               </td>
             </tr>
@@ -2098,14 +2098,14 @@
                 <ul class="assessment-list">
                   <li>교사가 답을 알고 있는가?
                     <ul class="sub-list">
-                      <li class="inline-item">(O): <input class="fit-answer" data-answer="display question" aria-label="display question" placeholder="정답" style="width:20ch;"></li>
-                      <li class="inline-item">(X): <input class="fit-answer" data-answer="referential question" aria-label="referential question" placeholder="정답" style="width:20ch;"></li>
+                      <li class="inline-item">(O): <input class="fit-answer" data-answer="display question" aria-label="display question" placeholder="정답" style="min-width:20ch;"></li>
+                      <li class="inline-item">(X): <input class="fit-answer" data-answer="referential question" aria-label="referential question" placeholder="정답" style="min-width:20ch;"></li>
                     </ul>
                   </li>
                   <li>질문의 답이 정해져 있는가?
                     <ul class="sub-list">
-                      <li class="inline-item">(O): <input class="fit-answer" data-answer="closed question" aria-label="closed question" placeholder="정답" style="width:18ch;"></li>
-                      <li class="inline-item">(X): <input class="fit-answer" data-answer="open question" aria-label="open question" placeholder="정답" style="width:18ch;"></li>
+                      <li class="inline-item">(O): <input class="fit-answer" data-answer="closed question" aria-label="closed question" placeholder="정답" style="min-width:18ch;"></li>
+                      <li class="inline-item">(X): <input class="fit-answer" data-answer="open question" aria-label="open question" placeholder="정답" style="min-width:18ch;"></li>
                     </ul>
                   </li>
                 </ul>
@@ -2119,7 +2119,7 @@
             <tr>
               <td>
                 <ul class="assessment-list">
-                  <li>뜻: <input class="fit-answer" data-answer="Teaching English in English" aria-label="Teaching English in English" placeholder="정답" style="width:26ch;"></li>
+                  <li>뜻: <input class="fit-answer" data-answer="Teaching English in English" aria-label="Teaching English in English" placeholder="정답" style="min-width:26ch;"></li>
                   <li>필요성
                     <ul class="sub-list">
                       <li class="inline-item"><input class="fit-answer" data-answer="input" aria-label="input" placeholder="정답">↑</li>
@@ -2148,11 +2148,11 @@
       <table><tbody>
         <tr>
           <td class="inline-answers">
-            <span class="inline-item"><input class="fit-answer" data-answer="Practicality" aria-label="Practicality" placeholder="정답" style="width:14ch;"></span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Reliability" aria-label="Reliability" placeholder="정답" style="width:13ch;"></span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Authenticity" aria-label="Authenticity" placeholder="정답" style="width:14ch;"></span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Validity" aria-label="Validity" placeholder="정답" style="width:10ch;"></span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Washback" aria-label="Washback" placeholder="정답" style="width:10ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Practicality" aria-label="Practicality" placeholder="정답" style="min-width:14ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Reliability" aria-label="Reliability" placeholder="정답" style="min-width:13ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Authenticity" aria-label="Authenticity" placeholder="정답" style="min-width:14ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Validity" aria-label="Validity" placeholder="정답" style="min-width:10ch;"></span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Washback" aria-label="Washback" placeholder="정답" style="min-width:10ch;"></span>
           </td>
         </tr>
       </tbody></table>
@@ -2162,10 +2162,10 @@
       <table><tbody>
         <tr>
           <td class="inline-answers">
-            <span class="inline-item"><input class="fit-answer" data-answer="Proficiency" aria-label="Proficiency" placeholder="정답" style="width:13ch;"> test</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Placement" aria-label="Placement" placeholder="정답" style="width:11ch;"> test</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답" style="width:12ch;"> test</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Achievement" aria-label="Achievement" placeholder="정답" style="width:13ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Proficiency" aria-label="Proficiency" placeholder="정답" style="min-width:13ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Placement" aria-label="Placement" placeholder="정답" style="min-width:11ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Diagnostic" aria-label="Diagnostic" placeholder="정답" style="min-width:12ch;"> test</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Achievement" aria-label="Achievement" placeholder="정답" style="min-width:13ch;"> test</span>
           </td>
         </tr>
       </tbody></table>
@@ -2175,8 +2175,8 @@
       <table><tbody>
         <tr>
           <td class="inline-answers">
-            <span class="inline-item"><input class="fit-answer" data-answer="Summative" aria-label="Summative" placeholder="정답" style="width:11ch;"> assessment</span>
-            <span class="inline-item"><input class="fit-answer" data-answer="Formative" aria-label="Formative" placeholder="정답" style="width:11ch;"> assessment</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Summative" aria-label="Summative" placeholder="정답" style="min-width:11ch;"> assessment</span>
+            <span class="inline-item"><input class="fit-answer" data-answer="Formative" aria-label="Formative" placeholder="정답" style="min-width:11ch;"> assessment</span>
           </td>
         </tr>
       </tbody></table>
@@ -2187,12 +2187,12 @@
         <tr>
           <td class="inline-answers">
             <span class="inline-item">
-              <input class="fit-answer" data-answer="Indirect" aria-label="Indirect" placeholder="정답" style="width:10ch;"> /
-              <input class="fit-answer" data-answer="Direct" aria-label="Direct" placeholder="정답" style="width:8ch;"> test
+              <input class="fit-answer" data-answer="Indirect" aria-label="Indirect" placeholder="정답" style="min-width:10ch;"> /
+              <input class="fit-answer" data-answer="Direct" aria-label="Direct" placeholder="정답" style="min-width:8ch;"> test
             </span>
             <span class="inline-item">
-              <input class="fit-answer" data-answer="Integrative" aria-label="Integrative" placeholder="정답" style="width:13ch;"> /
-              <input class="fit-answer" data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답" style="width:16ch;"> test
+              <input class="fit-answer" data-answer="Integrative" aria-label="Integrative" placeholder="정답" style="min-width:13ch;"> /
+              <input class="fit-answer" data-answer="Discrete-point" aria-label="Discrete-point" placeholder="정답" style="min-width:16ch;"> test
             </span>
           </td>
         </tr>
@@ -2205,21 +2205,21 @@
           <td>
             <ul class="assessment-list">
               <li>
-                <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="width:19ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="width:13ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="width:11ch;"> assessment</span>
+                <span class="inline-item" style="white-space: nowrap;"><input class="fit-answer" data-answer="Performance-based" aria-label="Performance-based" placeholder="정답" style="min-width:19ch;"> assessment = <input class="fit-answer" data-answer="Alternative" aria-label="Alternative" placeholder="정답" style="min-width:13ch;"> assessment = <input class="fit-answer" data-answer="Authentic" aria-label="Authentic" placeholder="정답" style="min-width:11ch;"> assessment</span>
               </li>
               <li>
                 <span class="sub-title">주체에 따른 분류</span>
                 <ul class="sub-list">
-                  <li class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="width:13ch;"></li>
-                  <li class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="width:17ch;"></li>
-                  <li class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="width:17ch;"></li>
+                  <li class="inline-item">교사: <input class="fit-answer" data-answer="Observation" aria-label="Observation" placeholder="정답" style="min-width:13ch;"></li>
+                  <li class="inline-item">나: <input class="fit-answer" data-answer="Self-assessment" aria-label="Self-assessment" placeholder="정답" style="min-width:17ch;"></li>
+                  <li class="inline-item">동료: <input class="fit-answer" data-answer="Peer-assessment" aria-label="Peer-assessment" placeholder="정답" style="min-width:17ch;"></li>
                 </ul>
               </li>
               <li>
                 <span class="sub-title">수단에 따른 분류</span>
                 <ul class="sub-list">
-                  <li class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="width:11ch;"></li>
-                  <li class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="width:11ch;"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Interview" aria-label="Interview" placeholder="정답" style="min-width:11ch;"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Portfolio" aria-label="Portfolio" placeholder="정답" style="min-width:11ch;"></li>
                 </ul>
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- tweak padding factor in `adjustEnglishInputWidths`
- allow inline inputs to grow by switching `width` to `min-width`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a7fea4858832c8b669bda4f9282af