### PR TITLE
Add flashing win lights for slot machine

### DIFF
--- a/app.js
+++ b/app.js
@@ -368,15 +368,8 @@
                     playSound(slotWinAudio);
                     slotMachineEl.classList.add('win');
                     setTimeout(() => slotMachineEl.classList.remove('win'), 1000);
-                    const duration = 800;
-                    const end = Date.now() + duration;
-                    const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 300 };
-                    const interval = setInterval(() => {
-                        const timeLeft = end - Date.now();
-                        if (timeLeft <= 0) return clearInterval(interval);
-                        const count = 50 * (timeLeft / duration);
-                        confetti({ ...defaults, particleCount: count, origin: { x: Math.random(), y: Math.random() - 0.2 } });
-                    }, 200);
+                    slotMachineEl.classList.add('win-lights');
+                    setTimeout(() => slotMachineEl.classList.remove('win-lights'), 800);
                 }
                 setTimeout(() => this.start(), 1000);
             },

--- a/styles.css
+++ b/styles.css
@@ -137,14 +137,24 @@
     }
 
 /* Flash reels when the slot machine hits a win */
-    .slot-machine.win .reel {
-      animation: reel-win-flash 0.4s ease-out 0s 2;
-    }
+  .slot-machine.win .reel {
+    animation: reel-win-flash 0.4s ease-out 0s 2;
+  }
 
-    @keyframes reel-win-flash {
-      0%, 100% { transform: scale(1); box-shadow: 0 0 0 var(--accent); }
-      50% { transform: scale(1.3); box-shadow: 0 0 15px var(--accent); }
-    }
+  @keyframes reel-win-flash {
+    0%, 100% { transform: scale(1); box-shadow: 0 0 0 var(--accent); }
+    50% { transform: scale(1.3); box-shadow: 0 0 15px var(--accent); }
+  }
+
+  /* Brief glow/shake for the entire machine on a win */
+  .slot-machine.win-lights {
+    animation: machine-glow 0.3s ease-out 0s 3;
+  }
+
+  @keyframes machine-glow {
+    0%, 100% { box-shadow: 0 0 0 0 var(--accent); transform: translateX(0); }
+    50% { box-shadow: 0 0 20px 5px var(--accent); transform: translateX(-2px); }
+  }
 
     .btn {
       cursor: pointer;


### PR DESCRIPTION
## Summary
- show a quick glow on the slot machine when all reels match
- remove the old confetti logic
- keep the slot-machine reset behavior the same

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880506126c8832ca427abab935e6a3d