### PR TITLE
Add check for quiz element

### DIFF
--- a/app.js
+++ b/app.js
@@ -521,6 +521,10 @@
             };
             headerTitle.textContent = subjectMap[gameState.selectedSubject] || '퀴즈';
            const mainEl = document.getElementById(`${gameState.selectedSubject}-quiz-main`);
+           if (!mainEl) {
+               console.error(`Element #${gameState.selectedSubject}-quiz-main not found`);
+               return;
+           }
            mainEl.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
            resetToFirstStage(gameState.selectedSubject);
 


### PR DESCRIPTION
## Summary
- verify the quiz main element exists when starting the game
- log an error and return early if the element cannot be found

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687afd3d3b24832c95c9ac5a3e2c2815