### PR TITLE
Fix PE back answer field width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1316,3 +1316,8 @@ td input.activity-input:not(:first-child) {
   color: var(--revealed);
   border-color: var(--revealed);
 }
+
+/* Wider blanks for the PE (Back) teaching methods section */
+#pe-back-quiz-main .inline-item input.fit-answer {
+  min-width: 30ch;
+}


### PR DESCRIPTION
## Summary
- widen answer blanks for "PE (Back)" teaching methods section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68826d8743a0832cb0a3435d3cbb9a54