### PR TITLE
Increase hit effect volume

### DIFF
--- a/app.js
+++ b/app.js
@@ -175,7 +175,7 @@
         clickAudio.volume = SFX_VOLUME;
         const slotWinAudio = new Audio('./hit.mp3');
         slotWinAudio.preload = 'auto';
-        slotWinAudio.volume = SFX_VOLUME;
+        slotWinAudio.volume = Math.min(1, SFX_VOLUME * 2);
         
         // --- UTILITY FUNCTIONS ---
         const fmt = n => String(n).padStart(2, '0');


### PR DESCRIPTION
## Summary
- bump up the volume for the slot machine win sound effect

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687fd9bd69e4832c8e2fcb515c20a4aa