### PR TITLE
Add detailed language acquisition theory quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -2021,9 +2021,113 @@
     </div>
     <section id="acquisition" class="active">
       <h2>언어 습득 이론</h2>
-      <div class="grade-container"><div><table><tbody>
-        <tr><th>개념</th><td><input data-answer="언어 습득 이론" aria-label="언어 습득 이론" placeholder="정답"></td></tr>
-      </tbody></table></div></div>
+      <div class="grade-container">
+        <div>
+          <div class="grade-title">모국어</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>Behaviorism
+                <ul class="sub-list">
+                  <li class="inline-item">인간 = <input class="fit-answer" data-answer="tabula rasa" aria-label="tabula rasa" placeholder="정답"></li>
+                  <li class="inline-item">과정: 1st <input class="fit-answer" data-answer="stimulus" aria-label="stimulus" placeholder="정답"> → 2nd <input class="fit-answer" data-answer="response" aria-label="response" placeholder="정답"> → 3rd <input class="fit-answer" data-answer="reinforcement" aria-label="reinforcement" placeholder="정답"> → <input class="fit-answer" data-answer="habit formation" aria-label="habit formation" placeholder="정답"> / <input class="fit-answer" data-answer="conditioning" aria-label="conditioning" placeholder="정답"></li>
+                  <li class="inline-item">습관형성 원인: <input class="fit-answer" data-answer="mimicry" aria-label="mimicry" placeholder="정답">, <input class="fit-answer" data-answer="imitation" aria-label="imitation" placeholder="정답">과 <input class="fit-answer" data-answer="repetition" aria-label="repetition" placeholder="정답"></li>
+                  <li class="inline-item">지도 방법: <input class="fit-answer" data-answer="drill" aria-label="drill" placeholder="정답"></li>
+                  <li class="inline-item">교수법: <input class="fit-answer" data-answer="ALM" aria-label="ALM" placeholder="정답"></li>
+                </ul>
+              </li>
+              <li>Nativism/Innatism
+                <ul class="sub-list">
+                  <li class="inline-item">input → <input class="fit-answer" data-answer="LAD" aria-label="LAD" placeholder="정답"> = <input class="fit-answer" data-answer="Language Acquisition Device" aria-label="Language Acquisition Device" placeholder="정답"> → output</li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="자연적, 무의식적" aria-label="자연적, 무의식적" placeholder="정답">으로 <input class="fit-answer" data-answer="규칙 내면화" aria-label="규칙 내면화" placeholder="정답"></li>
+                  <li class="inline-item">output: <input class="fit-answer" data-answer="무한한 발화" aria-label="무한한 발화" placeholder="정답"></li>
+                </ul>
+              </li>
+              <li>Constructivism/Functional Approach
+                <ul class="sub-list">
+                  <li class="inline-item">k: <input class="fit-answer" data-answer="interaction" aria-label="interaction" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="student" aria-label="student" placeholder="정답">-centered</li>
+                  <li class="inline-item">Not <input class="fit-answer" data-answer="form" aria-label="form" placeholder="정답"> But <input class="fit-answer" data-answer="function" aria-label="function" placeholder="정답"></li>
+                  <li class="inline-item">교수법: 의사소통적 교수법</li>
+                </ul>
+              </li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+        <div>
+          <div class="grade-title">제2언어</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li><input class="fit-answer" data-answer="Five" aria-label="Five" placeholder="정답"> Hypotheses, Krashen
+                <ul class="sub-list">
+                  <li>1. <input class="fit-answer" data-answer="Acquisition-Learning Hypothesis" aria-label="Acquisition-Learning Hypothesis" placeholder="정답">
+                    <ul class="sub-list">
+                      <li class="inline-item">acquisition: natural communication, subconscious, implicit knowledge</li>
+                      <li class="inline-item">learning: formal teaching, conscious, explicit knowledge</li>
+                      <li class="inline-item">서로 관계: <input class="fit-answer" data-answer="no-interface" aria-label="no-interface" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Monitor" aria-label="Monitor" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Input" aria-label="Input" placeholder="정답">
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="comprehensible" aria-label="comprehensible" placeholder="정답"> input</li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="silent period" aria-label="silent period" placeholder="정답">: 자연스럽게 나타나는 것. 발화 강요 X</li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="modified" aria-label="modified" placeholder="정답"> input
+                        <ul class="sub-list">
+                          <li class="inline-item"><input class="fit-answer" data-answer="syntactic" aria-label="syntactic" placeholder="정답"> modification</li>
+                          <li class="inline-item"><input class="fit-answer" data-answer="lexical" aria-label="lexical" placeholder="정답"> modification</li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Affective Filter" aria-label="Affective Filter" placeholder="정답">
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="motivation" aria-label="motivation" placeholder="정답">, <input class="fit-answer" data-answer="confidence" aria-label="confidence" placeholder="정답">, <input class="fit-answer" data-answer="anxiety" aria-label="anxiety" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="Natural Order" aria-label="Natural Order" placeholder="정답"></li>
+                </ul>
+              </li>
+              <li><input class="fit-answer" data-answer="Output" aria-label="Output" placeholder="정답"> Hypothesis, Swain
+                <ul class="sub-list">
+                  <li class="inline-item">input = <input class="fit-answer" data-answer="semantic" aria-label="semantic" placeholder="정답"> processing</li>
+                  <li class="inline-item">output = <input class="fit-answer" data-answer="syntactic" aria-label="syntactic" placeholder="정답"> processing</li>
+                  <li class="inline-item">k: <input class="fit-answer" data-answer="pushed output" aria-label="pushed output" placeholder="정답"> = <input class="fit-answer" data-answer="modified comprehensible output" aria-label="modified comprehensible output" placeholder="정답">
+                    <ul class="sub-list">
+                      <li class="inline-item">기능: <input class="fit-answer" data-answer="noticing" aria-label="noticing" placeholder="정답"> function, <input class="fit-answer" data-answer="hypothesis-testing" aria-label="hypothesis-testing" placeholder="정답"> function, <input class="fit-answer" data-answer="metalinguistic" aria-label="metalinguistic" placeholder="정답"> function</li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+              <li><input class="fit-answer" data-answer="Interaction" aria-label="Interaction" placeholder="정답"> Hypothesis, Long
+                <ul class="sub-list">
+                  <li class="inline-item"><input class="fit-answer" data-answer="meaning negotiation" aria-label="meaning negotiation" placeholder="정답">
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="comprehension check" aria-label="comprehension check" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="confirmation check" aria-label="confirmation check" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="clarification request" aria-label="clarification request" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="modified" aria-label="modified" placeholder="정답"> input vs <input class="fit-answer" data-answer="unmodified" aria-label="unmodified" placeholder="정답"> input
+                    <ul class="sub-list">
+                      <li class="inline-item">premodified input</li>
+                      <li class="inline-item">interactionally modified input</li>
+                    </ul>
+                  </li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="modified" aria-label="modified" placeholder="정답"> output</li>
+                </ul>
+              </li>
+              <li>Sociocultural Theory (Vygotsky)
+                <ul class="sub-list">
+                  <li class="inline-item"><input class="fit-answer" data-answer="social interaction" aria-label="social interaction" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="zone of proximal development" aria-label="zone of proximal development" placeholder="정답"></li>
+                  <li class="inline-item">⇒ <input class="fit-answer" data-answer="actual developmental level" aria-label="actual developmental level" placeholder="정답"> ~ <input class="fit-answer" data-answer="potential developmental level" aria-label="potential developmental level" placeholder="정답"></li>
+                  <li class="inline-item">도구: <input class="fit-answer" data-answer="scaffolding" aria-label="scaffolding" placeholder="정답"></li>
+                </ul>
+              </li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+      </div>
     </section>
     <section id="methodology">
       <h2>영어 교수법</h2>


### PR DESCRIPTION
## Summary
- expand English `언어 습득 이론` section with behaviorism, nativism, constructivism
- include second language hypotheses such as Krashen's Five Hypotheses and others
- keep ESLint passing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b5f20f52c832cb76dbb73c7e45c83