### PR TITLE
Add activity-based English section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2354,9 +2354,85 @@
     </section>
     <section id="activity">
       <h2>활동중심수업</h2>
-      <div class="grade-container"><div><table><tbody>
-        <tr><th>개념</th><td><input data-answer="활동중심수업" aria-label="활동중심수업" placeholder="정답"></td></tr>
-      </tbody></table></div></div>
+      <div class="grade-container">
+        <div>
+          <div class="grade-title">Chant &amp; Song</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li class="inline-item">효과: <input class="fit-answer" data-answer="초분절 음소" aria-label="초분절 음소" placeholder="정답"> 지도에 용이</li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+        <div>
+          <div class="grade-title">Game</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>유용성
+                <ul class="sub-list">
+                  <li class="inline-item"><input class="fit-answer" data-answer="authenticity" aria-label="authenticity" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="정의적 이유" aria-label="정의적 이유" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="비예측성" aria-label="비예측성" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="연습 효과" aria-label="연습 효과" placeholder="정답"></li>
+                </ul>
+              </li>
+              <li class="inline-item">선정기준: <input class="fit-answer" data-answer="학습 목표" aria-label="학습 목표" placeholder="정답">에 부합, <input class="fit-answer" data-answer="경쟁" aria-label="경쟁" placeholder="정답">보다는 <input class="fit-answer" data-answer="협동" aria-label="협동" placeholder="정답"></li>
+              <li>분류
+                <ul class="sub-list">
+                  <li class="inline-item"><input class="fit-answer" data-answer="acuracy-focused" aria-label="acuracy-focused" placeholder="정답"> → <input class="fit-answer" data-answer="language drills" aria-label="language drills" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="fluency-focused" aria-label="fluency-focused" placeholder="정답"> → <input class="fit-answer" data-answer="extralinguisic objective" aria-label="extralinguisic objective" placeholder="정답">, <input class="fit-answer" data-answer="information gap" aria-label="information gap" placeholder="정답"></li>
+                </ul>
+              </li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+        <div>
+          <div class="grade-title">Storytelling</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>story 선정 시
+                <ul class="sub-list">
+                  <li class="inline-item">refrain -&gt; choral speaking</li>
+                  <li class="inline-item">rhyme</li>
+                </ul>
+              </li>
+              <li>수업 적용 시
+                <ul class="sub-list">
+                  <li class="inline-item">다양한 <input class="fit-answer" data-answer="목소리" aria-label="목소리" placeholder="정답">, <input class="fit-answer" data-answer="몸동작" aria-label="몸동작" placeholder="정답">, <input class="fit-answer" data-answer="손동작" aria-label="손동작" placeholder="정답"> 필요</li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="시각적 단서" aria-label="시각적 단서" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="TPR 스토리텔링" aria-label="TPR 스토리텔링" placeholder="정답"></li>
+                </ul>
+              </li>
+              <li>장점
+                <ul class="sub-list">
+                  <li class="inline-item"><input class="fit-answer" data-answer="context" aria-label="context" placeholder="정답"> -&gt; 모르는 단어의 의미를 추론</li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="comprehensible input" aria-label="comprehensible input" placeholder="정답"> 제공</li>
+                  <li class="inline-item">언어 형태 무의식적 습득: <input class="fit-answer" data-answer="의미 이해" aria-label="의미 이해" placeholder="정답">에 집중</li>
+                </ul>
+              </li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+        <div>
+          <div class="grade-title">교실 드라마</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>Role-play
+                <ul class="sub-list">
+                  <li class="inline-item">구성요소: <input class="fit-answer" data-answer="situation" aria-label="situation" placeholder="정답">, <input class="fit-answer" data-answer="role" aria-label="role" placeholder="정답">, <input class="fit-answer" data-answer="useful expression" aria-label="useful expression" placeholder="정답"></li>
+                  <li class="inline-item">장점: <input class="fit-answer" data-answer="turn-taking" aria-label="turn-taking" placeholder="정답"> 기능을 익힘</li>
+                  <li class="inline-item">방법: <input class="fit-answer" data-answer="대본" aria-label="대본" placeholder="정답"> 유무</li>
+                </ul>
+              </li>
+              <li>readers' theater
+                <ul class="sub-list">
+                  <li class="inline-item">뜻: 암기할 필요 없이 대본을 읽으면서 연기</li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="reapeated reading" aria-label="reapeated reading" placeholder="정답"> → <input class="fit-answer" data-answer="reading fluency" aria-label="reading fluency" placeholder="정답"></li>
+                </ul>
+              </li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+      </div>
     </section>
     <section id="teacher-talk">
       <h2>교사언어</h2>


### PR DESCRIPTION
## Summary
- expand the English '활동중심수업' area with chant, game, storytelling and drama content

## Testing
- `npm run lint` *(fails: npm registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687b7e4430d0832c926ba957cbde43e1