### PR TITLE
Fix blanks and wrapping in English acquisition section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2061,21 +2061,21 @@
                 <ul class="sub-list">
                   <li>1. <input class="fit-answer" data-answer="Acquisition-Learning Hypothesis" aria-label="Acquisition-Learning Hypothesis" placeholder="정답">
                     <ul class="sub-list">
-                        <li class="inline-item">(acquisition)
+                        <li class="inline-item"><input class="fit-answer" data-answer="acquisition" aria-label="acquisition" placeholder="정답"><br>
                           <ul class="sub-list">
-                            <li class="inline-item">(natural communication)</li>
-                            <li class="inline-item">(subconscious)</li>
-                            <li class="inline-item">(implicit knowledge)</li>
+                            <li class="inline-item"><input class="fit-answer" data-answer="natural communication" aria-label="natural communication" placeholder="정답"></li>
+                            <li class="inline-item"><input class="fit-answer" data-answer="subconscious" aria-label="subconscious" placeholder="정답"></li>
+                            <li class="inline-item"><input class="fit-answer" data-answer="implicit knowledge" aria-label="implicit knowledge" placeholder="정답"></li>
                           </ul>
                         </li>
-                        <li class="inline-item">(learning)
+                        <li class="inline-item"><input class="fit-answer" data-answer="learning" aria-label="learning" placeholder="정답"><br>
                           <ul class="sub-list">
-                            <li class="inline-item">(formal teaching)</li>
-                            <li class="inline-item">(conscious)</li>
-                            <li class="inline-item">(explicit knowledge)</li>
+                            <li class="inline-item"><input class="fit-answer" data-answer="formal teaching" aria-label="formal teaching" placeholder="정답"></li>
+                            <li class="inline-item"><input class="fit-answer" data-answer="conscious" aria-label="conscious" placeholder="정답"></li>
+                            <li class="inline-item"><input class="fit-answer" data-answer="explicit knowledge" aria-label="explicit knowledge" placeholder="정답"></li>
                           </ul>
                         </li>
-                        <li class="inline-item">서로 관계: (no-interface)</li>
+                        <li class="inline-item">서로 관계: <input class="fit-answer" data-answer="no-interface" aria-label="no-interface" placeholder="정답"></li>
                     </ul>
                   </li>
                   <li class="inline-item"><input class="fit-answer" data-answer="Monitor" aria-label="Monitor" placeholder="정답"></li>
@@ -2121,8 +2121,8 @@
                   </li>
                   <li class="inline-item"><input class="fit-answer" data-answer="modified" aria-label="modified" placeholder="정답"> input vs <input class="fit-answer" data-answer="unmodified" aria-label="unmodified" placeholder="정답"> input
                     <ul class="sub-list">
-                      <li class="inline-item">(premodified) input</li>
-                      <li class="inline-item">(interactionally modified) input</li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="premodified" aria-label="premodified" placeholder="정답"> input</li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="interactionally modified" aria-label="interactionally modified" placeholder="정답"> input</li>
                     </ul>
                   </li>
                   <li class="inline-item"><input class="fit-answer" data-answer="modified" aria-label="modified" placeholder="정답"> output</li>

--- a/styles.css
+++ b/styles.css
@@ -939,6 +939,7 @@ td input.activity-input:not(:first-child) {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
 }
 .inline-item input {
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary
- add missing blank inputs for English acquisition theory questions
- allow input items to wrap within list items

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b6f52ff88832c8fff7bffa21fca97