### PR TITLE
Add screenshot capture and copy for progress modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -131,6 +131,7 @@
         const stageClearModal = document.getElementById('stage-clear-modal');
         const progressModal = document.getElementById('progress-modal');
         const closeProgressModalBtn = document.getElementById('close-progress-modal-btn');
+        const scrapResultImageBtn = document.getElementById('scrap-result-image-btn');
         const startModal = document.getElementById('start-modal');
         const guideModal = document.getElementById('guide-modal');
         const closeGuideBtn = document.getElementById('close-guide-btn');
@@ -1334,6 +1335,26 @@
             progressModal.classList.remove('active');
             showAnswersBtn.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
             resetBtn.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+        });
+
+        scrapResultImageBtn.addEventListener('click', () => {
+            const modal = document.getElementById('progress-modal');
+            html2canvas(modal)
+                .then(canvas =>
+                    canvas.toBlob(async blob => {
+                        try {
+                            await navigator.clipboard.write([
+                                new ClipboardItem({ 'image/png': blob })
+                            ]);
+                            alert('결과 이미지가 복사되었습니다!');
+                        } catch (err) {
+                            alert('이미지 복사에 실패했습니다.');
+                        }
+                    })
+                )
+                .catch(() => {
+                    alert('이미지 캡처에 실패했습니다.');
+                });
         });
 
         decreaseTimeBtn.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -4017,6 +4017,7 @@
           <p>과목: <span id="result-subject"></span></p>
           <p>맞춘 개수: <span id="correct-count">0</span> / <span id="total-count">0</span></p>
           <div id="heatmap" class="heatmap"></div>
+          <button id="scrap-result-image-btn" class="btn">이미지 스크랩</button>
           <button id="close-progress-modal-btn" class="btn">확인</button>
       </div>
   </div>
@@ -4110,6 +4111,7 @@
     </div>
 
 
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load html2canvas library
- add screenshot button in progress modal
- enable copying progress modal image to clipboard with alerts

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895743d57d0832c8f8ee79d09fb882f