### PR TITLE
Disable result modal on reveal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1372,14 +1372,7 @@
                     });
             }
             showAnswersBtn.disabled = true;
-            if (isQuizComplete()) {
-                if (gameState.timerId) {
-                    gameState.total = 0;
-                    tick();
-                } else {
-                    handleGameOver();
-                }
-            }
+            // 결과 창이 즉시 표시되지 않도록 진행 상태를 확인하지 않는다.
         });
 
         // --- INITIAL SETUP ---


### PR DESCRIPTION
## Summary
- prevent results modal from appearing when clicking **정답 보기**

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68888a235cd0832ca9bb6becfffbda3b