### PR TITLE
Arrange curriculum subject buttons in two rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,6 +140,7 @@
         const timeSetterWrapper = document.getElementById('time-setter-wrapper');
         const topicSelector = document.querySelector('.topic-selector');
         const subjectSelector = document.querySelector('.subject-selector');
+        const curriculumBreak = document.getElementById('curriculum-break');
         const quizContainers = document.querySelectorAll('main[id$="-quiz-main"]');
         const modalCharacterPlaceholder = document.getElementById('modal-character-placeholder');
         const speechBubble = document.querySelector('.speech-bubble');
@@ -469,9 +470,11 @@
                     btn.classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, !visible);
                     btn.disabled = false;
                 });
+                curriculumBreak.classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, topic !== CONSTANTS.TOPICS.CURRICULUM);
             } else {
                 subjectSelector.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
                 subjectButtons.forEach(btn => { btn.disabled = true; });
+                curriculumBreak.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             }
             renderHeatmap(getDailyStats(30));
         }

--- a/index.html
+++ b/index.html
@@ -4070,6 +4070,7 @@
                 <button class="btn subject-btn" data-subject="art" data-topic="curriculum">미술</button>
                 <button class="btn subject-btn" data-subject="pe" data-topic="curriculum">체육</button>
                 <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model basic achievement">랜덤</button>
+                <div id="curriculum-break" class="subject-break hidden"></div>
                 <button class="btn subject-btn" data-subject="life" data-topic="curriculum">바른 생활</button>
                 <button class="btn subject-btn" data-subject="wise" data-topic="curriculum">슬기로운 생활</button>
                 <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐거운 생활</button>

--- a/styles.css
+++ b/styles.css
@@ -563,6 +563,11 @@ td input.activity-input:not(:first-child) {
         flex-wrap: wrap;
     }
 
+    .subject-break {
+        flex-basis: 100%;
+        height: 0;
+    }
+
     /* Arrange topic buttons in two rows with three per row */
     .topic-selector {
         display: grid;


### PR DESCRIPTION
## Summary
- Force curriculum subject selector into two rows with a break element
- Style new break element and hide it when not needed
- Toggle break visibility via script to keep layout for other topics

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956ae5f854832caf079b4c1dfb7228