### PR TITLE
Arrange topic buttons in grid

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -486,6 +486,15 @@ td input.activity-input:not(:first-child) {
         margin: 2rem 0;
         flex-wrap: wrap;
     }
+
+    /* Arrange topic buttons in two rows with three per row */
+    .topic-selector {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .topic-btn {
+        width: 100%;
+    }
     #time-setting-display {
         font-family: 'Source Code Pro', monospace;
         font-size: 3rem;


### PR DESCRIPTION
## Summary
- adjust styles so that topic buttons are arranged in a 3-column grid

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b8cff7404832c94c8fe486557bb6a