### PR TITLE
Add complete functional language guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -2750,9 +2750,205 @@
     </section>
     <section id="functional">
       <h2>기능별 언어 지도</h2>
-      <div class="grade-container"><div><table><tbody>
-        <tr><th>개념</th><td><input data-answer="기능별 언어 지도" aria-label="기능별 언어 지도" placeholder="정답"></td></tr>
-      </tbody></table></div></div>
+      <div class="grade-container">
+        <div>
+          <div class="grade-title">공통</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>교수-학습 요소
+                <ul class="sub-list">
+                  <li class="inline-item"><input class="fit-answer" data-answer="motivation" aria-label="motivation" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="schema" aria-label="schema" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="personalization" aria-label="personalization" placeholder="정답"></li>
+                </ul>
+              </li>
+              <li>수업 초점
+                <ul class="sub-list">
+                  <li class="inline-item"><input class="fit-answer" data-answer="fluecny" aria-label="fluecny" placeholder="정답"> → <input class="fit-answer" data-answer="message-oriented" aria-label="message-oriented" placeholder="정답"> → <input class="fit-answer" data-answer="language use" aria-label="language use" placeholder="정답"></li>
+                  <li class="inline-item"><input class="fit-answer" data-answer="accuracy" aria-label="accuracy" placeholder="정답"> → <input class="fit-answer" data-answer="language-oriented" aria-label="language-oriented" placeholder="정답"> → <input class="fit-answer" data-answer="language usage" aria-label="language usage" placeholder="정답"></li>
+                </ul>
+              </li>
+              <li class="inline-item"><input class="fit-answer" data-answer="skill integration" aria-label="skill integration" placeholder="정답"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="Computer-Assisted Language Learning" aria-label="Computer-Assisted Language Learning" placeholder="정답"> = <input class="fit-answer" data-answer="CALL" aria-label="CALL" placeholder="정답"></li>
+              <li class="inline-item">Computer-Mediated Communication → <input class="fit-answer" data-answer="synchronous" aria-label="synchronous" placeholder="정답">/<input class="fit-answer" data-answer="asynchronous" aria-label="asynchronous" placeholder="정답"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="blended learning" aria-label="blended learning" placeholder="정답"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="flipped learning" aria-label="flipped learning" placeholder="정답"></li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+        <div>
+          <div class="grade-title">이해 기능 (Receptive Skills)</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>[공통]
+                <ul class="sub-list">
+                  <li>이해 처리 과정
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="bottom-up" aria-label="bottom-up" placeholder="정답"> → <input class="fit-answer" data-answer="decoding" aria-label="decoding" placeholder="정답"></li>
+                      <li><input class="fit-answer" data-answer="top-down" aria-label="top-down" placeholder="정답">
+                        <ul class="sub-list">
+                          <li class="inline-item"><input class="fit-answer" data-answer="deriving meaning" aria-label="deriving meaning" placeholder="정답"></li>
+                          <li class="inline-item"><input class="fit-answer" data-answer="schema" aria-label="schema" placeholder="정답"></li>
+                          <li class="inline-item"><input class="fit-answer" data-answer="interpretation" aria-label="interpretation" placeholder="정답"></li>
+                          <li class="inline-item"><input class="fit-answer" data-answer="global understanding" aria-label="global understanding" placeholder="정답"></li>
+                        </ul>
+                      </li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="interactive" aria-label="interactive" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                  <li>과정중심지도
+                    <ul class="sub-list">
+                      <li class="inline-item">전: <input class="fit-answer" data-answer="어휘" aria-label="어휘" placeholder="정답">, <input class="fit-answer" data-answer="목적" aria-label="목적" placeholder="정답">, <input class="fit-answer" data-answer="schema" aria-label="schema" placeholder="정답">, <input class="fit-answer" data-answer="motivation" aria-label="motivation" placeholder="정답"></li>
+                      <li class="inline-item">중: <input class="fit-answer" data-answer="의미이해" aria-label="의미이해" placeholder="정답">를 도움</li>
+                      <li class="inline-item">후: <input class="fit-answer" data-answer="이해확인" aria-label="이해확인" placeholder="정답">, <input class="fit-answer" data-answer="상향식 이해처리 연습" aria-label="상향식 이해처리 연습" placeholder="정답">, <input class="fit-answer" data-answer="skillintegration" aria-label="skillintegration" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+              <li>[listening]
+                <ul class="sub-list">
+                  <li>교실 듣기 유형
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="reactive" aria-label="reactive" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="responsive" aria-label="responsive" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="intensive" aria-label="intensive" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="extensive" aria-label="extensive" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="selective" aria-label="selective" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="interactive" aria-label="interactive" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+              <li>[reading]
+                <ul class="sub-list">
+                  <li>단계
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="literal" aria-label="literal" placeholder="정답"> comprehension</li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="interpretive" aria-label="interpretive" placeholder="정답">/<input class="fit-answer" data-answer="inferential" aria-label="inferential" placeholder="정답"> comprehension</li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="critical" aria-label="critical" placeholder="정답"> comprehension</li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="creative" aria-label="creative" placeholder="정답"> comprehension</li>
+                    </ul>
+                  </li>
+                  <li>전략
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="scanning" aria-label="scanning" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="skimming" aria-label="skimming" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="semantic mapping" aria-label="semantic mapping" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="guessing" aria-label="guessing" placeholder="정답">/<input class="fit-answer" data-answer="inferencing" aria-label="inferencing" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="thinking aloud" aria-label="thinking aloud" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                  <li>읽기지도방법
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="dictcated stories" aria-label="dictcated stories" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="reading aloud" aria-label="reading aloud" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="shared reading" aria-label="shared reading" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="sustained silent reading" aria-label="sustained silent reading" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                  <li>유형
+                    <ul class="sub-list">
+                      <li class="inline-item">1: <input class="fit-answer" data-answer="intensive" aria-label="intensive" placeholder="정답"> → <input class="fit-answer" data-answer="classroom-oriented" aria-label="classroom-oriented" placeholder="정답"></li>
+                      <li class="inline-item">1: <input class="fit-answer" data-answer="extensive" aria-label="extensive" placeholder="정답"> → <input class="fit-answer" data-answer="outside class time" aria-label="outside class time" placeholder="정답">, <input class="fit-answer" data-answer="pleasure reading" aria-label="pleasure reading" placeholder="정답"></li>
+                      <li class="inline-item">2: <input class="fit-answer" data-answer="reading aloud" aria-label="reading aloud" placeholder="정답"> → <input class="fit-answer" data-answer="실제성" aria-label="실제성" placeholder="정답">↓, <input class="fit-answer" data-answer="내용 이해" aria-label="내용 이해" placeholder="정답"> 어려움</li>
+                      <li class="inline-item">2: <input class="fit-answer" data-answer="silent rading" aria-label="silent rading" placeholder="정답"></li>
+                      <li>3: <input class="fit-answer" data-answer="repeated reading" aria-label="repeated reading" placeholder="정답"> → <input class="fit-answer" data-answer="readers' theatre" aria-label="readers' theatre" placeholder="정답">
+                        <ul class="sub-list">
+                          <li class="inline-item">효과: <input class="fit-answer" data-answer="fluency" aria-label="fluency" placeholder="정답"> ↑</li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>기타
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="phonics" aria-label="phonics" placeholder="정답"> → <input class="fit-answer" data-answer="decodable text" aria-label="decodable text" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="sight words" aria-label="sight words" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+        <div>
+          <div class="grade-title">표현 기능 (Productive Skills)</div>
+          <table><tbody><tr><td>
+            <ul class="assessment-list">
+              <li>[공통]
+                <ul class="sub-list">
+                  <li class="inline-item">지도단계: <input class="fit-answer" data-answer="controlled" aria-label="controlled" placeholder="정답"> → <input class="fit-answer" data-answer="guided" aria-label="guided" placeholder="정답"> → <input class="fit-answer" data-answer="free" aria-label="free" placeholder="정답"></li>
+                </ul>
+              </li>
+              <li>[speaking]
+                <ul class="sub-list">
+                  <li>drill
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="mechanical" aria-label="mechanical" placeholder="정답">: <input class="fit-answer" data-answer="의미 이해" aria-label="의미 이해" placeholder="정답"> 필요 없음, 답은 <input class="fit-answer" data-answer="1개" aria-label="1개" placeholder="정답"></li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="meaningful" aria-label="meaningful" placeholder="정답">: <input class="fit-answer" data-answer="의미 이해" aria-label="의미 이해" placeholder="정답"> 필요, 답은 <input class="fit-answer" data-answer="2개 이상" aria-label="2개 이상" placeholder="정답">, <input class="fit-answer" data-answer="정보차" aria-label="정보차" placeholder="정답"> X</li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="communicative" aria-label="communicative" placeholder="정답">: <input class="fit-answer" data-answer="정보차" aria-label="정보차" placeholder="정답"> O, 목표 구문 연습한다는 점에서 <input class="fit-answer" data-answer="통제" aria-label="통제" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                  <li>PPP
+                    <ul class="sub-list">
+                      <li class="inline-item"><input class="fit-answer" data-answer="presentation" aria-label="presentation" placeholder="정답"></li>
+                      <li><input class="fit-answer" data-answer="practice" aria-label="practice" placeholder="정답">
+                        <ul class="sub-list">
+                          <li class="inline-item"><input class="fit-answer" data-answer="controlled" aria-label="controlled" placeholder="정답"></li>
+                          <li class="inline-item"><input class="fit-answer" data-answer="guided" aria-label="guided" placeholder="정답"></li>
+                        </ul>
+                      </li>
+                      <li class="inline-item"><input class="fit-answer" data-answer="production" aria-label="production" placeholder="정답"></li>
+                    </ul>
+                  </li>
+                  <li>오류 지도
+                    <ul class="sub-list">
+                      <li>유형
+                        <ul class="sub-list">
+                          <li class="inline-item">1.<input class="fit-answer" data-answer="global" aria-label="global" placeholder="정답"> – <input class="fit-answer" data-answer="fluency" aria-label="fluency" placeholder="정답"> 초점</li>
+                          <li class="inline-item">1.<input class="fit-answer" data-answer="local" aria-label="local" placeholder="정답"> – <input class="fit-answer" data-answer="accuracy" aria-label="accuracy" placeholder="정답"> 초점</li>
+                          <li class="inline-item">2.<input class="fit-answer" data-answer="interference" aria-label="interference" placeholder="정답"> – L1-&gt; L2</li>
+                          <li class="inline-item">2.<input class="fit-answer" data-answer="developmental" aria-label="developmental" placeholder="정답"> – L2 – <input class="fit-answer" data-answer="overgeneralization" aria-label="overgeneralization" placeholder="정답"></li>
+                        </ul>
+                      </li>
+                      <li>원인
+                        <ul class="sub-list">
+                          <li class="inline-item"><input class="fit-answer" data-answer="interlingual transfer" aria-label="interlingual transfer" placeholder="정답"></li>
+                          <li class="inline-item"><input class="fit-answer" data-answer="intralingual transfer" aria-label="intralingual transfer" placeholder="정답"></li>
+                          <li class="inline-item"><input class="fit-answer" data-answer="communication strategies" aria-label="communication strategies" placeholder="정답"></li>
+                        </ul>
+                      </li>
+                      <li>피드백 유형
+                        <ul class="sub-list">
+                          <li>input providing
+                            <ul class="sub-list">
+                              <li class="inline-item"><input class="fit-answer" data-answer="explicit correction" aria-label="explicit correction" placeholder="정답"></li>
+                              <li class="inline-item"><input class="fit-answer" data-answer="recast" aria-label="recast" placeholder="정답"></li>
+                            </ul>
+                          </li>
+                          <li>output prompting
+                            <ul class="sub-list">
+                              <li class="inline-item"><input class="fit-answer" data-answer="metalinguistic feedback" aria-label="metalinguistic feedback" placeholder="정답"></li>
+                              <li class="inline-item"><input class="fit-answer" data-answer="repetition" aria-label="repetition" placeholder="정답"></li>
+                              <li class="inline-item"><input class="fit-answer" data-answer="elicitation" aria-label="elicitation" placeholder="정답"></li>
+                              <li class="inline-item"><input class="fit-answer" data-answer="clarification request" aria-label="clarification request" placeholder="정답"></li>
+                            </ul>
+                          </li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+              <li>[writing]
+                <ul class="sub-list">
+                  <li class="inline-item">과정 중심 쓰기: <input class="fit-answer" data-answer="planning" aria-label="planning" placeholder="정답"> → <input class="fit-answer" data-answer="drafting" aria-label="drafting" placeholder="정답"> → <input class="fit-answer" data-answer="revising" aria-label="revising" placeholder="정답"> → <input class="fit-answer" data-answer="editing" aria-label="editing" placeholder="정답"> → <input class="fit-answer" data-answer="publishing" aria-label="publishing" placeholder="정답"></li>
+                  <li class="inline-item">피드백: <input class="fit-answer" data-answer="peer editing" aria-label="peer editing" placeholder="정답">, <input class="fit-answer" data-answer="conference" aria-label="conference" placeholder="정답">, <input class="fit-answer" data-answer="ECC" aria-label="ECC" placeholder="정답"></li>
+                </ul>
+              </li>
+            </ul>
+          </td></tr></tbody></table>
+        </div>
+      </div>
     </section>
     <section id="element">
       <h2>요소별 언어 지도</h2>


### PR DESCRIPTION
## Summary
- flesh out the English quiz section for '기능별 언어 지도'
- include receptive and productive skills content

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68809bf86174832c917892543c75a4e6