### PR TITLE
scroll to focused inputs

### DIFF
--- a/app.js
+++ b/app.js
@@ -222,7 +222,10 @@
 
        function focusFirstInput(container) {
            const firstInput = container.querySelector('input[data-answer]:not([disabled])');
-           if (firstInput) firstInput.focus();
+           if (firstInput) {
+               firstInput.focus();
+               firstInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+           }
        }
 
        function adjustCreativeInputWidths() {
@@ -807,6 +810,7 @@
                     for (let i = idx + 1; i < inputs.length; i++) {
                         if (!inputs[i].disabled) {
                             inputs[i].focus();
+                            inputs[i].scrollIntoView({ behavior: 'smooth', block: 'center' });
                             break;
                         }
                     }
@@ -1056,6 +1060,7 @@
                         for (let i = idx + 1; i < inputs.length; i++) {
                             if (!inputs[i].disabled) {
                                 inputs[i].focus();
+                                inputs[i].scrollIntoView({ behavior: 'smooth', block: 'center' });
                                 break;
                             }
                         }


### PR DESCRIPTION
## Summary
- smooth scroll when focusing next input
- keep scrolled input centered when Enter jumps to next
- ensure accordions scroll to their first input

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cfcdd98e0832cb2a20cfe0aa3ab16