### PR TITLE
Add win flash effect for slot machine

### DIFF
--- a/app.js
+++ b/app.js
@@ -305,6 +305,8 @@
                 const values = Array.from(slotReels).map(r => r.textContent);
                 if (values.every(v => v === values[0])) {
                     playSound(slotWinAudio);
+                    slotMachineEl.classList.add('win');
+                    setTimeout(() => slotMachineEl.classList.remove('win'), 1000);
                     const duration = 800;
                     const end = Date.now() + duration;
                     const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 300 };

--- a/styles.css
+++ b/styles.css
@@ -136,6 +136,16 @@
       display: none;
     }
 
+/* Flash reels when the slot machine hits a win */
+    .slot-machine.win .reel {
+      animation: reel-win-flash 0.4s ease-out 0s 2;
+    }
+
+    @keyframes reel-win-flash {
+      0%, 100% { transform: scale(1); box-shadow: 0 0 0 var(--accent); }
+      50% { transform: scale(1.3); box-shadow: 0 0 15px var(--accent); }
+    }
+
     .btn {
       cursor: pointer;
       font-weight: 700;


### PR DESCRIPTION
## Summary
- add a flash animation to highlight slot machine reels when all symbols match
- trigger the new animation in `checkWin`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fd4e34e30832c9059003d4fa9ee64