### PR TITLE
Restore red border color for focused inputs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -356,9 +356,9 @@
     }
     td input:focus {
       outline: none;
-      border-color: var(--accent);
+      border-color: var(--primary);
       background: var(--secondary);
-      box-shadow: 0 0 10px rgba(83, 52, 131, 0.5);
+      box-shadow: 0 0 10px rgba(233, 69, 96, 0.5);
     }
     td input.correct {
       border-color: var(--correct);
@@ -1244,7 +1244,7 @@ td input.activity-input:not(:first-child) {
 
 #creative-quiz-main .creative-question input:focus {
   outline: none;
-  border-color: var(--accent);
+  border-color: var(--primary);
 }
 #overview-quiz-main .overview-question input:focus,
 #integrated-course-quiz-main .overview-question input:focus,
@@ -1252,7 +1252,7 @@ td input.activity-input:not(:first-child) {
 #science-std-quiz-main .overview-question input:focus,
 #practical-std-quiz-main .overview-question input:focus {
   outline: none;
-  border-color: var(--accent);
+  border-color: var(--primary);
 }
 
 #creative-quiz-main .creative-question input.correct {


### PR DESCRIPTION
## Summary
- Revert focused input border color to primary red and adjust glow effect
- Ensure quiz input focus styles use red border across sections

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956c60c8ac832c8e9cd71c367c8892