### PR TITLE
Improve English subject hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ This command will analyze JavaScript and HTML files using the configuration prov
 ## Visual Styles
 
 Additional CSS rules refine the nested list appearance within the English quiz section. Third and fourth list levels now have larger left margins and unique bullet styles to make the hierarchy clearer.
+Dividing lines have been added to the English quiz lists so each level is visibly separated.

--- a/styles.css
+++ b/styles.css
@@ -1012,6 +1012,18 @@ td input.activity-input:not(:first-child) {
   list-style-type: disc;
 }
 
+/* Visual separators for English quiz hierarchy */
+#english-quiz-main .assessment-list > li:not(:last-child) {
+  border-bottom: 2px solid var(--secondary);
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
+}
+
+#english-quiz-main .sub-list {
+  border-left: 2px dashed var(--secondary);
+  padding-left: 1rem;
+}
+
 /* Creative subject readability tweaks */
 #creative-quiz-main .creative-block {
   margin-bottom: 2rem;


### PR DESCRIPTION
## Summary
- add dividing lines for the English quiz lists
- document list separators in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b6c65300c832c81f70c182f3a58a1