### PR TITLE
Fix narrow blanks for overview and creative sections

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1118,7 +1118,7 @@ td input.activity-input:not(:first-child) {
   color: var(--text-light);
   text-align: center;
   width: auto;
-  min-width: 16ch;
+  min-width: 8ch;
 }
 #overview-quiz-main .overview-question input,
 #integrated-course-quiz-main .overview-question input {
@@ -1131,7 +1131,7 @@ td input.activity-input:not(:first-child) {
   color: var(--text-light);
   text-align: center;
   width: auto;
-  min-width: 16ch;
+  min-width: 8ch;
 }
 
 #creative-quiz-main .creative-question input:focus {


### PR DESCRIPTION
## Summary
- shrink default input width in the overview and creative quizzes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cfeb8f598832cbb1e470d2bf20b9f