### PR TITLE
Remove background from essay discourse blocks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -981,10 +981,7 @@ td input.activity-input:not(:first-child) {
 #essay-quiz-main .discourse-pair > div {
   flex: 1;
   min-width: 320px;
-  background: var(--bg-light);
-  border: 3px solid var(--primary);
   padding: 2rem;
-  border-radius: 12px;
 }
 
 /* Arrange English acquisition blocks vertically */


### PR DESCRIPTION
## Summary
- remove background and border from the '문단별/문단내 담화표지어' blocks

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb5ef298c832ca39371d1c7605606