### PR TITLE
Fix creative input width

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,9 +228,18 @@
        function adjustCreativeInputWidths() {
             document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer]')
                 .forEach(input => {
-                    const answerLen = (input.dataset.answer || '').length;
-                    const size = Math.max(2, answerLen + 1);
-                    input.setAttribute('size', size);
+                    const answer = input.dataset.answer || '';
+                    const answerLen = answer.length;
+                    const hasHangul = /[\u3131-\uD79D]/.test(answer);
+                    const factor = hasHangul ? 1.8 : 1.3;
+                    const desired = Math.max(2, Math.ceil(answerLen * factor) + 4);
+                    const inlineWidth = parseInt(input.style.width) || 0;
+                    const attrSize = parseInt(input.getAttribute('size')) || 0;
+                    const current = Math.max(inlineWidth, attrSize);
+                    if (current < desired) {
+                        input.setAttribute('size', desired);
+                        input.style.width = `${desired}ch`;
+                    }
                 });
        }
 

--- a/styles.css
+++ b/styles.css
@@ -1118,6 +1118,7 @@ td input.activity-input:not(:first-child) {
   color: var(--text-light);
   text-align: center;
   width: auto;
+  min-width: 16ch;
 }
 #overview-quiz-main .overview-question input,
 #integrated-course-quiz-main .overview-question input {
@@ -1130,6 +1131,7 @@ td input.activity-input:not(:first-child) {
   color: var(--text-light);
   text-align: center;
   width: auto;
+  min-width: 16ch;
 }
 
 #creative-quiz-main .creative-question input:focus {


### PR DESCRIPTION
## Summary
- use a dynamic width calculation for creative answer inputs
- keep a minimum width so answers aren't truncated in overview/creative sections

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cf8ebed2c832c9369cef817fe3f16