### PR TITLE
Fix HTML structure for science matter section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1495,7 +1495,6 @@
         </div>
 </td></tr></tbody></table></div></div>
     </section>
-  </main>
 <section id="matter">
   <h2>물질</h2>
   <div class="grade-container"><div><table><tbody><tr><td>
@@ -1634,6 +1633,7 @@
     </div>
   </td></tr></tbody></table></div></div>
 </section>
+</main>
   <main id="pe-back-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="teach-learn">교수⋅학습</div>


### PR DESCRIPTION
## Summary
- fix layout for the `물질` section in the science achievement standards

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68823ed530a0832c8e88617944757aca