### PR TITLE
Fix English course note formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -2109,8 +2109,8 @@
                   </li>
                   <li class="inline-item"><input class="fit-answer" data-answer="modified" aria-label="modified" placeholder="정답"> input vs <input class="fit-answer" data-answer="unmodified" aria-label="unmodified" placeholder="정답"> input
                     <ul class="sub-list">
-                      <li class="inline-item">premodified input</li>
-                      <li class="inline-item">interactionally modified input</li>
+                      <li class="inline-item">(premodified) input</li>
+                      <li class="inline-item">(interactionally modified) input</li>
                     </ul>
                   </li>
                   <li class="inline-item"><input class="fit-answer" data-answer="modified" aria-label="modified" placeholder="정답"> output</li>


### PR DESCRIPTION
## Summary
- add missing parentheses around input categories in *index.html*

## Testing
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b6456e050832c93da6fc66e5fb91b