### PR TITLE
Fix English acquisition block layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -962,6 +962,15 @@ td input.activity-input:not(:first-child) {
   width: 100%;
 }
 
+/* Arrange English acquisition blocks vertically */
+#english-quiz-main #acquisition .grade-container {
+  flex-direction: column;
+}
+#english-quiz-main #acquisition .grade-container > div {
+  flex: none;
+  width: 100%;
+}
+
 .inline-answers {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- ensure English acquisition section stacks vertically on large screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b60c0679c832cac8579efc64e4103