### PR TITLE
Improve Science Achievement Layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1362,6 +1362,7 @@
     <section id="life" class="active">
       <h2>생명</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="achievement-block">
         <div class="outline-title">#동물의 생활</div>
         <div class="overview-question">[4과02-01] 여러 가지 동물을 관찰하여 <input data-answer="특징" aria-label="특징" placeholder="정답">에 따라 동물을 <input data-answer="분류" aria-label="분류" placeholder="정답">할 수 있다.</div>
         <div class="overview-question">• [4과02-01] 동물의 <input data-answer="형태적 특징" aria-label="형태적 특징" placeholder="정답">을 찾고 그 특징에 따라 <input data-answer="분류 기준" aria-label="분류 기준" placeholder="정답">을 정하여 분류하는 활동을 하도록 하며 <input data-answer="생물학적 분류 체계" aria-label="생물학적 분류 체계" placeholder="정답">는 다루지 않는다.</div>
@@ -1375,6 +1376,9 @@
         <div class="outline-title">(나) 성취기준 적용 시 고려 사항</div>
         <div class="overview-question">• 초등학교 3∼4학년군 ‘생물의 한살이’, ‘생물과 환경’, 5∼6학년군 ‘우리 몸의 구조와 기능’과 중학교 1∼3학년군 ‘생물의 구성과 다양성’, ‘동물과 에너지’와 연계된다.</div>
         <div class="overview-question">• ‘동물의 생활’에서는 여러 가지 동물의 <input data-answer="형태적 특징" aria-label="형태적 특징" placeholder="정답">을 중심으로 <input data-answer="관찰" aria-label="관찰" placeholder="정답">, <input data-answer="분류" aria-label="분류" placeholder="정답"> 활동을 한다.</div>
+        </div>
+
+        <div class="achievement-block">
 
         <div class="outline-title">#식물의 생활</div>
         <div class="overview-question">[4과03-01] 여러 가지 식물을 관찰하여 <input data-answer="특징" aria-label="특징" placeholder="정답">에 따라 식물을 <input data-answer="분류" aria-label="분류" placeholder="정답">할 수 있다.</div>
@@ -1391,6 +1395,7 @@
         <div class="overview-question">• 여러 가지 식물을 줄기, 잎, 꽃 등으로 분류 활동을 할 수 있으나, <input data-answer="주변" aria-label="주변" placeholder="정답">에서 쉽게 구할 수 있는 식물의 <input data-answer="잎" aria-label="잎" placeholder="정답">을 대상으로 활동하도록 한다.</div>
         <div class="overview-question">• 초등학교 5∼6학년군 ‘식물의 구조와 기능’에서 각 부위의 <input data-answer="구조" aria-label="구조" placeholder="정답">와 <input data-answer="기능" aria-label="기능" placeholder="정답">을 이해하는 데 중점을 두고 다루므로 ‘식물의 생활’에서는 여러 가지 식물의 <input data-answer="잎" aria-label="잎" placeholder="정답">을 중심으로 <input data-answer="관찰" aria-label="관찰" placeholder="정답">, <input data-answer="분류" aria-label="분류" placeholder="정답"> 활동을 한다.</div>
 
+        </div>
         <div class="outline-title">#생물의 한살이</div>
         <div class="overview-question">[4과04-01] <input data-answer="동물의 한살이" aria-label="동물의 한살이" placeholder="정답">를 직접 관찰하고, 관찰한 내용을 글과 그림으로 표현할 수 있다.</div>
         <div class="overview-question">[4과04-02] <input data-answer="식물" aria-label="식물" placeholder="정답">이 자라는 데 필요한 <input data-answer="조건" aria-label="조건" placeholder="정답">을 찾는 실험을 설계하여 수행할 수 있다.</div>

--- a/styles.css
+++ b/styles.css
@@ -1171,11 +1171,24 @@ td input.activity-input:not(:first-child) {
   border: 2px solid var(--secondary);
   border-radius: 8px;
 }
+#science-std-quiz-main .achievement-block {
+  margin-bottom: 2rem;
+  padding: 1rem;
+  background: var(--bg-light);
+  border: 2px solid var(--secondary);
+  border-radius: 8px;
+}
 #creative-quiz-main .outline-title {
   font-size: 2rem;
   font-weight: 700;
   margin-bottom: 1rem;
   color: var(--primary);
+}
+#science-std-quiz-main .outline-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #ff5555;
 }
 #overview-quiz-main .outline-title,
 #integrated-course-quiz-main .outline-title {


### PR DESCRIPTION
## Summary
- wrap biology sections in `.achievement-block` for better readability
- highlight science section headings in red

## Testing
- `npm run lint` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68807133a19c832ca09d97e02ac9588a