### PR TITLE
Add moral course goal section

### DIFF
--- a/index.html
+++ b/index.html
@@ -895,6 +895,7 @@
     <div class="tabs">
       <div class="tab active" data-target="moral-overview">개요</div>
         <div class="tab" data-target="moral-character">성격</div>
+        <div class="tab" data-target="moral-goal">목표</div>
     </div>
     <section id="moral-overview" class="active">
       <h2>교육과정 설계의 개요</h2>
@@ -931,6 +932,26 @@
       <div class="overview-question">이때 <input data-answer="도덕적 지식과 실천의 연계 과정" aria-label="도덕적 지식과 실천의 연계 과정" placeholder="정답">은 인간으로서 지향해야 하는 <input data-answer="가치" aria-label="가치" placeholder="정답">로서의 <input data-answer="도" aria-label="도" placeholder="정답">와 그 도에 이르고자 하는 <input data-answer="실천 역량" aria-label="실천 역량" placeholder="정답">으로서 <input data-answer="덕" aria-label="덕" placeholder="정답">을 기반으로 삼아, 도덕적 탐구와 윤리적 성찰, 일상의 실천이 몸과 마음에 새겨져 도덕적 행동으로 연결될 수 있는 가능성을 높이고자 하는 과정을 지칭하는 개념이기도 하다.</div>
       <div class="overview-question">우리 학교 상황 속에서 도덕 교과는 특히 <input data-answer="인성 교육" aria-label="인성 교육" placeholder="정답">과 <input data-answer="시민교육" aria-label="시민교육" placeholder="정답">에서 중요한 역할을 감당해주어야 한다는 요청을 받고 있다. 도덕 교과는 <input data-answer="바람직한 인성" aria-label="바람직한 인성" placeholder="정답">을 함양하기 위한 핵심 교과임과 동시에, <input data-answer="시민" aria-label="시민" placeholder="정답">의 도덕성과 역량을 길러주기 위한 학교 <input data-answer="시민교육" aria-label="시민교육" placeholder="정답">의 주요 교과 중 하나라는 위상과 역할을 부여받고 있다. 시민사회에서 개인의 바람직한 인성은 시민으로서 갖추고 있어야 할 도덕성과 기본 역량의 토대이고 시민의 역량 또한 도덕성을 기반으로 삼아 정치⋅경제적 역량 등으로 확장될 수 있기 때문에, 도덕 교과는 타 교과와의 긴밀한 연계와 협조를 전제로 시민교육을 담당하는 주요 교과로서 <input data-answer="교과통합적" aria-label="교과통합적" placeholder="정답"> 기능도 수행한다.</div>
       <div class="overview-question">이런 필요에 부응하기 위하여 도덕과는 <input data-answer="도덕적인 인간" aria-label="도덕적인 인간" placeholder="정답">을 토대로 그가 살아가야 할 <input data-answer="정의로운 사회" aria-label="정의로운 사회" placeholder="정답">를 연속적인 지향점으로 설정하고자 한다. <input data-answer="도덕적인 인간" aria-label="도덕적인 인간" placeholder="정답">은 개인적인 삶의 영역에서 <input data-answer="도덕성" aria-label="도덕성" placeholder="정답">을 핵심 지향으로 삼는 인간이고, 그 도덕적 인간의 시민사회적 외연은 자연스럽게 <input data-answer="정의로운 시민" aria-label="정의로운 시민" placeholder="정답">으로 확장된다. 이러한 교육적 인간상을 통해 도덕 교과는 학교 시민교육의 주요 교과 중 하나로서의 성격을 보다 적극적으로 천명할 수 있게 될 뿐만 아니라, 인성 교육과 시민교육 사이의 접점을 적극적으로 모색하는 교과로서의 성격도 지닐 수 있게 된다.</div>
