### PR TITLE
Replace heatmap with progress bar in results

### DIFF
--- a/app.js
+++ b/app.js
@@ -149,6 +149,8 @@
         const resultTitle = document.getElementById('result-title');
         const resultSubject = document.getElementById('result-subject');
         const resultTopic = document.getElementById('result-topic');
+        const resultProgress = document.getElementById('result-progress');
+        const resultPercentage = document.getElementById('result-percentage');
         const slotMachineEl = document.getElementById('slot-machine');
         const slotReels = slotMachineEl.querySelectorAll('.reel');
         
@@ -607,63 +609,8 @@
 
             document.getElementById('correct-count').textContent = correctCount;
             document.getElementById('total-count').textContent = totalCount;
-            const heatmap = document.getElementById('heatmap');
-            heatmap.innerHTML = '';
-
-            const quizMain = document.getElementById(`${gameState.selectedSubject}-quiz-main`);
-            const sections = quizMain.querySelectorAll('section');
-
-            const areaStats = new Map();
-            if (sections.length > 0) {
-                sections.forEach(section => {
-                    const areaName = section.querySelector('h2')?.textContent.trim() || '';
-                    const sectionInputs = section.querySelectorAll('input[data-answer]').length;
-                    const correctInSection = section.querySelectorAll(`input.${CONSTANTS.CSS_CLASSES.CORRECT}`).length;
-                    areaStats.set(areaName, { correct: correctInSection, total: sectionInputs });
-                });
-            } else {
-                allInputs.forEach(input => {
-                    const row = input.closest('tr');
-                    const areaName = row ? row.querySelector('th')?.textContent.trim() : '';
-                    if (!areaStats.has(areaName)) {
-                        areaStats.set(areaName, { correct: 0, total: 0 });
-                    }
-                    const stats = areaStats.get(areaName);
-                    stats.total++;
-                    if (input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
-                        stats.correct++;
-                    }
-                });
-            }
-
-            const CELLS_PER_AREA = 10;
-            areaStats.forEach((stats, areaName) => {
-                const wrapper = document.createElement('div');
-                wrapper.classList.add('heatmap-area');
-
-                const label = document.createElement('div');
-                label.classList.add('heatmap-label');
-                label.textContent = areaName;
-
-                const row = document.createElement('div');
-                row.classList.add('heatmap-row');
-
-                const correctCells = stats.total > 0 ? Math.round((stats.correct / stats.total) * CELLS_PER_AREA) : 0;
-                for (let i = 0; i < CELLS_PER_AREA; i++) {
-                    const cell = document.createElement('div');
-                    cell.classList.add('heatmap-cell');
-                    if (i < correctCells) {
-                        cell.classList.add(CONSTANTS.CSS_CLASSES.CORRECT);
-                    } else {
-                        cell.classList.add(CONSTANTS.CSS_CLASSES.INCORRECT);
-                    }
-                    row.appendChild(cell);
-                }
-
-                wrapper.appendChild(label);
-                wrapper.appendChild(row);
-                heatmap.appendChild(wrapper);
-            });
+            resultProgress.style.width = `${percentage}%`;
+            resultPercentage.textContent = `${percentage}%`;
 
             resultSubject.textContent = SUBJECT_NAMES[gameState.selectedSubject] || '';
             resultTopic.textContent = TOPIC_NAMES[gameState.selectedTopic] || '';

--- a/index.html
+++ b/index.html
@@ -4013,10 +4013,17 @@
               </div>
           </div>
           <h2 id="result-title">게임 결과</h2>
-          <p>주제: <span id="result-topic"></span></p>
-          <p>과목: <span id="result-subject"></span></p>
-          <p>맞춘 개수: <span id="correct-count">0</span> / <span id="total-count">0</span></p>
-          <div id="heatmap" class="heatmap"></div>
+          <div id="result-info">
+              <p><span class="label">주제:</span> <span id="result-topic"></span></p>
+              <p><span class="label">과목:</span> <span id="result-subject"></span></p>
+              <p><span class="label">맞춘 개수:</span> <span id="correct-count">0</span> / <span id="total-count">0</span></p>
+              <div class="progress-container">
+                  <div class="progress-bar">
+                      <div id="result-progress" class="progress-fill"></div>
+                  </div>
+                  <span id="result-percentage">0%</span>
+              </div>
+          </div>
           <button id="scrap-result-image-btn" class="btn">결과창 복사</button>
           <button id="close-progress-modal-btn" class="btn">확인</button>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -531,33 +531,36 @@ td input.activity-input:not(:first-child) {
         margin: 2.5rem auto 0;
         font-family: 'Press Start 2P', cursive;
     }
-
-
-    .heatmap {
-        display: flex;
-        flex-direction: column;
-        gap: 0.8rem;
-        margin: 1.5rem 0;
+    #result-info p {
+        font-size: 1.6rem;
+        margin: 0.5rem 0;
     }
-    .heatmap-area {
+    #result-info .label {
+        font-weight: bold;
+        margin-right: 0.5rem;
+    }
+    .progress-container {
         display: flex;
         align-items: center;
-        gap: 0.8rem;
+        gap: 1rem;
+        margin-top: 1rem;
     }
-    .heatmap-label {
-        font-size: 1.4rem;
-        min-width: 6rem;
+    .progress-bar {
+        flex: 1;
+        height: 20px;
+        background: #e0e0e0;
+        border-radius: 10px;
+        overflow: hidden;
     }
-    .heatmap-row {
-        display: grid;
-        grid-template-columns: repeat(10, 20px);
-        gap: 4px;
-    }
-    .heatmap-cell.correct {
+    .progress-fill {
+        height: 100%;
+        width: 0%;
         background: var(--correct);
     }
-    .heatmap-cell.incorrect {
-        background: var(--incorrect);
+    #result-percentage {
+        font-size: 1.6rem;
+        min-width: 3rem;
+        text-align: right;
     }
 
     .time-setter, .subject-selector, .mode-selector, .topic-selector {


### PR DESCRIPTION
## Summary
- replace result heatmap with a progress bar and percentage
- present topic, subject and answer counts in a clearer layout
- add styles for the new progress display

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689579d4389c832c89f82e32e612806b