### PR TITLE
Increase blank width for PE Back methods

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1317,7 +1317,10 @@ td input.activity-input:not(:first-child) {
   border-color: var(--revealed);
 }
 
-/* Wider blanks for the PE (Back) teaching methods section */
+/* Wider blanks for the PE (Back) teaching methods section
+   Ensure blanks expand within each numbered item */
 #pe-back-quiz-main .inline-item input.fit-answer {
+  flex: 1 1 auto;
+  width: 100%;
   min-width: 30ch;
 }


### PR DESCRIPTION
## Summary
- widen teaching methods blanks in PE (Back) section and allow them to fill available width

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68826f7f9c24832c8f9b79f99696b841