### PR TITLE
Move contribution heatmap to sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
       <button id="reset-btn" class="btn hidden">재시작</button>
     </div>
   </header>
+  <aside id="left-sidebar">
+      <div id="activity-heatmap"></div>
+  </aside>
   <main id="music-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="performance">연주</div>
@@ -3176,8 +3179,6 @@
             <div id="hard-core-description" class="notice-text hidden">
                 <p>제한시간 60초, 정답 시 +5초가 주어집니다.</p>
             </div>
-            <h2>최근 활동</h2>
-            <div id="activity-heatmap"></div>
             <button id="start-game-btn" class="btn">시작</button>
         </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -608,6 +608,17 @@ td input.activity-input:not(:first-child) {
     .heatmap-cell.level-3 { background: #a3e4b6; }
     .heatmap-cell.level-4 { background: #d1f2d6; }
 
+    /* Sidebar placement for heatmap */
+    #left-sidebar {
+        position: fixed;
+        top: 12rem;
+        left: 1rem;
+        z-index: 50;
+    }
+    #left-sidebar #activity-heatmap {
+        margin-top: 0;
+    }
+
     /* Character Assistant Styles */
     #character-assistant {
         position: fixed;


### PR DESCRIPTION
## Summary
- move the activity heatmap from the start modal to a left sidebar
- style the sidebar so the heatmap is fixed on the left

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687fef17bfb8832ca00ee0102adac300