### PR TITLE
Add essay topic

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@
                 PE_BACK: 'pe-back',
                 CREATIVE: 'creative',
                 OVERVIEW: 'overview',
+                ESSAY: 'essay',
                 COMPETENCY: "competency",
                 RANDOM: 'random'
             },
@@ -40,7 +41,8 @@
                 COMPETENCY: 'competency',
                 MODEL: 'model',
                 COURSE: 'course',
-                BASIC: 'basic'
+                BASIC: 'basic',
+                ESSAY: 'essay'
             },
             MODES: {
                 NORMAL: 'normal',
@@ -514,7 +516,8 @@
                 [CONSTANTS.SUBJECTS.PE_BACK]: '체육(뒷교)',
                 [CONSTANTS.SUBJECTS.CREATIVE]: '창체',
                 [CONSTANTS.SUBJECTS.OVERVIEW]: '총론',
-                [CONSTANTS.SUBJECTS.COMPETENCY]: '역량'
+                [CONSTANTS.SUBJECTS.COMPETENCY]: '역량',
+                [CONSTANTS.SUBJECTS.ESSAY]: '논술'
             };
             headerTitle.textContent = subjectMap[gameState.selectedSubject] || '퀴즈';
            const mainEl = document.getElementById(`${gameState.selectedSubject}-quiz-main`);
@@ -807,7 +810,11 @@
             } else {
                 subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
-                gameState.selectedSubject = CONSTANTS.SUBJECTS.COMPETENCY;
+                if (topic === CONSTANTS.TOPICS.ESSAY) {
+                    gameState.selectedSubject = CONSTANTS.SUBJECTS.ESSAY;
+                } else {
+                    gameState.selectedSubject = CONSTANTS.SUBJECTS.COMPETENCY;
+                }
             }
             updateStartModalUI();
         });

--- a/index.html
+++ b/index.html
@@ -2230,6 +2230,84 @@
   </div>
 </section>
   </main>
+  <main id="essay-quiz-main" class="hidden">
+    <div class="tabs">
+      <div class="tab active" data-target="essay-intro">서론</div>
+      <div class="tab" data-target="essay-conclusion">결론</div>
+      <div class="tab" data-target="essay-markers">담화표지어</div>
+      <div class="tab" data-target="essay-arguments">논거</div>
+    </div>
+    <section id="essay-intro" class="active">
+      <h2>서론</h2>
+      <div class="grade-container">
+        <div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>(최근 초등 교육 현장에서 <input data-answer="00" aria-label="00" placeholder="정답">이가 매우 큰 화두이다.)</li>
+              <li>(왜냐하면 이는 교육의 질, 교사의 전문성, 학생의 바람직한 성장에 중요한 영향을 미치기 때문이다.)</li>
+              <li>(따라서 본고에서는 주제에 대해 논하고자 한다.)</li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+      </div>
+    </section>
+    <section id="essay-conclusion">
+      <h2>결론</h2>
+      <div class="grade-container">
+        <div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>(교사의 전문성은 교육의 질을 좌우한다.)</li>
+              <li>(따라서 교사는 연찬의 의무를 다하여 <input data-answer="00" aria-label="00" placeholder="정답">대한 연구를 지속해야 한다.)</li>
+              <li>(이러한 교사와 함께 생활하는 학생들은 미래 사회가 요구하는 핵심 역량과 바람직한 인성을 갖춘 전인적인 인물로 성장할 것이다.)</li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+      </div>
+    </section>
+    <section id="essay-markers">
+      <h2>담화표지어</h2>
+      <div class="grade-container">
+        <div>
+          <div class="grade-title">문단별</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li class="inline-item">1st: <input class="fit-answer" data-answer="먼저" aria-label="먼저" placeholder="정답"></li>
+              <li class="inline-item">2nd: <input class="fit-answer" data-answer="다음으로" aria-label="다음으로" placeholder="정답"></li>
+              <li class="inline-item">if): <input class="fit-answer" data-answer="더불어" aria-label="더불어" placeholder="정답"></li>
+              <li class="inline-item">3rd: <input class="fit-answer" data-answer="마지막으로" aria-label="마지막으로" placeholder="정답"></li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+        <div>
+          <div class="grade-title">문단 내 예시</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li class="inline-item">(논점1)에서 <input class="fit-answer" data-answer="00" aria-label="00" placeholder="정답">은 다음과 같다.</li>
+              <li class="inline-item">(이어서), <input class="fit-answer" data-answer="00" aria-label="00" placeholder="정답">은 다음과 같다.</li>
+              <li class="inline-item">(아울러), <input class="fit-answer" data-answer="00" aria-label="00" placeholder="정답"> 다음과 같다.</li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+      </div>
+    </section>
+    <section id="essay-arguments">
+      <h2>논거</h2>
+      <div class="grade-container">
+        <div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="인용" aria-label="인용" placeholder="정답"> - (이는 "<input data-answer="" aria-label="" placeholder="정답">"라는 김 교사의 말에서 알 수 있다.)</li>
+              <li class="inline-item"><input class="fit-answer" data-answer="방법" aria-label="방법" placeholder="정답">- (~함으로써 ~할 수 있다.)</li>
+              <li class="inline-item"><input class="fit-answer" data-answer="효과" aria-label="효과" placeholder="정답"> - (이를 통해 ~한 효과를 얻을 수 있다.)</li>
+              <li class="inline-item"><input class="fit-answer" data-answer="정의" aria-label="정의" placeholder="정답"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="이유" aria-label="이유" placeholder="정답"> - (왜냐하면 ~기 때문이다.)</li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+      </div>
+    </section>
+  </main>
 <!-- competency main start -->
 <main id="competency-quiz-main" class="hidden competency-ui">
   <div class="competency-tab-wrapper">
@@ -2406,6 +2484,7 @@
                 <button class="btn topic-btn" data-topic="model">모형</button>
                 <button class="btn topic-btn" data-topic="course">교육과정</button>
                 <button class="btn topic-btn" data-topic="basic">기본이론</button>
+                <button class="btn topic-btn" data-topic="essay">논술</button>
             </div>
             <h2>과목 선택</h2>
             <div class="subject-selector">


### PR DESCRIPTION
## Summary
- add a new topic button for 논술
- support 'essay' topic and subject in the JS logic
- implement the essay quiz section in the HTML

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687aa25daa98832cae1e674a4efe01d5