### PR TITLE
Add shake animation for incorrect answers

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,7 +60,8 @@
                 SELECTED: 'selected',
                 IS_SELECTING: 'is-selecting',
                 ACTIVE: 'active',
-                COMBO_POP: 'combo-pop'
+                COMBO_POP: 'combo-pop',
+                SHAKE: 'shake'
             },
             DEFAULT_DURATION: 900,
             HARD_CORE_DURATION: 60,
@@ -974,6 +975,11 @@
 
                 playSound(failAudio);
                 setCharacterState('sad');
+
+                input.classList.add(CONSTANTS.CSS_CLASSES.SHAKE);
+                input.addEventListener('animationend', () => {
+                    input.classList.remove(CONSTANTS.CSS_CLASSES.SHAKE);
+                }, { once: true });
 
                 if (gameState.selectedSubject === CONSTANTS.SUBJECTS.COMPETENCY) {
                     input.classList.remove(CONSTANTS.CSS_CLASSES.RETRYING);

--- a/styles.css
+++ b/styles.css
@@ -378,6 +378,16 @@
       background: var(--bg-light);
     }
 
+    td input.shake {
+      animation: dori-dori 0.3s;
+    }
+
+    @keyframes dori-dori {
+      0%, 100% { transform: translateX(0); }
+      25% { transform: translateX(-4px); }
+      75% { transform: translateX(4px); }
+    }
+
 th.sub-area-cell {
   min-width: 22rem;
 }


### PR DESCRIPTION
## Summary
- add `shake` CSS class and keyframes for dori-dori animation
- trigger shake animation on incorrect answers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689566e538e0832cbc1dbf2db1a2d61b