### PR TITLE
Improve essay input sizing

### DIFF
--- a/app.js
+++ b/app.js
@@ -259,8 +259,8 @@
                     const answer = input.dataset.answer || '';
                     const answerLen = answer.length;
                     const hasHangul = /[\u3131-\uD79D]/.test(answer);
-                    const factor = hasHangul ? 1.2 : 1.1;
-                    const desired = Math.max(2, Math.ceil(answerLen * factor) + 2);
+                    const factor = hasHangul ? 1.8 : 1.3;
+                    const desired = Math.max(2, Math.ceil(answerLen * factor) + 4);
                     const inlineWidth = parseInt(input.style.width) || 0;
                     const attrSize = parseInt(input.getAttribute('size')) || 0;
                     const current = Math.max(inlineWidth, attrSize);

--- a/styles.css
+++ b/styles.css
@@ -286,7 +286,7 @@
     td input.fit-answer {
       width: auto;
       display: inline-block;
-      min-width: 14ch;
+      min-width: 18ch;
     }
     td input:focus {
       outline: none;


### PR DESCRIPTION
## Summary
- bump `.fit-answer` minimum width
- increase dynamic sizing for essay blanks

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b387f9be8832c9ee3549229244c60