### PR TITLE
feat: update input focus border color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -356,9 +356,9 @@
     }
     td input:focus {
       outline: none;
-      border-color: var(--primary);
+      border-color: #fff;
       background: var(--secondary);
-      box-shadow: 0 0 10px rgba(233, 69, 96, 0.5);
+      box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
     }
     td input.correct {
       border-color: var(--correct);
@@ -1229,7 +1229,7 @@ td input.activity-input:not(:first-child) {
 
 #creative-quiz-main .creative-question input:focus {
   outline: none;
-  border-color: var(--primary);
+  border-color: #fff;
 }
 #overview-quiz-main .overview-question input:focus,
 #integrated-course-quiz-main .overview-question input:focus,
@@ -1237,7 +1237,7 @@ td input.activity-input:not(:first-child) {
 #science-std-quiz-main .overview-question input:focus,
 #practical-std-quiz-main .overview-question input:focus {
   outline: none;
-  border-color: var(--primary);
+  border-color: #fff;
 }
 
 #creative-quiz-main .creative-question input.correct {


### PR DESCRIPTION
## Summary
- switch focused input border to white for better contrast
- align special quiz input fields with white focus border

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895676774c8832c8bd648ccbaefc1d4