### PR TITLE
Improve English quiz blank layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -937,6 +937,7 @@ td input.activity-input:not(:first-child) {
 
 .inline-item {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
 }
@@ -969,6 +970,12 @@ td input.activity-input:not(:first-child) {
 #english-quiz-main #acquisition .grade-container > div {
   flex: none;
   width: 100%;
+}
+
+/* Prevent long answers from overflowing in English quizzes */
+#english-quiz-main input.fit-answer {
+  width: 100%;
+  max-width: 100%;
 }
 
 .inline-answers {


### PR DESCRIPTION
## Summary
- allow wrapping of inline assessment items
- keep English quiz answer inputs within their blocks

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b634b37b0832cb3862b65b59b0e12