### PR TITLE
Improve essay blank widths

### DIFF
--- a/app.js
+++ b/app.js
@@ -259,8 +259,8 @@
                     const answer = input.dataset.answer || '';
                     const answerLen = answer.length;
                     const hasHangul = /[\u3131-\uD79D]/.test(answer);
-                    const factor = hasHangul ? 1.8 : 1.3;
-                    const desired = Math.max(2, Math.ceil(answerLen * factor) + 4);
+                    const factor = hasHangul ? 2.0 : 1.4;
+                    const desired = Math.max(2, Math.ceil(answerLen * factor) + 6);
                     const inlineWidth = parseInt(input.style.width) || 0;
                     const attrSize = parseInt(input.getAttribute('size')) || 0;
                     const current = Math.max(inlineWidth, attrSize);

--- a/styles.css
+++ b/styles.css
@@ -945,6 +945,14 @@ td input.activity-input:not(:first-child) {
   width: auto;
 }
 
+/* Ensure essay inputs resemble English blanks */
+#essay-quiz-main input.fit-answer {
+  width: auto;
+  display: inline-block;
+  min-width: 16ch;
+  margin: 0 0.4rem;
+}
+
 .inline-answers {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- expand essay input width calculation for better fit
- style essay blanks like English ones

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b3c1113a4832c973fb3cd8efacf54