### PR TITLE
Fix essay input overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -978,6 +978,12 @@ td input.activity-input:not(:first-child) {
   gap: 1rem;
 }
 
+/* Prevent long essay answers from overflowing */
+#essay-quiz-main .assessment-list .fit-answer {
+  width: 100%;
+  max-width: 100%;
+}
+
 .sub-list {
   list-style-type: circle;
   margin-left: 2rem;


### PR DESCRIPTION
## Summary
- prevent essay `fit-answer` inputs from overflowing the block

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b5614c040832c9df07737aecef4c3