### PR TITLE
Unify achievement blanks with overview style

### DIFF
--- a/app.js
+++ b/app.js
@@ -394,7 +394,7 @@
        }
 
        function adjustCreativeInputWidths() {
-            document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer]')
+            document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #science-std-quiz-main .overview-question input[data-answer]')
                 .forEach(input => {
                     const answer = input.dataset.answer || '';
                     const answerLen = answer.length;
@@ -750,7 +750,8 @@
             if (
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.CREATIVE ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.OVERVIEW ||
-                gameState.selectedSubject === CONSTANTS.SUBJECTS.INTEGRATED_COURSE
+                gameState.selectedSubject === CONSTANTS.SUBJECTS.INTEGRATED_COURSE ||
+                gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD
             ) {
                 adjustCreativeInputWidths();
             } else if (
@@ -1160,7 +1161,9 @@
                             gameState.selectedSubject ===
                                 CONSTANTS.SUBJECTS.OVERVIEW ||
                             gameState.selectedSubject ===
-                                CONSTANTS.SUBJECTS.INTEGRATED_COURSE
+                                CONSTANTS.SUBJECTS.INTEGRATED_COURSE ||
+                            gameState.selectedSubject ===
+                                CONSTANTS.SUBJECTS.SCIENCE_STD
                         ) {
                             adjustCreativeInputWidths();
                         }
@@ -1182,7 +1185,9 @@
                                     gameState.selectedSubject ===
                                         CONSTANTS.SUBJECTS.OVERVIEW ||
                                     gameState.selectedSubject ===
-                                        CONSTANTS.SUBJECTS.INTEGRATED_COURSE
+                                        CONSTANTS.SUBJECTS.INTEGRATED_COURSE ||
+                                    gameState.selectedSubject ===
+                                        CONSTANTS.SUBJECTS.SCIENCE_STD
                                 ) {
                                     adjustCreativeInputWidths();
                                 }
@@ -1212,7 +1217,8 @@
                         if (
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.CREATIVE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.OVERVIEW ||
-                            gameState.selectedSubject === CONSTANTS.SUBJECTS.INTEGRATED_COURSE
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.INTEGRATED_COURSE ||
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD
                         ) {
                             adjustCreativeInputWidths();
                         }

--- a/styles.css
+++ b/styles.css
@@ -1195,7 +1195,8 @@ td input.activity-input:not(:first-child) {
   margin-bottom: 3rem; /* extra spacing between questions */
 }
 #overview-quiz-main .overview-question,
-#integrated-course-quiz-main .overview-question {
+#integrated-course-quiz-main .overview-question,
+#science-std-quiz-main .overview-question {
   display: block;
   line-height: 1.8;
   font-size: 2rem;
@@ -1208,7 +1209,8 @@ td input.activity-input:not(:first-child) {
   border-bottom: none;
 }
 #overview-quiz-main .overview-question:last-child,
-#integrated-course-quiz-main .overview-question:last-child {
+#integrated-course-quiz-main .overview-question:last-child,
+#science-std-quiz-main .overview-question:last-child {
   border-bottom: none;
 }
 #creative-quiz-main .creative-question input {
@@ -1224,7 +1226,8 @@ td input.activity-input:not(:first-child) {
   min-width: 8ch;
 }
 #overview-quiz-main .overview-question input,
-#integrated-course-quiz-main .overview-question input {
+#integrated-course-quiz-main .overview-question input,
+#science-std-quiz-main .overview-question input {
   font-size: 2rem;
   padding: 0.2rem 0.4rem;
   margin: 0 0.4rem;
@@ -1243,7 +1246,8 @@ td input.activity-input:not(:first-child) {
   border-color: var(--primary);
 }
 #overview-quiz-main .overview-question input:focus,
-#integrated-course-quiz-main .overview-question input:focus {
+#integrated-course-quiz-main .overview-question input:focus,
+#science-std-quiz-main .overview-question input:focus {
   outline: none;
   border-color: var(--primary);
 }
@@ -1253,7 +1257,8 @@ td input.activity-input:not(:first-child) {
   color: var(--correct);
 }
 #overview-quiz-main .overview-question input.correct,
-#integrated-course-quiz-main .overview-question input.correct {
+#integrated-course-quiz-main .overview-question input.correct,
+#science-std-quiz-main .overview-question input.correct {
   border-color: var(--correct);
   color: var(--correct);
 }
@@ -1263,7 +1268,8 @@ td input.activity-input:not(:first-child) {
   color: var(--incorrect);
 }
 #overview-quiz-main .overview-question input.incorrect,
-#integrated-course-quiz-main .overview-question input.incorrect {
+#integrated-course-quiz-main .overview-question input.incorrect,
+#science-std-quiz-main .overview-question input.incorrect {
   border-color: var(--incorrect);
   color: var(--incorrect);
 }
@@ -1273,7 +1279,8 @@ td input.activity-input:not(:first-child) {
   color: var(--retrying);
 }
 #overview-quiz-main .overview-question input.retrying,
-#integrated-course-quiz-main .overview-question input.retrying {
+#integrated-course-quiz-main .overview-question input.retrying,
+#science-std-quiz-main .overview-question input.retrying {
   border-color: var(--retrying);
   color: var(--retrying);
 }
@@ -1283,7 +1290,8 @@ td input.activity-input:not(:first-child) {
   border-color: var(--revealed);
 }
 #overview-quiz-main .overview-question input.revealed,
-#integrated-course-quiz-main .overview-question input.revealed {
+#integrated-course-quiz-main .overview-question input.revealed,
+#science-std-quiz-main .overview-question input.revealed {
   color: var(--revealed);
   border-color: var(--revealed);
 }


### PR DESCRIPTION
## Summary
- match `science-std` achievement inputs with overview styling
- resize achievement blanks like overview sections

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880655565d4832ca492a14afe1f4f43