### PR TITLE
Adjust essay layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2644,32 +2644,34 @@
             </tr>
           </tbody></table>
         </div>
-        <div>
-          <div class="grade-title">문단별 담화표지어</div>
-          <table><tbody>
-            <tr>
-              <td class="inline-answers">
-                <span class="inline-item">1st: <input class="fit-answer" data-answer="먼저" aria-label="먼저" placeholder="정답"></span>
-                <span class="inline-item">2nd: <input class="fit-answer" data-answer="다음으로" aria-label="다음으로" placeholder="정답"></span>
-                <span class="inline-item">if: <input class="fit-answer" data-answer="더불어" aria-label="더불어" placeholder="정답"></span>
-                <span class="inline-item">3rd: <input class="fit-answer" data-answer="마지막으로" aria-label="마지막으로" placeholder="정답"></span>
-              </td>
-            </tr>
-          </tbody></table>
-        </div>
-        <div>
-          <div class="grade-title">문단내 담화표지어</div>
-          <table><tbody>
-            <tr>
-              <td>
-                <ul class="assessment-list">
-                  <li><input class="fit-answer" data-answer="논점1" aria-label="논점1" placeholder="정답">에서 ~는 다음과 같다.</li>
-                  <li><input class="fit-answer" data-answer="이어서" aria-label="이어서" placeholder="정답">, ~는 다음과 같다.</li>
-                  <li><input class="fit-answer" data-answer="아울러" aria-label="아울러" placeholder="정답">, ~는 다음과 같다.</li>
-                </ul>
-              </td>
-            </tr>
-          </tbody></table>
+        <div class="discourse-pair">
+          <div>
+            <div class="grade-title">문단별 담화표지어</div>
+            <table><tbody>
+              <tr>
+                <td class="inline-answers">
+                  <span class="inline-item">1st: <input class="fit-answer" data-answer="먼저" aria-label="먼저" placeholder="정답"></span>
+                  <span class="inline-item">2nd: <input class="fit-answer" data-answer="다음으로" aria-label="다음으로" placeholder="정답"></span>
+                  <span class="inline-item">if: <input class="fit-answer" data-answer="더불어" aria-label="더불어" placeholder="정답"></span>
+                  <span class="inline-item">3rd: <input class="fit-answer" data-answer="마지막으로" aria-label="마지막으로" placeholder="정답"></span>
+                </td>
+              </tr>
+            </tbody></table>
+          </div>
+          <div>
+            <div class="grade-title">문단내 담화표지어</div>
+            <table><tbody>
+              <tr>
+                <td>
+                  <ul class="assessment-list">
+                    <li><input class="fit-answer" data-answer="논점1" aria-label="논점1" placeholder="정답">에서 ~는 다음과 같다.</li>
+                    <li><input class="fit-answer" data-answer="이어서" aria-label="이어서" placeholder="정답">, ~는 다음과 같다.</li>
+                    <li><input class="fit-answer" data-answer="아울러" aria-label="아울러" placeholder="정답">, ~는 다음과 같다.</li>
+                  </ul>
+                </td>
+              </tr>
+            </tbody></table>
+          </div>
         </div>
         <div>
           <div class="grade-title">논거</div>

--- a/styles.css
+++ b/styles.css
@@ -972,6 +972,21 @@ td input.activity-input:not(:first-child) {
   width: 100%;
 }
 
+/* Display discourse marker sections side by side */
+#essay-quiz-main .discourse-pair {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+}
+#essay-quiz-main .discourse-pair > div {
+  flex: 1;
+  min-width: 320px;
+  background: var(--bg-light);
+  border: 3px solid var(--primary);
+  padding: 2rem;
+  border-radius: 12px;
+}
+
 /* Arrange English acquisition blocks vertically */
 #english-quiz-main #acquisition .grade-container {
   flex-direction: column;


### PR DESCRIPTION
## Summary
- group discourse marker sections in the essay topic
- add CSS to arrange the pair side by side

## Testing
- `apt-get update` *(fails: repository not signed)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb3d7d8c8832cb8600d53a0337101