### PR TITLE
Use progress bars instead of heatmap for results

### DIFF
--- a/app.js
+++ b/app.js
@@ -607,8 +607,8 @@
 
             document.getElementById('correct-count').textContent = correctCount;
             document.getElementById('total-count').textContent = totalCount;
-            const heatmap = document.getElementById('heatmap');
-            heatmap.innerHTML = '';
+            const progressContainer = document.getElementById('progress-bars');
+            progressContainer.innerHTML = '';
 
             const quizMain = document.getElementById(`${gameState.selectedSubject}-quiz-main`);
             const sections = quizMain.querySelectorAll('section');
@@ -636,33 +636,31 @@
                 });
             }
 
-            const CELLS_PER_AREA = 10;
             areaStats.forEach((stats, areaName) => {
                 const wrapper = document.createElement('div');
-                wrapper.classList.add('heatmap-area');
+                wrapper.classList.add('progress-area');
 
                 const label = document.createElement('div');
-                label.classList.add('heatmap-label');
+                label.classList.add('progress-label');
                 label.textContent = areaName;
 
-                const row = document.createElement('div');
-                row.classList.add('heatmap-row');
+                const bar = document.createElement('div');
+                bar.classList.add('progress-bar');
 
-                const correctCells = stats.total > 0 ? Math.round((stats.correct / stats.total) * CELLS_PER_AREA) : 0;
-                for (let i = 0; i < CELLS_PER_AREA; i++) {
-                    const cell = document.createElement('div');
-                    cell.classList.add('heatmap-cell');
-                    if (i < correctCells) {
-                        cell.classList.add(CONSTANTS.CSS_CLASSES.CORRECT);
-                    } else {
-                        cell.classList.add(CONSTANTS.CSS_CLASSES.INCORRECT);
-                    }
-                    row.appendChild(cell);
-                }
+                const fill = document.createElement('div');
+                fill.classList.add('progress-fill');
+                const percent = stats.total > 0 ? Math.round((stats.correct / stats.total) * 100) : 0;
+                fill.style.width = `${percent}%`;
 
+                const percentLabel = document.createElement('div');
+                percentLabel.classList.add('progress-percent');
+                percentLabel.textContent = `${percent}%`;
+
+                bar.appendChild(fill);
                 wrapper.appendChild(label);
-                wrapper.appendChild(row);
-                heatmap.appendChild(wrapper);
+                wrapper.appendChild(bar);
+                wrapper.appendChild(percentLabel);
+                progressContainer.appendChild(wrapper);
             });
 
             resultSubject.textContent = SUBJECT_NAMES[gameState.selectedSubject] || '';

--- a/index.html
+++ b/index.html
@@ -4016,7 +4016,7 @@
           <p>주제: <span id="result-topic"></span></p>
           <p>과목: <span id="result-subject"></span></p>
           <p>맞춘 개수: <span id="correct-count">0</span> / <span id="total-count">0</span></p>
-          <div id="heatmap" class="heatmap"></div>
+          <div id="progress-bars" class="progress-bars"></div>
           <button id="scrap-result-image-btn" class="btn">Scrap</button>
           <button id="close-progress-modal-btn" class="btn">확인</button>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -532,32 +532,37 @@ td input.activity-input:not(:first-child) {
         font-family: 'Press Start 2P', cursive;
     }
 
-
-    .heatmap {
+    .progress-bars {
         display: flex;
         flex-direction: column;
         gap: 0.8rem;
         margin: 1.5rem 0;
     }
-    .heatmap-area {
+    .progress-area {
         display: flex;
         align-items: center;
         gap: 0.8rem;
     }
-    .heatmap-label {
+    .progress-label {
         font-size: 1.4rem;
         min-width: 6rem;
     }
-    .heatmap-row {
-        display: grid;
-        grid-template-columns: repeat(10, 20px);
-        gap: 4px;
-    }
-    .heatmap-cell.correct {
-        background: var(--correct);
-    }
-    .heatmap-cell.incorrect {
+    .progress-bar {
+        flex: 1;
         background: var(--incorrect);
+        height: 20px;
+        border-radius: 10px;
+        overflow: hidden;
+    }
+    .progress-fill {
+        height: 100%;
+        background: var(--correct);
+        width: 0;
+    }
+    .progress-percent {
+        min-width: 3rem;
+        text-align: right;
+        font-size: 1.2rem;
     }
 
     .time-setter, .subject-selector, .mode-selector, .topic-selector {


### PR DESCRIPTION
## Summary
- Replace quiz result heatmap with progress bars
- Add progress bar styles
- Update markup to display progress bars in result modal

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689578918940832c9e3325832770c5e0