### PR TITLE
Add heatmap panel inside settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,6 @@
       <button id="reset-btn" class="btn hidden">재시작</button>
     </div>
   </header>
-  <aside id="left-sidebar">
-      <div id="activity-heatmap"></div>
-  </aside>
   <main id="music-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="performance">연주</div>
@@ -3134,52 +3131,60 @@
 
   <div id="start-modal" class="modal-overlay">
         <div class="modal-content">
-            <h2>주제 선택</h2>
-            <div class="topic-selector">
-                <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>
-                <button class="btn topic-btn" data-topic="competency">역량</button>
-                <button class="btn topic-btn" data-topic="model">모형</button>
-                <button class="btn topic-btn" data-topic="course">교육과정</button>
-                <button class="btn topic-btn" data-topic="basic">기본이론</button>
-                <button class="btn topic-btn" data-topic="essay">논술</button>
-            </div>
-            <h2>과목 선택</h2>
-            <div class="subject-selector">
-                <button class="btn subject-btn selected" data-subject="music" data-topic="curriculum">음악</button>
-                <button class="btn subject-btn" data-subject="art" data-topic="curriculum">미술</button>
-                <button class="btn subject-btn" data-subject="korean" data-topic="curriculum">국어</button>
-                <button class="btn subject-btn" data-subject="life" data-topic="curriculum">바른 생활</button>
-                <button class="btn subject-btn" data-subject="wise" data-topic="curriculum">슬기로운 생활</button>
-                <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐거운 생활</button>
-                <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
-                <button class="btn subject-btn" data-subject="english" data-topic="basic">영어</button>
-                <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
-                <button class="btn subject-btn" data-subject="practical" data-topic="model">실과</button>
-                <button class="btn subject-btn" data-subject="social" data-topic="model">사회</button>
-                <button class="btn subject-btn" data-subject="science" data-topic="model">과학</button>
-                <button class="btn subject-btn" data-subject="pe-back" data-topic="course">체육(뒷교)</button>
-                <button class="btn subject-btn" data-subject="creative" data-topic="course">창체</button>
-                <button class="btn subject-btn" data-subject="overview" data-topic="course">총론</button>
-                <button class="btn subject-btn" data-subject="integrated-course" data-topic="course">통합</button>
-                <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model basic">랜덤</button>
-            </div>
-            <h2>게임 모드</h2>
-            <div class="mode-selector">
-                <button class="btn mode-btn selected" data-mode="normal">기본 모드</button>
-                <button class="btn mode-btn" data-mode="hard-core">하드 코어</button>
-            </div>
-            <div id="time-setter-wrapper">
-                <h2>제한 시간 선택</h2>
-                <div class="time-setter">
-                    <button id="decrease-time" class="btn time-control-btn">-</button>
-                    <div id="time-setting-display">15:00</div>
-                    <button id="increase-time" class="btn time-control-btn">+</button>
+            <div class="settings-container">
+                <aside class="heatmap-panel">
+                    <h3>최근 기여도</h3>
+                    <div id="activity-heatmap"></div>
+                </aside>
+                <div class="settings-main">
+                    <h2>주제 선택</h2>
+                    <div class="topic-selector">
+                        <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>
+                        <button class="btn topic-btn" data-topic="competency">역량</button>
+                        <button class="btn topic-btn" data-topic="model">모형</button>
+                        <button class="btn topic-btn" data-topic="course">교육과정</button>
+                        <button class="btn topic-btn" data-topic="basic">기본이론</button>
+                        <button class="btn topic-btn" data-topic="essay">논술</button>
+                    </div>
+                    <h2>과목 선택</h2>
+                    <div class="subject-selector">
+                        <button class="btn subject-btn selected" data-subject="music" data-topic="curriculum">음악</button>
+                        <button class="btn subject-btn" data-subject="art" data-topic="curriculum">미술</button>
+                        <button class="btn subject-btn" data-subject="korean" data-topic="curriculum">국어</button>
+                        <button class="btn subject-btn" data-subject="life" data-topic="curriculum">바른 생활</button>
+                        <button class="btn subject-btn" data-subject="wise" data-topic="curriculum">슬기로운 생활</button>
+                        <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐거운 생활</button>
+                        <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
+                        <button class="btn subject-btn" data-subject="english" data-topic="basic">영어</button>
+                        <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
+                        <button class="btn subject-btn" data-subject="practical" data-topic="model">실과</button>
+                        <button class="btn subject-btn" data-subject="social" data-topic="model">사회</button>
+                        <button class="btn subject-btn" data-subject="science" data-topic="model">과학</button>
+                        <button class="btn subject-btn" data-subject="pe-back" data-topic="course">체육(뒷교)</button>
+                        <button class="btn subject-btn" data-subject="creative" data-topic="course">창체</button>
+                        <button class="btn subject-btn" data-subject="overview" data-topic="course">총론</button>
+                        <button class="btn subject-btn" data-subject="integrated-course" data-topic="course">통합</button>
+                        <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model basic">랜덤</button>
+                    </div>
+                    <h2>게임 모드</h2>
+                    <div class="mode-selector">
+                        <button class="btn mode-btn selected" data-mode="normal">기본 모드</button>
+                        <button class="btn mode-btn" data-mode="hard-core">하드 코어</button>
+                    </div>
+                    <div id="time-setter-wrapper">
+                        <h2>제한 시간 선택</h2>
+                        <div class="time-setter">
+                            <button id="decrease-time" class="btn time-control-btn">-</button>
+                            <div id="time-setting-display">15:00</div>
+                            <button id="increase-time" class="btn time-control-btn">+</button>
+                        </div>
+                    </div>
+                    <div id="hard-core-description" class="notice-text hidden">
+                        <p>제한시간 60초, 정답 시 +5초가 주어집니다.</p>
+                    </div>
+                    <button id="start-game-btn" class="btn">시작</button>
                 </div>
             </div>
-            <div id="hard-core-description" class="notice-text hidden">
-                <p>제한시간 60초, 정답 시 +5초가 주어집니다.</p>
-            </div>
-            <button id="start-game-btn" class="btn">시작</button>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -608,15 +608,25 @@ td input.activity-input:not(:first-child) {
     .heatmap-cell.level-3 { background: #a3e4b6; }
     .heatmap-cell.level-4 { background: #d1f2d6; }
 
-    /* Sidebar placement for heatmap */
-    #left-sidebar {
-        position: fixed;
-        top: 12rem;
-        left: 1rem;
-        z-index: 50;
+    /* Start modal layout for heatmap */
+    #start-modal .modal-content {
+        display: flex;
+        gap: 2rem;
+        max-width: 800px;
+        text-align: left;
     }
-    #left-sidebar #activity-heatmap {
-        margin-top: 0;
+    #start-modal .heatmap-panel {
+        width: 220px;
+        flex-shrink: 0;
+        text-align: center;
+    }
+    #start-modal .heatmap-panel h3 {
+        font-family: 'Press Start 2P', cursive;
+        color: var(--primary);
+        margin-bottom: 1rem;
+    }
+    #start-modal .settings-main {
+        flex: 1;
     }
 
     /* Character Assistant Styles */


### PR DESCRIPTION
## Summary
- show contribution heatmap only inside the start modal
- layout start modal with new heatmap panel on the left

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ff20b526c832c9648fdfb8cdd86be