### PR TITLE
Fix science matter quiz section display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1495,7 +1495,6 @@
         </div>
 </td></tr></tbody></table></div></div>
     </section>
-  </main>
 <section id="matter">
   <h2>물질</h2>
   <div class="grade-container"><div><table><tbody><tr><td>
@@ -1634,6 +1633,7 @@
     </div>
   </td></tr></tbody></table></div></div>
 </section>
+</main>
   <main id="pe-back-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="teach-learn">교수⋅학습</div>


### PR DESCRIPTION
## Summary
- fix closing `</main>` tag placement so matter questions display under science

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688240f450f0832cb7dae986a055c3ce