### PR TITLE
Organize competency tabs into two columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -3886,26 +3886,28 @@
 <main id="competency-quiz-main" class="hidden competency-ui">
   <div class="competency-tab-wrapper">
     <div class="tabs competency-tabs">
-    <div class="tab-row">
-        <button class="competency-tab tab active" data-target="summary">총론</button>
+      <div class="competency-column">
+        <div class="column-title">교육과정A</div>
         <button class="competency-tab tab" data-target="korean">국어</button>
-        <button class="competency-tab tab" data-target="math">수학</button>
-        <button class="competency-tab tab" data-target="social">사회</button>
-        <button class="competency-tab tab" data-target="science">과학</button>
         <button class="competency-tab tab" data-target="english">영어</button>
-        <button class="competency-tab tab" data-target="music-subject">음악</button>
-        <button class="competency-tab tab" data-target="art">미술</button>
-        <button class="competency-tab tab" data-target="pe">체육</button>
+        <button class="competency-tab tab active" data-target="summary">총론</button>
+        <button class="competency-tab tab" data-target="social">사회</button>
+        <button class="competency-tab tab" data-target="moral-future">도덕-미래사회가 요구하는 역량</button>
+        <button class="competency-tab tab" data-target="moral-emphasis">도덕-도덕과 강조점</button>
         <button class="competency-tab tab" data-target="practical">실과</button>
-    </div>
-    <div class="tab-row">
+      </div>
+      <div class="competency-column">
+        <div class="column-title">교육과정B</div>
+        <button class="competency-tab tab" data-target="math">수학</button>
+        <button class="competency-tab tab" data-target="art">미술</button>
         <button class="competency-tab tab" data-target="integrated">통합</button>
         <button class="competency-tab tab" data-target="goodlife">통합-바생(총론)</button>
         <button class="competency-tab tab" data-target="sociality">통합-슬생(총론)</button>
         <button class="competency-tab tab" data-target="joyful">통합-즐생(총론)</button>
-        <button class="competency-tab tab" data-target="moral-future">도덕-미래사회가 요구하는 역량</button>
-        <button class="competency-tab tab" data-target="moral-emphasis">도덕-도덕과 강조점</button>
-    </div>
+        <button class="competency-tab tab" data-target="science">과학</button>
+        <button class="competency-tab tab" data-target="music-subject">음악</button>
+        <button class="competency-tab tab" data-target="pe">체육</button>
+      </div>
     </div>
   </div>
     <section id="summary" class="active">

--- a/styles.css
+++ b/styles.css
@@ -1052,23 +1052,25 @@ td input.activity-input:not(:first-child) {
 #competency-quiz-main .competency-tab-wrapper {
     display: flex;
     justify-content: center;
-    flex-wrap: wrap;
-    gap: 1rem;
     margin-bottom: 2rem;
 }
 
 #competency-quiz-main .competency-tabs {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 3rem;
+}
+
+#competency-quiz-main .competency-column {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 1rem;
 }
 
-#competency-quiz-main .competency-tabs .tab-row {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 1rem;
+#competency-quiz-main .competency-column .column-title {
+    font-weight: 700;
 }
 #competency-quiz-main .competency-tab {
     flex: 0 0 auto;


### PR DESCRIPTION
## Summary
- Group competency subject tabs into '교육과정A' and '교육과정B' columns with labels
- Style new competency column layout for clear two-column display

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68957e34c594832cad055d5d3fae514e