### PR TITLE
Match integrated course styling to overview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1054,7 +1054,8 @@ td input.activity-input:not(:first-child) {
   border: 2px solid var(--secondary);
   border-radius: 8px;
 }
-#overview-quiz-main .creative-block {
+#overview-quiz-main .creative-block,
+#integrated-course-quiz-main .creative-block {
   margin-bottom: 2rem;
   padding: 1rem;
   background: var(--bg-light);
@@ -1067,13 +1068,15 @@ td input.activity-input:not(:first-child) {
   margin-bottom: 1rem;
   color: var(--primary);
 }
-#overview-quiz-main .outline-title {
+#overview-quiz-main .outline-title,
+#integrated-course-quiz-main .outline-title {
   font-size: 2rem;
   font-weight: 700;
   margin-bottom: 1rem;
   color: var(--primary);
 }
-#overview-quiz-main .sub-title {
+#overview-quiz-main .sub-title,
+#integrated-course-quiz-main .sub-title {
   font-size: 1.8rem;
   font-weight: 600;
   margin: 1rem 0;
@@ -1088,7 +1091,8 @@ td input.activity-input:not(:first-child) {
   border-bottom: 2px dashed var(--secondary);
   margin-bottom: 3rem; /* extra spacing between questions */
 }
-#overview-quiz-main .overview-question {
+#overview-quiz-main .overview-question,
+#integrated-course-quiz-main .overview-question {
   display: block;
   line-height: 1.8;
   font-size: 2rem;
@@ -1100,7 +1104,8 @@ td input.activity-input:not(:first-child) {
 #creative-quiz-main .creative-question:last-child {
   border-bottom: none;
 }
-#overview-quiz-main .overview-question:last-child {
+#overview-quiz-main .overview-question:last-child,
+#integrated-course-quiz-main .overview-question:last-child {
   border-bottom: none;
 }
 #creative-quiz-main .creative-question input {
@@ -1114,7 +1119,8 @@ td input.activity-input:not(:first-child) {
   text-align: center;
   width: auto;
 }
-#overview-quiz-main .overview-question input {
+#overview-quiz-main .overview-question input,
+#integrated-course-quiz-main .overview-question input {
   font-size: 2rem;
   padding: 0.2rem 0.4rem;
   margin: 0 0.4rem;
@@ -1130,7 +1136,8 @@ td input.activity-input:not(:first-child) {
   outline: none;
   border-color: var(--primary);
 }
-#overview-quiz-main .overview-question input:focus {
+#overview-quiz-main .overview-question input:focus,
+#integrated-course-quiz-main .overview-question input:focus {
   outline: none;
   border-color: var(--primary);
 }
@@ -1139,7 +1146,8 @@ td input.activity-input:not(:first-child) {
   border-color: var(--correct);
   color: var(--correct);
 }
-#overview-quiz-main .overview-question input.correct {
+#overview-quiz-main .overview-question input.correct,
+#integrated-course-quiz-main .overview-question input.correct {
   border-color: var(--correct);
   color: var(--correct);
 }
@@ -1148,7 +1156,8 @@ td input.activity-input:not(:first-child) {
   border-color: var(--incorrect);
   color: var(--incorrect);
 }
-#overview-quiz-main .overview-question input.incorrect {
+#overview-quiz-main .overview-question input.incorrect,
+#integrated-course-quiz-main .overview-question input.incorrect {
   border-color: var(--incorrect);
   color: var(--incorrect);
 }
@@ -1157,7 +1166,8 @@ td input.activity-input:not(:first-child) {
   border-color: var(--retrying);
   color: var(--retrying);
 }
-#overview-quiz-main .overview-question input.retrying {
+#overview-quiz-main .overview-question input.retrying,
+#integrated-course-quiz-main .overview-question input.retrying {
   border-color: var(--retrying);
   color: var(--retrying);
 }
@@ -1166,7 +1176,8 @@ td input.activity-input:not(:first-child) {
   color: var(--revealed);
   border-color: var(--revealed);
 }
-#overview-quiz-main .overview-question input.revealed {
+#overview-quiz-main .overview-question input.revealed,
+#integrated-course-quiz-main .overview-question input.revealed {
   color: var(--revealed);
   border-color: var(--revealed);
 }


### PR DESCRIPTION
## Summary
- extend overview UI styles to cover the integrated course subject

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bc07710a4832cb207d7c33b28077e