### PR TITLE
Improve width for Korean answers in English basic

### DIFF
--- a/app.js
+++ b/app.js
@@ -232,10 +232,14 @@
        }
 
        function adjustEnglishInputWidths() {
-            document.querySelectorAll('#english-quiz-main input[data-answer]')
+            document
+                .querySelectorAll('#english-quiz-main input[data-answer]')
                 .forEach(input => {
-                    const answerLen = (input.dataset.answer || '').length;
-                    const desired = Math.max(2, Math.ceil(answerLen * 1.3) + 4);
+                    const answer = input.dataset.answer || '';
+                    const answerLen = answer.length;
+                    const hasHangul = /[\u3131-\uD79D]/.test(answer);
+                    const factor = hasHangul ? 1.8 : 1.3;
+                    const desired = Math.max(2, Math.ceil(answerLen * factor) + 4);
                     const inlineWidth = parseInt(input.style.width) || 0;
                     const attrSize = parseInt(input.getAttribute('size')) || 0;
                     const current = Math.max(inlineWidth, attrSize);


### PR DESCRIPTION
## Summary
- compute a larger width when English basic answers contain Hangul
- adjust `adjustEnglishInputWidths` to detect Hangul and use higher factor

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a82412088832c9116a76fdf1a2040