### PR TITLE
Advance stage when inputs disabled

### DIFF
--- a/app.js
+++ b/app.js
@@ -658,7 +658,10 @@
 
         function checkStageClear(sectionElement) {
             const inputsInSection = sectionElement.querySelectorAll('input[data-answer]');
-            return inputsInSection.length > 0 && [...inputsInSection].every(input => input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT));
+            return (
+                inputsInSection.length > 0 &&
+                [...inputsInSection].every(input => input.disabled)
+            );
         }
 
        function showStageClear() {
@@ -818,13 +821,6 @@
                     comboCounter.classList.add(CONSTANTS.CSS_CLASSES.COMBO_POP);
                 }
                 
-                if (checkStageClear(section)) {
-                    if (gameState.selectedSubject === CONSTANTS.SUBJECTS.COMPETENCY) {
-                        setTimeout(() => celebrateCompetencySection(section), 300);
-                    } else {
-                        setTimeout(showStageClear, 300);
-                    }
-                }
             } else {
                 gameState.combo = 0;
                 updateMushroomGrowth();
@@ -849,6 +845,14 @@
                 } else {
                     input.classList.add(CONSTANTS.CSS_CLASSES.RETRYING);
                     input.value = '';
+                }
+            }
+
+            if (shouldAdvance && checkStageClear(section)) {
+                if (gameState.selectedSubject === CONSTANTS.SUBJECTS.COMPETENCY) {
+                    setTimeout(() => celebrateCompetencySection(section), 300);
+                } else {
+                    setTimeout(showStageClear, 300);
                 }
             }
 


### PR DESCRIPTION
## Summary
- treat a stage as cleared when all inputs are disabled, not only when correct
- check for stage completion after a second incorrect answer and advance automatically

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fc4c1de94832cb0b60d6eac939d7b