### PR TITLE
feat: reorder curriculum subject buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4065,13 +4065,14 @@
             </div>
             <h2>과목 선택</h2>
             <div class="subject-selector">
+                <button class="btn subject-btn" data-subject="korean" data-topic="curriculum">국어</button>
                 <button class="btn subject-btn selected" data-subject="music" data-topic="curriculum">음악</button>
                 <button class="btn subject-btn" data-subject="art" data-topic="curriculum">미술</button>
-                <button class="btn subject-btn" data-subject="korean" data-topic="curriculum">국어</button>
+                <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
+                <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model basic achievement">랜덤</button>
                 <button class="btn subject-btn" data-subject="life" data-topic="curriculum">바른 생활</button>
                 <button class="btn subject-btn" data-subject="wise" data-topic="curriculum">슬기로운 생활</button>
                 <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐거운 생활</button>
-                <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
                 <button class="btn subject-btn" data-subject="english" data-topic="basic">영어</button>
                 <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
                 <button class="btn subject-btn" data-subject="practical" data-topic="model">실과</button>
@@ -4084,7 +4085,6 @@
                 <button class="btn subject-btn" data-subject="overview" data-topic="course">총론</button>
                 <button class="btn subject-btn" data-subject="integrated-course" data-topic="course">통합</button>
                 <button class="btn subject-btn" data-subject="moral-course" data-topic="course">도덕</button>
-                <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model basic achievement">랜덤</button>
             </div>
             <h2>게임 모드</h2>
             <div class="mode-selector">


### PR DESCRIPTION
## Summary
- reorder curriculum subject buttons into two rows with Korean, Music, Art, PE, Random followed by Barun, Seulgiro-un, and Joyful Life

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895699604f8832ca1bdf35221d0ccd4