### PR TITLE
Refine result modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4024,8 +4024,10 @@
                   <span id="result-percentage">0%</span>
               </div>
           </div>
-          <button id="scrap-result-image-btn" class="btn">결과창 복사</button>
-          <button id="close-progress-modal-btn" class="btn">확인</button>
+          <div class="result-buttons">
+              <button id="scrap-result-image-btn" class="btn">결과창 복사</button>
+              <button id="close-progress-modal-btn" class="btn">확인</button>
+          </div>
       </div>
   </div>
   

--- a/styles.css
+++ b/styles.css
@@ -531,6 +531,14 @@ td input.activity-input:not(:first-child) {
         margin: 2.5rem auto 0;
         font-family: 'Press Start 2P', cursive;
     }
+    #result-info {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 0.8rem;
+        margin-bottom: 2rem;
+    }
     #result-info p {
         font-size: 1.6rem;
         margin: 0.5rem 0;
@@ -544,6 +552,8 @@ td input.activity-input:not(:first-child) {
         align-items: center;
         gap: 1rem;
         margin-top: 1rem;
+        width: 100%;
+        max-width: 400px;
     }
     .progress-bar {
         flex: 1;
@@ -561,6 +571,13 @@ td input.activity-input:not(:first-child) {
         font-size: 1.6rem;
         min-width: 3rem;
         text-align: right;
+    }
+
+    .result-buttons {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
     }
 
     .time-setter, .subject-selector, .mode-selector, .topic-selector {


### PR DESCRIPTION
## Summary
- Group result buttons into a dedicated container for clearer separation from progress details
- Apply flex layout and gaps to result info and progress bar for improved readability

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68957bef11c8832cbb63974fe4bb014e