### PR TITLE
Add slot-machine style randomization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This command will analyze JavaScript and HTML files using the configuration prov
 Additional CSS rules refine the nested list appearance within the English quiz section. Third and fourth list levels now have larger left margins and unique bullet styles to make the hierarchy clearer.
 Dividing lines have been added to the English quiz lists so each level is visibly separated.
 
+## Slot Machine Style Randomization
+
+Clicking the **랜덤** button now triggers a slot machine style overlay that cycles
+through subjects before selecting one at random. This short animation adds a
+fun, immersive feel to the subject selection process.
+
 ## License
 
 This project is licensed under the [ISC License](LICENSE).

--- a/app.js
+++ b/app.js
@@ -133,6 +133,8 @@
         const startModal = document.getElementById('start-modal');
         const guideModal = document.getElementById('guide-modal');
         const closeGuideBtn = document.getElementById('close-guide-btn');
+        const slotMachineOverlay = document.getElementById('slot-machine-overlay');
+        const slotMachineText = document.getElementById('slot-machine-text');
         const timeSettingDisplay = document.getElementById('time-setting-display');
         const decreaseTimeBtn = document.getElementById('decrease-time');
         const increaseTimeBtn = document.getElementById('increase-time');
@@ -945,12 +947,15 @@
                 gameState.isRandomizing = true;
                 const subjectBtns = Array.from(document.querySelectorAll('.subject-btn:not([data-subject="random"]):not(.hidden)'));
                 const allSelectorBtns = document.querySelectorAll('.subject-selector .btn');
-                
+
                 allSelectorBtns.forEach(b => b.disabled = true);
                 subjectBtns.forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));
 
                 randomAudio.loop = true;
                 playSound(randomAudio);
+
+                slotMachineOverlay.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+                const subjectNames = subjectBtns.map(b => b.textContent);
 
                 let shuffleCount = 0;
                 const maxShuffles = CONSTANTS.RANDOM_ANIMATION_DURATION / CONSTANTS.RANDOM_ANIMATION_INTERVAL;
@@ -958,24 +963,27 @@
                 const randomInterval = setInterval(() => {
                     shuffleCount++;
                     subjectBtns.forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.IS_SELECTING));
+                    const currentIndex = shuffleCount % subjectBtns.length;
+                    subjectBtns[currentIndex].classList.add(CONSTANTS.CSS_CLASSES.IS_SELECTING);
+                    slotMachineText.textContent = subjectNames[currentIndex];
 
                     if (shuffleCount >= maxShuffles) {
                         clearInterval(randomInterval);
                         randomAudio.pause();
-                        
+
                         const randomIndex = Math.floor(Math.random() * subjectBtns.length);
                         const chosenBtn = subjectBtns[randomIndex];
-                        
-                        chosenBtn.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
-                        gameState.selectedSubject = chosenBtn.dataset.subject;
-                        
-                        allSelectorBtns.forEach(b => b.disabled = false);
-                        gameState.isRandomizing = false;
-                        return;
+
+                        slotMachineText.textContent = chosenBtn.textContent;
+
+                        setTimeout(() => {
+                            slotMachineOverlay.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE);
+                            chosenBtn.classList.add(CONSTANTS.CSS_CLASSES.SELECTED);
+                            gameState.selectedSubject = chosenBtn.dataset.subject;
+                            allSelectorBtns.forEach(b => b.disabled = false);
+                            gameState.isRandomizing = false;
+                        }, 500);
                     }
-                    
-                    const currentIndex = shuffleCount % subjectBtns.length;
-                    subjectBtns[currentIndex].classList.add(CONSTANTS.CSS_CLASSES.IS_SELECTING);
                 }, CONSTANTS.RANDOM_ANIMATION_INTERVAL);
             } else {
                 document.querySelectorAll('.subject-btn').forEach(b => b.classList.remove(CONSTANTS.CSS_CLASSES.SELECTED));

--- a/index.html
+++ b/index.html
@@ -3096,7 +3096,13 @@
           <button id="close-progress-modal-btn" class="btn">확인</button>
       </div>
   </div>
-  
+
+  <div id="slot-machine-overlay" class="modal-overlay">
+      <div class="slot-machine-content">
+          <span id="slot-machine-text">?</span>
+      </div>
+  </div>
+
   <div id="guide-modal" class="modal-overlay">
       <div class="modal-content">
           <h3>HOW TO PLAY</h3>

--- a/styles.css
+++ b/styles.css
@@ -382,6 +382,20 @@ td input.activity-input:not(:first-child) {
       max-width: 600px;
       border-radius: 12px;
     }
+    #slot-machine-overlay .slot-machine-content {
+      background: var(--bg-light);
+      padding: 2rem 3rem;
+      font-size: 3rem;
+      color: var(--primary);
+      border: 4px solid var(--secondary);
+      box-shadow: 10px 10px 0 var(--primary);
+      border-radius: 10px;
+      animation: slot-pop 0.3s ease-out;
+    }
+    @keyframes slot-pop {
+      from { transform: scale(0.8); opacity: 0; }
+      to { transform: scale(1); opacity: 1; }
+    }
     .modal-overlay.active .modal-content { transform: scale(1); }
     .modal-content h2 {
       color: var(--primary);


### PR DESCRIPTION
## Summary
- implement slot machine overlay that displays during random subject selection
- animate overlay with CSS for a pop effect
- update `app.js` to cycle subject names in the overlay
- document slot machine style in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fcb8829c4832cbd78f8b17425ad9c