### PR TITLE
Increase PE-back method width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1322,5 +1322,5 @@ td input.activity-input:not(:first-child) {
 #pe-back-quiz-main .inline-item input.fit-answer {
   flex: 1 1 auto;
   width: 100%;
-  min-width: 30ch;
+  min-width: 60ch;
 }


### PR DESCRIPTION
## Summary
- enlarge the input width for the PE (Back) teaching methods section to give more space for answers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688270e42db0832cbcff05d30f0fc48c