### PR TITLE
Group result heatmap by section

### DIFF
--- a/app.js
+++ b/app.js
@@ -610,19 +610,31 @@
             const heatmap = document.getElementById('heatmap');
             heatmap.innerHTML = '';
 
+            const quizMain = document.getElementById(`${gameState.selectedSubject}-quiz-main`);
+            const sections = quizMain.querySelectorAll('section');
+
             const areaStats = new Map();
-            allInputs.forEach(input => {
-                const row = input.closest('tr');
-                const areaName = row ? row.querySelector('th').textContent.trim() : '';
-                if (!areaStats.has(areaName)) {
-                    areaStats.set(areaName, { correct: 0, total: 0 });
-                }
-                const stats = areaStats.get(areaName);
-                stats.total++;
-                if (input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
-                    stats.correct++;
-                }
-            });
+            if (sections.length > 0) {
+                sections.forEach(section => {
+                    const areaName = section.querySelector('h2')?.textContent.trim() || '';
+                    const sectionInputs = section.querySelectorAll('input[data-answer]').length;
+                    const correctInSection = section.querySelectorAll(`input.${CONSTANTS.CSS_CLASSES.CORRECT}`).length;
+                    areaStats.set(areaName, { correct: correctInSection, total: sectionInputs });
+                });
+            } else {
+                allInputs.forEach(input => {
+                    const row = input.closest('tr');
+                    const areaName = row ? row.querySelector('th')?.textContent.trim() : '';
+                    if (!areaStats.has(areaName)) {
+                        areaStats.set(areaName, { correct: 0, total: 0 });
+                    }
+                    const stats = areaStats.get(areaName);
+                    stats.total++;
+                    if (input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
+                        stats.correct++;
+                    }
+                });
+            }
 
             const CELLS_PER_AREA = 10;
             areaStats.forEach((stats, areaName) => {


### PR DESCRIPTION
## Summary
- Display result heatmap grouped by quiz sections (e.g., 연주, 감상, 창작, 음악 요소)
- Provide fallback to previous row-based grouping when no sections exist

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895765048c8832c8790f21d9a6a03c8