### PR TITLE
Fix essay blank width

### DIFF
--- a/app.js
+++ b/app.js
@@ -259,8 +259,8 @@
                     const answer = input.dataset.answer || '';
                     const answerLen = answer.length;
                     const hasHangul = /[\u3131-\uD79D]/.test(answer);
-                    const factor = hasHangul ? 1.2 : 1.1;
-                    const desired = Math.max(2, Math.ceil(answerLen * factor) + 2);
+                    const factor = hasHangul ? 1.8 : 1.3;
+                    const desired = Math.max(2, Math.ceil(answerLen * factor) + 4);
                     const inlineWidth = parseInt(input.style.width) || 0;
                     const attrSize = parseInt(input.getAttribute('size')) || 0;
                     const current = Math.max(inlineWidth, attrSize);


### PR DESCRIPTION
## Summary
- tweak essay answer width calculation to reserve extra space

## Testing
- `npm run lint` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687b3a2e3738832caac79f7ab7999404