### PR TITLE
Fix settings panel height

### DIFF
--- a/index.html
+++ b/index.html
@@ -3131,7 +3131,7 @@
 
   <div id="start-modal" class="modal-overlay">
         <div class="modal-boxes">
-            <div class="modal-content">
+            <div id="settings-panel" class="modal-content">
             <h2>주제 선택</h2>
             <div class="topic-selector">
                 <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>

--- a/styles.css
+++ b/styles.css
@@ -1287,3 +1287,7 @@ td input.activity-input:not(:first-child) {
   color: var(--revealed);
   border-color: var(--revealed);
 }
+#settings-panel {
+    height: 600px;
+    overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- keep the start modal height consistent when switching topics by giving the settings panel a fixed height

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688060268d90832cb41e406cf09689c8