### PR TITLE
Increase PE back blank width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1320,5 +1320,5 @@ td input.activity-input:not(:first-child) {
 #pe-back-quiz-main .inline-item input.fit-answer {
   flex: 1 1 auto;
   width: 100%;
-  min-width: 60ch;
+  /* Allow the blank to stretch the full cell width */
 }


### PR DESCRIPTION
## Summary
- adjust PE (back) blank width style to fully stretch within each row

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688710b8010c832c85b1c92f4e9beb0a