### PR TITLE
Update integrated course blanks

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,10 +726,10 @@
           <div class="overview-question">④<input data-answer="누리과정" aria-label="누리과정" placeholder="정답"> 및 <input data-answer="3학년 이후 교과 교육" aria-label="3학년 이후 교과 교육" placeholder="정답">과 연계해서 다룰 수 있도록 안내하였다.</div>
           <div class="outline-title">#성격</div>
           <div class="overview-question">초등학교 통합교과는 <input data-answer="지금-여기-우리 삶" aria-label="지금-여기-우리 삶" placeholder="정답">을 위한 배움을 추구한다.</div>
-          <div class="overview-question">-&gt; 이를 위해서 학생 개인의 관심사와 공동체의 문제를 아우를 수 있는 탈학문적 주제를 중심으로 교육과정을 통합하였다.</div>
+          <div class="overview-question">-&gt; 이를 위해서 학생 개인의 관심사와 공동체의 문제를 아우를 수 있는 <input data-answer="탈학문적 주제" aria-label="탈학문적 주제" placeholder="정답">를 중심으로 교육과정을 통합하였다.</div>
           <div class="overview-question">-&gt; 따라서 초등학교 통합교과는 ‘지금-여기-우리 삶’에 통합적으로 접근하는 <input data-answer="경험" aria-label="경험" placeholder="정답"> 중심 교과이다.</div>
           <div class="overview-question">-&gt; 학생은 통합 교과의 경험을 통해 탈학문적 주제를 중심으로 관심사를 탐구하고 당면한 문제를 해결하는 과정에서 다양한 지식을 연계하고 통합한다.</div>
-          <div class="overview-question">-&gt; 그 과정에서 학생은 자기주도적이고 창의적이며 더불어 사는 사람으로 성장할 수 있다.</div>
+          <div class="overview-question">-&gt; 그 과정에서 학생은 <input data-answer="자기주도적" aria-label="자기주도적" placeholder="정답">이고 <input data-answer="창의적" aria-label="창의적" placeholder="정답">이며 <input data-answer="더불어 사는 사람" aria-label="더불어 사는 사람" placeholder="정답">으로 성장할 수 있다.</div>
           <div class="outline-title">#교수·학습의 방향</div>
           <div class="overview-question">바슬즐과는 <input data-answer="영역" aria-label="영역" placeholder="정답"> 및 <input data-answer="핵심아이디어" aria-label="핵심아이디어" placeholder="정답">를 중심으로 서로를 통합하여 교수학습할 수 있다. 아울러 학생의 관심사를 반영한 <input data-answer="주제" aria-label="주제" placeholder="정답">를 중심으로 다른 교과, 창의적 체험활동을 통합할 수 있다</div>
           <div class="overview-question">교과 기능 8개: <input data-answer="조사하기" aria-label="조사하기" placeholder="정답">, <input data-answer="관련하기" aria-label="관련하기" placeholder="정답">, <input data-answer="질문하기" aria-label="질문하기" placeholder="정답">, <input data-answer="준비하기" aria-label="준비하기" placeholder="정답">, <input data-answer="계획하기" aria-label="계획하기" placeholder="정답">, <input data-answer="나타내기" aria-label="나타내기" placeholder="정답">, <input data-answer="의논하기" aria-label="의논하기" placeholder="정답">, <input data-answer="평가하기" aria-label="평가하기" placeholder="정답"></div>


### PR DESCRIPTION
## Summary
- add interactive blanks for key terms in the integrated course section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687dc8bdfa74832cba505d4b1799245c