### PR TITLE
Adjust input focus border color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -356,9 +356,9 @@
     }
     td input:focus {
       outline: none;
-      border-color: #fff;
+      border-color: var(--accent);
       background: var(--secondary);
-      box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+      box-shadow: 0 0 10px rgba(83, 52, 131, 0.5);
     }
     td input.correct {
       border-color: var(--correct);
@@ -1239,7 +1239,7 @@ td input.activity-input:not(:first-child) {
 
 #creative-quiz-main .creative-question input:focus {
   outline: none;
-  border-color: #fff;
+  border-color: var(--accent);
 }
 #overview-quiz-main .overview-question input:focus,
 #integrated-course-quiz-main .overview-question input:focus,
@@ -1247,7 +1247,7 @@ td input.activity-input:not(:first-child) {
 #science-std-quiz-main .overview-question input:focus,
 #practical-std-quiz-main .overview-question input:focus {
   outline: none;
-  border-color: #fff;
+  border-color: var(--accent);
 }
 
 #creative-quiz-main .creative-question input.correct {


### PR DESCRIPTION
## Summary
- tone down focus border on inputs by using accent color and matching shadow
- apply accent border to focused quiz inputs for consistency

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895693148ec832ca0166fcbb6b79687