### PR TITLE
Add 슬생 domain for integrated subject

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,6 +698,7 @@
     <div class="tabs">
       <div class="tab active" data-target="common-area">공통</div>
       <div class="tab" data-target="goodlife-area">바생</div>
+      <div class="tab" data-target="sociality-area">슬생</div>
     </div>
     <section id="common-area" class="active">
       <h2>공통</h2>
@@ -781,6 +782,50 @@
       <div class="overview-question">바른 생활과의 특성을 고려하여 점수 매기기, 등급 구분 등의 평가를 지양하고 학생의 습관 형성을 꾸준히 관찰하여 학습한 정도나 변화 정도를 <input data-answer="서술형" aria-label="서술형" placeholder="정답">으로 평가할 수 있다.</div>
       <div class="outline-title">#평가의 방향</div>
       <div class="overview-question">바른 생활과는 <input data-answer="실천 경험" aria-label="실천 경험" placeholder="정답"> 중심의 교과로 가정과 연계하여 평가하되 일회적 평가보다 학생의 생활화 정도를 종합적으로 고려하여 평가한다.</div>
+    </div>
+  </td></tr></tbody></table></div></div>
+</section>
+<section id="sociality-area">
+  <h2>슬생</h2>
+  <div class="grade-container"><div><table><tbody><tr><td>
+    <div class="creative-block">
+      <div class="outline-title">#교육과정 설계의 개요</div>
+      <div class="overview-question">슬기로운 생활과는 지금 여기서 삶의 맥락과 단절된 미래를 준비하는 것이 아니라 ‘지금-여기-우리의 삶’에 지속적으로 관심을 갖고 <input data-answer="탐구" aria-label="탐구" placeholder="정답">하는 경험 자체에 중점을 둔다.</div>
+      <div class="overview-question">자연과 사회에 대한 <input data-answer="사실" aria-label="사실" placeholder="정답">이나 <input data-answer="정보" aria-label="정보" placeholder="정답"> 중심의 교육 지양</div>
+      <div class="overview-question">네 가지 질문을 기반으로 환경과 더불어 사는 우리 존재나 삶을 이야기하면서 사람 자연 사회의 관계를 지속적으로 <input data-answer="탐구" aria-label="탐구" placeholder="정답">하는 활동을 지향</div>
+      <div class="overview-question">슬기로운 생활과의 성취기준과 관련 내용요소는 <input data-answer="탐구" aria-label="탐구" placeholder="정답"> 경험 중심의 수업을 구성하고 실행하는 기본요소이다.</div>
+
+      <div class="outline-title">#성격</div>
+      <div class="overview-question">초등학교 통합교과로서 슬기로운 생활과는 학생이 ‘지금-여기-우리 삶’에 관심을 갖고 적극적으로 참구하는 가운데 자신이 살고 있는 세상을 경험하는 <input data-answer="탐구 경험" aria-label="탐구 경험" placeholder="정답"> 중심 교과이다.</div>
+      <div class="overview-question">학생은 슬기로운 생활과 교육과정 경험을 통해 주변의 <input data-answer="모습" aria-label="모습" placeholder="정답">, 주변에서 일어나는 <input data-answer="변화" aria-label="변화" placeholder="정답">, <input data-answer="상호관계" aria-label="상호관계" placeholder="정답">에 지속적으로 관심을 가지고 이해를 확장하는 가운데 <input data-answer="탐구" aria-label="탐구" placeholder="정답"> 능력을 함양한다. 이 과정에서 학생은 자신이 살아가는 시간과 공간에서 필요한 지식을 공유하고 활용하며 생활환다.</div>
+
+      <div class="outline-title">#목표</div>
+      <div class="overview-question"><input data-answer="지금-여기-우리 삶" aria-label="지금-여기-우리 삶" placeholder="정답">에 지속적으로 관심을 갖고 <input data-answer="탐구" aria-label="탐구" placeholder="정답">한다.</div>
+      <div class="overview-question">첫째, 자신과 <input data-answer="주변" aria-label="주변" placeholder="정답">에서 관심을 가지고 질문을 제기하며 지속적으로 탐구한다.</div>
+      <div class="overview-question">둘째, 탐구 과정에서 필요한 지식이나 기능을 다루면서 주변을 <input data-answer="탐구" aria-label="탐구" placeholder="정답">하는 태도를 기른다.</div>
+      <div class="overview-question">셋째, 탐구 과정에서 형성한 이해를 <input data-answer="공동체" aria-label="공동체" placeholder="정답">와 공유하며 확장한다.</div>
+
+      <div class="outline-title">#교수·학습의 방향</div>
+      <div class="overview-question">슬기로운 생활과의 교수학습은 학생 내부에서 시작하는 흥미와 관심에 집중한다. 또한 학생이 배움의 즐거움을 잃지 않고 생생한 학습이 이루어질 수 있도록 학습 환경을 구성한다.</div>
+      <div class="overview-question">슬기로운 생활과에서 탐구 주제는 학생이 생활하며 만나는 ①<input data-answer="주변의 모습" aria-label="주변의 모습" placeholder="정답">, ②<input data-answer="주변의 변화" aria-label="주변의 변화" placeholder="정답">, ③<input data-answer="주변의 상호 관계" aria-label="주변의 상호 관계" placeholder="정답">에서 찾을 수 있다.</div>
+      <div class="overview-question">슬기로운 생활과의 교수학습 과정에서 <input data-answer="주변" aria-label="주변" placeholder="정답">을 <input data-answer="탐구" aria-label="탐구" placeholder="정답">하는 경험은 특히 <input data-answer="지식정보처리역량" aria-label="지식정보처리역량" placeholder="정답">, <input data-answer="창의적사고역량" aria-label="창의적사고역량" placeholder="정답">, <input data-answer="협력적소통역량" aria-label="협력적소통역량" placeholder="정답"> 등과 밀접한 관련이 있다.</div>
+      <div class="overview-question">슬기로운 생활과는 학생에게 친숙한 <input data-answer="주변" aria-label="주변" placeholder="정답"> 이 탐구 주제이기 때문에 학생의 일상적 경험을 벗어나지 않도록 유의한다. 단 학생에게 <input data-answer="물리적" aria-label="물리적" placeholder="정답">으로 친숙한 ‘주변’이외에도 <input data-answer="심리적" aria-label="심리적" placeholder="정답">으로 친숙한 ‘주변’도 다루도록 한다. 학생의 발달 단계에 부합하지 않더라도 교사는 학생이 관심을 갖는 대상에 주의를 기울여 이를 수업에 반영하도록 한다.</div>
+      <div class="overview-question">슬기로운 생활과를 통해 주변의 인물과 자연에 대한 존중, 이를 대하는 태도를 배움으로써 지구 안에서 함께 살아가는 기본적인 <input data-answer="민주시민" aria-label="민주시민" placeholder="정답"> 태도를 기를 수 있도록 한다.</div>
+      <div class="overview-question">슬기로운 생활과에서 <input data-answer="탐구" aria-label="탐구" placeholder="정답">는 학생이 지닌 궁금증, 호기심, 흥미, 관심에서 출발하므로 학습에서도 계획-실천에 이르는 교수학습 전 과정에 학생이 <input data-answer="주체적" aria-label="주체적" placeholder="정답">으로 참여할 수 있도록 한다.</div>
+      <div class="overview-question">슬기로운 생활과의 교수학습에서는 특히 누리과정의 <input data-answer="사회관계" aria-label="사회관계" placeholder="정답">, <input data-answer="자연탐구" aria-label="자연탐구" placeholder="정답"> 등 내용 영역과 초등학교 3학년 이후 <input data-answer="사회과" aria-label="사회과" placeholder="정답">, <input data-answer="과학과" aria-label="과학과" placeholder="정답"> 교육과정 등과의 연계를 고려한다.</div>
+      <div class="overview-question">슬기로운 생활과 <input data-answer="안전 교육" aria-label="안전 교육" placeholder="정답">을 연계해서 학생들의 <input data-answer="실생활" aria-label="실생활" placeholder="정답"> 중심으로 체험이나 실습을 할 수 있도록 지도한다.</div>
+      <div class="overview-question">슬기로운 생활과에서는 <input data-answer="언어 소양" aria-label="언어 소양" placeholder="정답">, <input data-answer="수리 소양" aria-label="수리 소양" placeholder="정답">, <input data-answer="디지털 소양" aria-label="디지털 소양" placeholder="정답">과 더불어 안전·건강 교육, 인성 교육, 진로 교육, 민주시민 교육, 인권 교육, 다문화 교육, 통일 교육, 독도 교육, <input data-answer="경제·금융 교육" aria-label="경제·금융 교육" placeholder="정답">, 환경·지속발전 교육 등의 <input data-answer="범교과 학습 주제" aria-label="범교과 학습 주제" placeholder="정답">를 연계하여 교수학습을 계획할 수 있다.</div>
+
+      <div class="outline-title">#교수·학습 방법</div>
+      <div class="overview-question">[차시 개발] 슬기로운 생활과의 교수학습은 주제와 관련하여 <input data-answer="수행" aria-label="수행" placeholder="정답">할 활동을 구상하는 일이다. 학생이 다양한 탐구 대상을 찾을 수 있도록 관찰, 견학, 가상 체험 등 다양한 <input data-answer="탐구" aria-label="탐구" placeholder="정답"> 활동을 고려하여 학습 환경을 제공할 수 있다.</div>
+      <div class="overview-question">[차시 조직] 차시는 순서를 미리 정한 후 활동 과정에서 상황에 따라 적절히 조정할 수 있다. 또한 미리 정하지 않고 활동하는 과정에서 즉흥적으로 순서를 정하며 할 수 있다.</div>
+      <div class="overview-question">차시 조직에서는 <input data-answer="필수" aria-label="필수" placeholder="정답">로 해야 할 차시와 <input data-answer="선택" aria-label="선택" placeholder="정답">해서 할 차시를 정할 수 있다.</div>
+      <div class="overview-question">특히 학생이 <input data-answer="탐구 주제" aria-label="탐구 주제" placeholder="정답">에 집중할 수 있도록 <input data-answer="프로젝트" aria-label="프로젝트" placeholder="정답">, 기르기, 만들기 등 일정 기간 동안 <input data-answer="몰입" aria-label="몰입" placeholder="정답">하여 수행하는 활동 등을 활용할 수 있다</div>
+      <div class="overview-question">이 과정에서 <input data-answer="가상 현실" aria-label="가상 현실" placeholder="정답">, <input data-answer="증강 현실" aria-label="증강 현실" placeholder="정답"> 등 학생의 탐구 대상을 <input data-answer="확장" aria-label="확장" placeholder="정답">할 수 있는 다양한 도구를 활용할 수 있다.</div>
+      <div class="overview-question">슬기로운 생활과에서 사용해 온 <input data-answer="경험 학습" aria-label="경험 학습" placeholder="정답">, <input data-answer="탐구 학습" aria-label="탐구 학습" placeholder="정답">, <input data-answer="체험 학습" aria-label="체험 학습" placeholder="정답"> 등을 활용할 수 있다.</div>
+
+      <div class="outline-title">#평가의 방향</div>
+      <div class="overview-question">슬기로운 생활과는 탐구 경험 중심의 교과인 만큼 학생이 자신의 일상뿐 아니라 주변에서 일어나는 <input data-answer="변화" aria-label="변화" placeholder="정답">, <input data-answer="관계" aria-label="관계" placeholder="정답">, <input data-answer="모습" aria-label="모습" placeholder="정답"> 등의 지속적으로 관심을 가지고 탐구하며 이해하는 정도를 종합적으로 고려하여 평가한다.</div>
     </div>
   </td></tr></tbody></table></div></div>
 </section>


### PR DESCRIPTION
## Summary
- add a new Sl생 tab in the integrated course section
- include new Sl생 curriculum content with blank answers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dd368f0c4832cad92f4c63a11a868