+    </div>
+  </td></tr></tbody></table></div></div>
+</section>
+<section id="moral-goal">
+  <h2>목표</h2>
+  <div class="grade-container"><div><table><tbody><tr><td>
+    <div class="creative-block">
+      <div class="outline-title">#목표</div>
+      <div class="overview-question">도덕 교과의 목표는 <input data-answer="도덕성" aria-label="도덕성" placeholder="정답"> 함양을 통한 <input data-answer="도덕적인 인간" aria-label="도덕적인 인간" placeholder="정답">의 지향이다. 이 목표는 동시에 도덕적인 인간이 함께 살아가야 하는 사회를 보다 <input data-answer="정의로운 사회" aria-label="정의로운 사회" placeholder="정답">로 만들고자 하는 지향을 포함한다.</div>
+      <div class="overview-question">도덕성은 각각 <input data-answer="개인적" aria-label="개인적" placeholder="정답"> 도덕성과 <input data-answer="사회구조적" aria-label="사회구조적" placeholder="정답"> 도덕성으로 나뉠 수 있고, 이 두 유형의 도덕성은 서로 긴밀한 영향을 주고받으면서 한 개인과 사회적 삶의 양상에 지대한 영향을 미친다.</div>
+      <div class="overview-question">따라서 도덕 교과의 목표는 이러한 두 도덕성 사이의 유기적 연관성을 토대로 삼아, <input data-answer="성실" aria-label="성실" placeholder="정답">, <input data-answer="배려" aria-label="배려" placeholder="정답">, <input data-answer="정의" aria-label="정의" placeholder="정답">, <input data-answer="책임" aria-label="책임" placeholder="정답">의 핵심 가치를 체득하여 도덕적 <input data-answer="지식" aria-label="지식" placeholder="정답">과 <input data-answer="실천" aria-label="실천" placeholder="정답">의 과정을 <input data-answer="연계" aria-label="연계" placeholder="정답">시킬 수 있는 <input data-answer="도덕적인 인간" aria-label="도덕적인 인간" placeholder="정답">을 바탕으로 <input data-answer="정의로운 사회" aria-label="정의로운 사회" placeholder="정답">를 만들고자 하는 의지와 역량을 갖춘 시민을 육성하는 것이다.</div>
+      <div class="overview-question">도덕과는 또한 인간의 삶에 내재해 있는 도덕적 차원에 관한 인식을 출발점으로 삼아 타자와의 관계를 통해서만 가능한 삶의 속성에 관한 인식 및 수용, 그 타자들을 대하는 도덕적 태도와 실천 역량을 길러주는 것을 목표로 삼는다.</div>
+      <div class="overview-question">이러한 목표 추구를 통해 도덕과는 자신을 사고와 행위의 주체로 인식하는 바탕 위에서 비판적이면서도 도덕적인 판단을 할 수 있게 하고, 건전한 도덕적 정서를 토대로 협력적이고 공감적인 의사소통을 가능하게 할 것이다.</div>
+      <div class="overview-question">그리고 우리 사회를 보다 건강한 도덕공동체로 작동하게 하는 데 기여할 수 있다.</div>
+      <div class="overview-question">도덕과는 교사와 학생이 도덕 수업이라는 시⋅공간을 통해 사회적 차원의 도덕 현상에 관한 탐구와 자기 내면의 도덕성에 관한 성찰, 일상의 실천이라는 세 요소로 구성되는 <input data-answer="도덕적 지식과 실천의 연계 과정" aria-label="도덕적 지식과 실천의 연계 과정" placeholder="정답">을 공유함으로써 일상 속 실천과 성찰의 연결고리를 확보하는 것을 목표로 한다.</div>
+      <div class="overview-question">이는 도덕적 지식의 비판적 이해와 수용, 도덕적 사고와 정서 기능의 습득, 도덕적 가치⋅태도의 함양 등과 같은 구체적이고 연속적인 과정의 공유를 통해 가능하다.</div>
+      <div class="overview-question">(1) 자신과의 관계에서는 <input data-answer="스스로" aria-label="스스로" placeholder="정답">에 대한 정당한 인식과 <input data-answer="도덕적 초월 가능성" aria-label="도덕적 초월 가능성" placeholder="정답">에 관한 성찰을 바탕으로, 자율적인 도덕 판단 능력과 균형 잡힌 도덕적 정서, 일상의 실천 역량을 함양한다.</div>
+      <div class="overview-question">(2) 타인과의 관계에서는 <input data-answer="사회 규범" aria-label="사회 규범" placeholder="정답">으로 존재하는 도덕을 탐구하고, 그 도덕과 내면의 도덕성 사이의 관계를 성찰하여 일상의 실천으로 연결시키는 역량을 함양한다.</div>
+      <div class="overview-question">(3) 사회 및 공동체와의 관계에서는 <input data-answer="민주시민" aria-label="민주시민" placeholder="정답">으로서 필요한 비판적 사고와 배려를 토대로, 민주적 가치⋅덕목과 규범을 내면화하여 실천할 수 있는 역량을 함양한다.</div>
+      <div class="overview-question">(4) 자연과의 관계에서는 <input data-answer="기후위기" aria-label="기후위기" placeholder="정답">로 상징되는 현재의 관계 맺기 방식에 관한 비판적 성찰을 토대로, 바람직한 자연관 모색 등을 통해 인간과 자연 간의 새로운 관계를 설정하여 <input data-answer="생태학적" aria-label="생태학적" placeholder="정답">으로 <input data-answer="지속가능한 삶" aria-label="지속가능한 삶" placeholder="정답">을 실천할 수 있는 역량을 기른다.</div>
     </div>
   </td></tr></tbody></table></div></div>
 </section>


### PR DESCRIPTION
## Summary
- extend the moral course quiz tabs with a new 목표 tab
- outline 도덕 subject goals with fill-in-the-blank inputs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68889c7f4cb8832cad7a35e49cf7607f