### PR TITLE
Fix width overflow for long quiz questions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1196,6 +1196,7 @@ td input.activity-input:not(:first-child) {
   line-height: 1.8; /* more breathing room for multi-line questions */
   font-size: 2rem;
   font-weight: 500;
+  overflow-wrap: anywhere; /* prevent long text from breaking layout */
   padding-bottom: 2rem;
   border-bottom: 2px dashed var(--secondary);
   margin-bottom: 3rem; /* extra spacing between questions */
@@ -1207,6 +1208,7 @@ td input.activity-input:not(:first-child) {
   line-height: 1.8;
   font-size: 2rem;
   font-weight: 500;
+  overflow-wrap: anywhere; /* handle long questions gracefully */
   padding-bottom: 2rem;
   border-bottom: 2px dashed var(--secondary);
   margin-bottom: 3rem;


### PR DESCRIPTION
## Summary
- wrap long text in creative and overview quiz question blocks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68806eb92490832c8ec63d1628898c96