### PR TITLE
Fix Contributions heading layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -595,7 +595,7 @@ td input.activity-input:not(:first-child) {
         grid-template-columns: repeat(7, 1fr);
         gap: 4px;
         justify-items: center;
-        margin-top: 1rem;
+        margin: 1rem auto 0;
     }
     .heatmap-cell {
         width: 20px;
@@ -616,10 +616,13 @@ td input.activity-input:not(:first-child) {
     }
     #heatmap-panel {
         max-width: 260px;
+        text-align: center;
     }
     #heatmap-panel h2 {
         margin-bottom: 1rem;
-        font-size: 2rem;
+        font-size: 1.6rem;
+        font-family: 'Noto Sans KR', sans-serif;
+        word-break: keep-all;
     }
 
     /* Character Assistant Styles */


### PR DESCRIPTION
## Summary
- center the activity heatmap grid
- shrink and wrap the heatmap heading for better readability

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ff5671374832cbbc9cccfd8df6bd0