### PR TITLE
Add slot machine mini-game

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,11 @@
             <div id="time">15:00</div>
             <div id="bar"><div></div></div>
         </div>
+        <div id="slot-machine" class="slot-machine hidden">
+            <div class="reel">?</div>
+            <div class="reel">?</div>
+            <div class="reel">?</div>
+        </div>
     </div>
     <div class="hud-right">
       <button id="force-quit-btn" class="btn hidden">강제 종료</button>

--- a/styles.css
+++ b/styles.css
@@ -103,6 +103,29 @@
       border-radius: 2px;
     }
 
+    .slot-machine {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+
+    .slot-machine .reel {
+      width: 3rem;
+      height: 3rem;
+      background: var(--secondary);
+      border: 3px solid var(--primary);
+      border-radius: 4px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-size: 2rem;
+      font-family: 'Press Start 2P', cursive;
+    }
+
+    .slot-machine.hidden {
+      display: none;
+    }
+
     .btn {
       cursor: pointer;
       font-weight: 700;


### PR DESCRIPTION
## Summary
- add slot machine markup in header
- style slot machine reels
- implement slot machine logic in JS
- start the slot machine when a game begins
- stop a reel after each correct answer and trigger sound on win
- reset slot machine on game reset or game over

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fca57733c832ca9f41a51f6feb82e