### PR TITLE
Fix start modal width

### DIFF
--- a/index.html
+++ b/index.html
@@ -3166,7 +3166,7 @@
 
   <div id="start-modal" class="modal-overlay">
         <div class="modal-boxes">
-            <div class="modal-content">
+            <div id="settings-panel" class="modal-content">
             <h2>주제 선택</h2>
             <div class="topic-selector">
                 <button class="btn topic-btn selected" data-topic="curriculum">내체표</button>

--- a/styles.css
+++ b/styles.css
@@ -638,9 +638,15 @@ td input.activity-input:not(:first-child) {
         gap: 2rem;
         align-items: flex-start;
     }
+    #settings-panel {
+        width: 600px;
+        max-width: 600px;
+        flex-shrink: 0;
+    }
     #heatmap-panel {
         max-width: 260px;
         text-align: center;
+        flex-shrink: 0;
     }
     #heatmap-panel h2 {
         margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- keep start modal width from jumping

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6880662ddb74832c904ee3d93ecb4549