### PR TITLE
Add pixel slot machine icons

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,7 +148,7 @@
         const resultSubject = document.getElementById('result-subject');
         const resultTopic = document.getElementById('result-topic');
         const slotMachineEl = document.getElementById('slot-machine');
-        const slotReels = slotMachineEl.querySelectorAll('.reel');
+        const slotReels = slotMachineEl.querySelectorAll('.reel img');
         
         // --- Audio ---
         const SFX_VOLUME = 0.4;
@@ -276,7 +276,15 @@
         }
 
         // --- SLOT MACHINE ---
-        const SLOT_SYMBOLS = ['🍒', '🍋', '🔔', '⭐', '7'];
+        const SLOT_SYMBOLS = ['cherry', 'lemon', 'bell', 'star', 'seven'];
+        const SYMBOL_MAP = {
+            cherry: 'icons/cherry.svg',
+            lemon: 'icons/lemon.svg',
+            bell: 'icons/bell.svg',
+            star: 'icons/star.svg',
+            seven: 'icons/seven.svg',
+            question: 'icons/question.svg'
+        };
         const slotMachine = {
             index: 0,
             predetermined: [],
@@ -305,14 +313,17 @@
                 this.predetermined = this.generateSymbols();
                 slotMachineEl.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
                 slotReels.forEach(reel => {
-                    reel.textContent = '?';
+                    reel.src = SYMBOL_MAP.question;
+                    reel.dataset.symbol = 'question';
                     reel.classList.remove('revealed');
                 });
             },
             stopNext() {
                 if (this.index >= slotReels.length) return;
                 const reel = slotReels[this.index];
-                reel.textContent = this.predetermined[this.index];
+                const symbol = this.predetermined[this.index];
+                reel.src = SYMBOL_MAP[symbol];
+                reel.dataset.symbol = symbol;
                 reel.classList.add('revealed');
                 setTimeout(() => reel.classList.remove('revealed'), 300);
                 this.index++;
@@ -321,7 +332,7 @@
                 }
             },
             checkWin() {
-                const values = Array.from(slotReels).map(r => r.textContent);
+                const values = Array.from(slotReels).map(r => r.dataset.symbol);
                 if (values.every(v => v === values[0])) {
                     playSound(slotWinAudio);
                     slotMachineEl.classList.add('win');
@@ -339,7 +350,10 @@
                 setTimeout(() => this.start(), 1000);
             },
             reset() {
-                slotReels.forEach(reel => reel.textContent = '?');
+                slotReels.forEach(reel => {
+                    reel.src = SYMBOL_MAP.question;
+                    reel.dataset.symbol = 'question';
+                });
                 this.predetermined = [];
                 this.index = 0;
                 if (slotMachineEl) slotMachineEl.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);

--- a/icons/bell.svg
+++ b/icons/bell.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" shape-rendering="crispEdges">
+  <rect width="16" height="16" fill="#000000"/>
+  <path d="M5 5h6l1 5H4z" fill="#ffd93d"/>
+  <rect x="7" y="11" width="2" height="2" fill="#ffd93d"/>
+</svg>

--- a/icons/cherry.svg
+++ b/icons/cherry.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" shape-rendering="crispEdges">
+  <rect width="16" height="16" fill="#000000"/>
+  <circle cx="5" cy="10" r="3" fill="#ff5555"/>
+  <circle cx="10" cy="10" r="3" fill="#ff5555"/>
+  <rect x="7" y="3" width="1" height="4" fill="#00aa00"/>
+  <rect x="6" y="2" width="4" height="1" fill="#00aa00"/>
+</svg>

--- a/icons/lemon.svg
+++ b/icons/lemon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" shape-rendering="crispEdges">
+  <rect width="16" height="16" fill="#000000"/>
+  <ellipse cx="8" cy="8" rx="4" ry="3" fill="#ffe066"/>
+</svg>

--- a/icons/question.svg
+++ b/icons/question.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" shape-rendering="crispEdges">
+  <rect width="16" height="16" fill="#000000"/>
+  <path d="M4 4h8v2H8v2h2v2H8v2h2v2H6v-2h2v-2H6V8h2V6H4z" fill="#ffffff"/>
+</svg>

--- a/icons/seven.svg
+++ b/icons/seven.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" shape-rendering="crispEdges">
+  <rect width="16" height="16" fill="#000000"/>
+  <path d="M4 4h8l-5 8H5z" fill="#ffffff"/>
+</svg>

--- a/icons/star.svg
+++ b/icons/star.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" shape-rendering="crispEdges">
+  <rect width="16" height="16" fill="#000000"/>
+  <polygon points="8,2 10,6 14,6 11,9 12,13 8,11 4,13 5,9 2,6 6,6" fill="#ffe066"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -27,9 +27,9 @@
             <div id="bar"><div></div></div>
         </div>
         <div id="slot-machine" class="slot-machine hidden">
-            <div class="reel">?</div>
-            <div class="reel">?</div>
-            <div class="reel">?</div>
+            <div class="reel"><img src="icons/question.svg" alt="?" /></div>
+            <div class="reel"><img src="icons/question.svg" alt="?" /></div>
+            <div class="reel"><img src="icons/question.svg" alt="?" /></div>
         </div>
     </div>
     <div class="hud-right">

--- a/styles.css
+++ b/styles.css
@@ -118,9 +118,14 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      font-size: 3rem;
-      font-family: 'Press Start 2P', cursive;
       transition: transform 0.3s, opacity 0.3s;
+      overflow: hidden;
+    }
+
+    .slot-machine .reel img {
+      width: 100%;
+      height: 100%;
+      image-rendering: pixelated;
     }
 
     .slot-machine .reel.revealed {


### PR DESCRIPTION
## Summary
- redesign slot machine reels as pixel art images
- style slot machine to use pixel icons
- switch JS logic to update reel images instead of emoji

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687fdd256594832c9f29890406cbeccc