### PR TITLE
Adjust HUD layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,17 +14,16 @@
   <header>
     <div class="hud-left">
         <h1 id="header-title">아웃풋을 해보자</h1>
-        <div id="combo-counter" class="hidden"></div>
+        <div id="timer-container" class="kitsch-box hidden">
+            <div id="time">15:00</div>
+            <div id="bar"><div></div></div>
+        </div>
     </div>
     <div class="hud-center">
         <div id="lives-container" class="hidden">
             <span class="heart-icon">♥</span>
             <span class="heart-icon">♥</span>
             <span class="heart-icon">♥</span>
-        </div>
-        <div id="timer-container" class="kitsch-box hidden">
-            <div id="time">15:00</div>
-            <div id="bar"><div></div></div>
         </div>
         <div id="slot-machine" class="slot-machine hidden">
             <div class="reel">?</div>
@@ -3054,6 +3053,7 @@
 <!-- competency main end -->
 
   <div id="character-assistant" class="idle">
+      <div id="combo-counter" class="hidden"></div>
       <div class="mushroom">
           <div class="devil-horns">
               <div class="horn left"></div>

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,12 @@
       border-radius: 8px;
     }
 
+    #timer-container {
+      margin-left: 2rem;
+      display: flex;
+      align-items: center;
+    }
+
     #time {
       font-family: 'Source Code Pro', monospace;
       font-size: 1.8rem;
@@ -104,9 +110,13 @@
     }
 
     .slot-machine {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translate(-50%, 0);
+      margin-top: 0.5rem;
       display: flex;
       gap: 0.5rem;
-      margin-top: 0.5rem;
     }
 
     .slot-machine .reel {
@@ -184,6 +194,14 @@
         font-size: 2.2rem; /* Match H1 size */
         font-weight: 800;
         text-shadow: 2px 2px 0px var(--primary);
+    }
+    #character-assistant #combo-counter {
+        position: absolute;
+        bottom: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        margin-bottom: 0.5rem;
+        white-space: nowrap;
     }
     .combo-pop { animation: combo-pop-animation 0.3s ease-out; }
     @keyframes combo-pop-animation {


### PR DESCRIPTION
## Summary
- swap positions of the timer and combo counter
- show combo text above the mushroom character
- place the slot machine centered at the top

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687fd63deae8832c88d8db5aebcd5ce2