### PR TITLE
Replace progress bar with heatmap for answer results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/app.js
+++ b/app.js
@@ -606,11 +606,21 @@
 
             document.getElementById('correct-count').textContent = correctCount;
             document.getElementById('total-count').textContent = totalCount;
-            document.getElementById('progress-text').textContent = `${percentage}%`;
+            const heatmap = document.getElementById('heatmap');
+            heatmap.innerHTML = '';
+            allInputs.forEach(input => {
+                const cell = document.createElement('div');
+                cell.classList.add('heatmap-cell');
+                if (input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
+                    cell.classList.add(CONSTANTS.CSS_CLASSES.CORRECT);
+                } else {
+                    cell.classList.add(CONSTANTS.CSS_CLASSES.INCORRECT);
+                }
+                heatmap.appendChild(cell);
+            });
+
             resultSubject.textContent = SUBJECT_NAMES[gameState.selectedSubject] || '';
             resultTopic.textContent = TOPIC_NAMES[gameState.selectedTopic] || '';
-
-            const progressBarFill = document.getElementById('progress-bar-fill');
             
             let feedback;
             if (percentage === 100) {
@@ -645,7 +655,6 @@
             typewriter(resultDialogue, feedback.dialogue);
             
             progressModal.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
-            setTimeout(() => { progressBarFill.style.width = `${percentage}%`; }, 100);
         }
 
         // --- GAME LOGIC FUNCTIONS ---

--- a/index.html
+++ b/index.html
@@ -4016,10 +4016,7 @@
           <p>주제: <span id="result-topic"></span></p>
           <p>과목: <span id="result-subject"></span></p>
           <p>맞춘 개수: <span id="correct-count">0</span> / <span id="total-count">0</span></p>
-          <div class="progress-bar-container">
-              <div id="progress-bar-fill"></div>
-          </div>
-          <p id="progress-text">0%</p>
+          <div id="heatmap" class="heatmap"></div>
           <button id="close-progress-modal-btn" class="btn">확인</button>
       </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -533,25 +533,23 @@ td input.activity-input:not(:first-child) {
     }
 
 
-    .progress-bar-container {
-        width: 100%;
-        height: 2.5rem;
-        background: var(--bg-dark);
-        border: 3px solid var(--secondary);
+    .heatmap {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 25px);
+        gap: 4px;
+        justify-content: center;
         margin: 1.5rem 0;
-        border-radius: 8px;
     }
-    #progress-bar-fill {
-        width: 0%;
-        height: 100%;
-        background: var(--correct);
-        transition: width 0.5s ease-out;
+    .heatmap-cell {
+        width: 25px;
+        height: 25px;
         border-radius: 4px;
     }
-    #progress-text {
-        font-size: 1.8rem !important;
-        margin-bottom: 2rem !important;
-        color: var(--correct);
+    .heatmap-cell.correct {
+        background: var(--correct);
+    }
+    .heatmap-cell.incorrect {
+        background: var(--incorrect);
     }
 
     .time-setter, .subject-selector, .mode-selector, .topic-selector {


### PR DESCRIPTION
## Summary
- replace progress bar with heatmap that marks correct answers in green and incorrect in red
- remove unused progress bar styles and add heatmap styles
- render heatmap cells in result modal instead of progress bar fill
- add .gitignore to ignore dependencies

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689572421834832cbee6e5587e48c153