### PR TITLE
Capture result modal only and simplify screenshot button

### DIFF
--- a/app.js
+++ b/app.js
@@ -1338,8 +1338,8 @@
         });
 
         scrapResultImageBtn.addEventListener('click', () => {
-            const modal = document.getElementById('progress-modal');
-            html2canvas(modal)
+            const modalContent = document.querySelector('#progress-modal .modal-content');
+            html2canvas(modalContent)
                 .then(canvas =>
                     canvas.toBlob(async blob => {
                         try {

--- a/index.html
+++ b/index.html
@@ -4017,7 +4017,7 @@
           <p>과목: <span id="result-subject"></span></p>
           <p>맞춘 개수: <span id="correct-count">0</span> / <span id="total-count">0</span></p>
           <div id="heatmap" class="heatmap"></div>
-          <button id="scrap-result-image-btn" class="btn">이미지 스크랩</button>
+          <button id="scrap-result-image-btn" class="btn">📸</button>
           <button id="close-progress-modal-btn" class="btn">확인</button>
       </div>
   </div>


### PR DESCRIPTION
## Summary
- Replace screenshot button text with camera emoji
- Capture only result modal content for result screenshots

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689575fc0ce8832ca5bd19baca6a04fb