### PR TITLE
Change scrap result button label to Korean

### DIFF
--- a/index.html
+++ b/index.html
@@ -4017,7 +4017,7 @@
           <p>과목: <span id="result-subject"></span></p>
           <p>맞춘 개수: <span id="correct-count">0</span> / <span id="total-count">0</span></p>
           <div id="heatmap" class="heatmap"></div>
-          <button id="scrap-result-image-btn" class="btn">Scrap</button>
+          <button id="scrap-result-image-btn" class="btn">결과창 복사</button>
           <button id="close-progress-modal-btn" class="btn">확인</button>
       </div>
   </div>


### PR DESCRIPTION
## Summary
- Use Korean text '결과창 복사' for the result scrap button

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689578842570832cb568253398ec9685