### PR TITLE
Display area-based proportions in result heatmap

### DIFF
--- a/app.js
+++ b/app.js
@@ -608,15 +608,48 @@
             document.getElementById('total-count').textContent = totalCount;
             const heatmap = document.getElementById('heatmap');
             heatmap.innerHTML = '';
+
+            const areaStats = new Map();
             allInputs.forEach(input => {
-                const cell = document.createElement('div');
-                cell.classList.add('heatmap-cell');
-                if (input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
-                    cell.classList.add(CONSTANTS.CSS_CLASSES.CORRECT);
-                } else {
-                    cell.classList.add(CONSTANTS.CSS_CLASSES.INCORRECT);
+                const row = input.closest('tr');
+                const areaName = row ? row.querySelector('th').textContent.trim() : '';
+                if (!areaStats.has(areaName)) {
+                    areaStats.set(areaName, { correct: 0, total: 0 });
                 }
-                heatmap.appendChild(cell);
+                const stats = areaStats.get(areaName);
+                stats.total++;
+                if (input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
+                    stats.correct++;
+                }
+            });
+
+            const CELLS_PER_AREA = 10;
+            areaStats.forEach((stats, areaName) => {
+                const wrapper = document.createElement('div');
+                wrapper.classList.add('heatmap-area');
+
+                const label = document.createElement('div');
+                label.classList.add('heatmap-label');
+                label.textContent = areaName;
+
+                const row = document.createElement('div');
+                row.classList.add('heatmap-row');
+
+                const correctCells = stats.total > 0 ? Math.round((stats.correct / stats.total) * CELLS_PER_AREA) : 0;
+                for (let i = 0; i < CELLS_PER_AREA; i++) {
+                    const cell = document.createElement('div');
+                    cell.classList.add('heatmap-cell');
+                    if (i < correctCells) {
+                        cell.classList.add(CONSTANTS.CSS_CLASSES.CORRECT);
+                    } else {
+                        cell.classList.add(CONSTANTS.CSS_CLASSES.INCORRECT);
+                    }
+                    row.appendChild(cell);
+                }
+
+                wrapper.appendChild(label);
+                wrapper.appendChild(row);
+                heatmap.appendChild(wrapper);
             });
 
             resultSubject.textContent = SUBJECT_NAMES[gameState.selectedSubject] || '';

--- a/styles.css
+++ b/styles.css
@@ -534,16 +534,24 @@ td input.activity-input:not(:first-child) {
 
 
     .heatmap {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, 25px);
-        gap: 4px;
-        justify-content: center;
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
         margin: 1.5rem 0;
     }
-    .heatmap-cell {
-        width: 25px;
-        height: 25px;
-        border-radius: 4px;
+    .heatmap-area {
+        display: flex;
+        align-items: center;
+        gap: 0.8rem;
+    }
+    .heatmap-label {
+        font-size: 1.4rem;
+        min-width: 6rem;
+    }
+    .heatmap-row {
+        display: grid;
+        grid-template-columns: repeat(10, 20px);
+        gap: 4px;
     }
     .heatmap-cell.correct {
         background: var(--correct);


### PR DESCRIPTION
## Summary
- Render result heatmap grouped by category with rows scaled to show correct-answer ratios.
- Style heatmap as flex rows and add labels for each area.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689574be3000832c83b47b5011154b9a