### PR TITLE
Arrange result buttons horizontally

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -590,7 +590,8 @@ td input.activity-input:not(:first-child) {
 
     .result-buttons {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
+        justify-content: center;
         align-items: center;
         gap: 1rem;
     }


### PR DESCRIPTION
## Summary
- display the "결과창 복사" and "확인" buttons side by side in the result window

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958418bb60832cb124766fec4aa170