### PR TITLE
style: soften input border color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -340,7 +340,7 @@
       width: 100%;
       padding: 1.2rem;
       font-size: 1.4rem;
-      border: 2px solid var(--text-dark);
+      border: 2px solid #e0e0e0; /* subtle off-white border */
       background: var(--bg-dark);
       color: var(--text-light);
       font-family: 'Noto Sans KR', sans-serif;
@@ -1109,7 +1109,7 @@ td input.activity-input:not(:first-child) {
 
 /* Visual separators for English quiz hierarchy */
 #english-quiz-main .assessment-list > li:not(:last-child) {
-  border-bottom: 2px solid var(--secondary);
+  border-bottom: 2px solid #e0e0e0; /* subtle off-white border */
   padding-bottom: 1rem;
   margin-bottom: 1rem;
 }
@@ -1212,7 +1212,7 @@ td input.activity-input:not(:first-child) {
   padding: 0.2rem 0.4rem;
   margin: 0 0.4rem;
   border: none;
-  border-bottom: 2px solid var(--secondary);
+  border-bottom: 2px solid #e0e0e0; /* subtle off-white border */
   background: transparent;
   color: var(--text-light);
   text-align: center;
@@ -1228,7 +1228,7 @@ td input.activity-input:not(:first-child) {
   padding: 0.2rem 0.4rem;
   margin: 0 0.4rem;
   border: none;
-  border-bottom: 2px solid var(--secondary);
+  border-bottom: 2px solid #e0e0e0; /* subtle off-white border */
   background: transparent;
   color: var(--text-light);
   text-align: center;


### PR DESCRIPTION
## Summary
- soften default and quiz input borders to a subtle off-white

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956a920c80832cad0cd556b178db1a