### PR TITLE
Update default timer to 15 minutes

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@
                 LOST: 'lost',
                 COMBO_POP: 'combo-pop'
             },
-            DEFAULT_DURATION: 600,
+            DEFAULT_DURATION: 900,
             HARD_CORE_DURATION: 60,
             HARD_CORE_LIVES: Infinity,
             HARD_CORE_TIME_BONUS: 5,

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             <span class="heart-icon">♥</span>
         </div>
         <div id="timer-container" class="kitsch-box hidden">
-            <div id="time">10:00</div>
+            <div id="time">15:00</div>
             <div id="bar"><div></div></div>
         </div>
     </div>
@@ -2923,7 +2923,7 @@
                 <h2>제한 시간 선택</h2>
                 <div class="time-setter">
                     <button id="decrease-time" class="btn time-control-btn">-</button>
-                    <div id="time-setting-display">10:00</div>
+                    <div id="time-setting-display">15:00</div>
                     <button id="increase-time" class="btn time-control-btn">+</button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- update default timer from 10:00 to 15:00 in the UI
- set `DEFAULT_DURATION` constant to 15 minutes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cf790855c832c82ee08726e6b2e91