### PR TITLE
Fix persistent random button BGM

### DIFF
--- a/app.js
+++ b/app.js
@@ -1112,7 +1112,9 @@
                     if (shuffleCount >= maxShuffles) {
                         clearInterval(randomInterval);
                         randomAudio.pause();
-                        
+                        randomAudio.currentTime = 0;
+                        randomAudio.loop = false;
+
                         const randomIndex = Math.floor(Math.random() * subjectBtns.length);
                         const chosenBtn = subjectBtns[randomIndex];
                         


### PR DESCRIPTION
## Summary
- stop random subject selection music once a subject is chosen by resetting the audio

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956afeca70832c9df393c4cc107f04