### PR TITLE
Add 바생 area to 통합 subject

### DIFF
--- a/index.html
+++ b/index.html
@@ -697,6 +697,7 @@
   <main id="integrated-course-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="common-area">공통</div>
+      <div class="tab" data-target="goodlife-area">바생</div>
     </div>
     <section id="common-area" class="active">
       <h2>공통</h2>
@@ -745,6 +746,44 @@
         </div>
       </td></tr></tbody></table></div></div>
     </section>
+<section id="goodlife-area">
+  <h2>바생</h2>
+  <div class="grade-container"><div><table><tbody><tr><td>
+    <div class="creative-block">
+      <div class="outline-title">#교육과정 설계의 개요</div>
+      <div class="overview-question">바른 생활과는 ‘지금-여기-우리 삶’의 문제를 <input data-answer="성찰" aria-label="성찰" placeholder="정답">하고 <input data-answer="실천" aria-label="실천" placeholder="정답">하는 <input data-answer="경험" aria-label="경험" placeholder="정답"> 자체에 중점을 둔다.</div>
+      <div class="overview-question">고정된 가치나 덕목을 습득하고 내면화하는 <input data-answer="덕목" aria-label="덕목" placeholder="정답"> 중심의 교육 지양</div>
+      <div class="overview-question">네 가지 영역별 질문을 기반으로 나와 공동체 사이의 관계를 <input data-answer="주체적" aria-label="주체적" placeholder="정답">으로 <input data-answer="만들어가는" aria-label="만들어가는" placeholder="정답"> 교육을 지향</div>
+      <div class="overview-question">바른 생활과의 성취기준과 관련 내용요소는 학생의 <input data-answer="실천 경험" aria-label="실천 경험" placeholder="정답"> 수업을 구성하고 실행하는 기본요소이다.</div>
+      <div class="outline-title">#성격</div>
+      <div class="overview-question">초등학교 통합교과로서 바른 생활과는 학생이 ‘지금-여기-우리 삶’을 지속적으로 성찰하는 가운데 구체적인 상황 속에서 바른 삶을 실천하도록 돕는 <input data-answer="실천 경험" aria-label="실천 경험" placeholder="정답"> 중심 교과이다.</div>
+      <div class="overview-question">학생은 바른 생활과 경험을 통해 자신의 삶을 지속적으로 성찰하고 이를 바탕으로 적절한 행동을 꾸준히 찾아서 실천한다. 이 과정에서 학생은 공동체 삶을 위한 생활과 학습 기능을 익히고 습관을 형성한다.</div>
+      <div class="outline-title">#목표</div>
+      <div class="overview-question">공동체 구성원으로서 ‘지금-여기-우리 삶’의 문제를 <input data-answer="성찰" aria-label="성찰" placeholder="정답">하고 <input data-answer="실천" aria-label="실천" placeholder="정답">한다.</div>
+      <div class="overview-question">첫째, 지금 만나는 삶의 문제를 인식하고 <input data-answer="스스로" aria-label="스스로" placeholder="정답"> 해결하려 노력한다.</div>
+      <div class="overview-question">둘째, 자신이 속한 <input data-answer="공동체" aria-label="공동체" placeholder="정답">에서 살아가는 데 필요한 <input data-answer="생활 습관" aria-label="생활 습관" placeholder="정답">과 <input data-answer="학습 습관" aria-label="학습 습관" placeholder="정답">을 형성한다.</div>
+      <div class="overview-question">셋째, 주변 사람들과 <input data-answer="소통" aria-label="소통" placeholder="정답">하고 <input data-answer="배려" aria-label="배려" placeholder="정답">하며 생활한다.</div>
+      <div class="outline-title">#교수·학습의 방향</div>
+      <div class="overview-question">바른 생활과의 교수학습은 덕목 중심의 표준적 태도나 행동을 습득하게 하는 것이 아니라, <input data-answer="맥락" aria-label="맥락" placeholder="정답">과 <input data-answer="공동체" aria-label="공동체" placeholder="정답">에 적절한 행위와 판단의 사례를 찾아보고 <input data-answer="실천" aria-label="실천" placeholder="정답">하면서 <input data-answer="윤리적 감각" aria-label="윤리적 감각" placeholder="정답">을 기를 수 있다.</div>
+      <div class="overview-question">바른 생활과의 교수학습 내용은 학생이 <input data-answer="일상생활" aria-label="일상생활" placeholder="정답">에서 개인적, 사회적, 보편적으로 만나는 시의적절한 문제 상황에서 찾을 수 있다.</div>
+      <div class="overview-question">바른 생활과의 교수학습 과정에서 문제를 다루는 <input data-answer="실천 경험" aria-label="실천 경험" placeholder="정답">은 특히 <input data-answer="자기관리역량" aria-label="자기관리역량" placeholder="정답">, <input data-answer="협력적소통역량" aria-label="협력적소통역량" placeholder="정답">, <input data-answer="공동체역량" aria-label="공동체역량" placeholder="정답"> 등과 밀접한 관련이 있다.</div>
+      <div class="overview-question">바른 생활과의 교수학습은 학생이 속해서 살아가는 여러 삶의 <input data-answer="장" aria-label="장" placeholder="정답">과 연계하여 지도하는 것이 중요하다. 특히 교수학습의 방법적 측면뿐만 아니라 교수학습 내용까지도 <input data-answer="가정" aria-label="가정" placeholder="정답"> 및 <input data-answer="지역" aria-label="지역" placeholder="정답"> 생활과 연계할 수 있다.</div>
+      <div class="overview-question">바른 생활과에서는 학습 문제를 공동으로 정하고 해결하는 과정을 통해 더불어 살아가는 <input data-answer="민주시민" aria-label="민주시민" placeholder="정답"> 태도를 기를 수 있다.</div>
+      <div class="overview-question">바른 생활과에서는 학생 주도의 유의미한 실천이 중요하므로 학습에서도 계획과 실천에 이르는 교수학습 전 과정에 학생이 <input data-answer="주체적" aria-label="주체적" placeholder="정답">으로 참여할 수 있도록 한다.</div>
+      <div class="overview-question">바른 생활과의 교수학습에서는 특히 누리과정의 <input data-answer="신체운동·건강" aria-label="신체운동·건강" placeholder="정답">, <input data-answer="사회관계" aria-label="사회관계" placeholder="정답"> 등 내용 영역과 초등학교 3학년 이후 <input data-answer="도덕과" aria-label="도덕과" placeholder="정답"> 교육과정 등과의 연계를 고려한다.</div>
+      <div class="overview-question">바른 생활과의 안전 교육을 연계하여 <input data-answer="실생활" aria-label="실생활" placeholder="정답"> 체험과 활동을 중심으로 <input data-answer="실천적" aria-label="실천적" placeholder="정답">인 안전 교육을 한다.</div>
+      <div class="overview-question">바른 생활과 교수학습은 <input data-answer="언어 소양" aria-label="언어 소양" placeholder="정답">, <input data-answer="디지털 소양" aria-label="디지털 소양" placeholder="정답">과 더불어 안전·건강 교육, 인성 교육, 진로 교육, 민주시민 교육, 인권 교육, 다문화 교육, 통일 교육, 독도 교육, 환경·지속발전 교육 등의 <input data-answer="범교과 학습 주제" aria-label="범교과 학습 주제" placeholder="정답">를 연계하여 계획할 수 있다</div>
+      <div class="outline-title">#교수·학습 방법</div>
+      <div class="overview-question">[차시 개발] 바른 생활과의 교수학습은 주제와 관련해서 나와 공동체의 문제를 해결하기 위한 <input data-answer="실천 활동" aria-label="실천 활동" placeholder="정답">을 구상하는 일이다. 이에 일상에서 직면할 수 있는 문제를 찾고 해결 방안을 모색하여 개별적으로나 협력하여 <input data-answer="실천" aria-label="실천" placeholder="정답">하는 활동으로 구성할 수 있다.</div>
+      <div class="overview-question">[차시 조직] 차시는 미리 조직해 놓고 실행할 수 있고, 실행하면서 다음 차시를 정하는 방식 <input data-answer="꼬리 잇기 방식" aria-label="꼬리 잇기 방식" placeholder="정답">으로 할 수 있다.</div>
+      <div class="overview-question">차시는 <input data-answer="개인적 실천" aria-label="개인적 실천" placeholder="정답"> 차시와 <input data-answer="집단적 실천" aria-label="집단적 실천" placeholder="정답"> 차시로 조직할 수 있다.</div>
+      <div class="overview-question">이 과정에서 <input data-answer="가상 현실" aria-label="가상 현실" placeholder="정답">, <input data-answer="증강 현실" aria-label="증강 현실" placeholder="정답"> 등 학생의 탐구 대상을 <input data-answer="확장" aria-label="확장" placeholder="정답">할 수 있는 다양한 도구를 활용할 수 있다.</div>
+      <div class="overview-question">바른 생활과의 특성을 고려하여 점수 매기기, 등급 구분 등의 평가를 지양하고 학생의 습관 형성을 꾸준히 관찰하여 학습한 정도나 변화 정도를 <input data-answer="서술형" aria-label="서술형" placeholder="정답">으로 평가할 수 있다.</div>
+      <div class="outline-title">#평가의 방향</div>
+      <div class="overview-question">바른 생활과는 <input data-answer="실천 경험" aria-label="실천 경험" placeholder="정답"> 중심의 교과로 가정과 연계하여 평가하되 일회적 평가보다 학생의 생활화 정도를 종합적으로 고려하여 평가한다.</div>
+    </div>
+  </td></tr></tbody></table></div></div>
+</section>
   </main>
   <main id="ethics-quiz-main" class="hidden">
     <div class="tabs">


### PR DESCRIPTION
## Summary
- add `바생` tab and section in 통합 과목
- populate `바생` 영역 with fill-in-the-blank content

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dbde246fc832c84ed09ef53cd923e