### PR TITLE
Keep start modal size constant across topic choices

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,6 +135,7 @@
         const startModal = document.getElementById('start-modal');
         const guideModal = document.getElementById('guide-modal');
         const closeGuideBtn = document.getElementById('close-guide-btn');
+        const settingsPanel = document.getElementById('settings-panel');
         const timeSettingDisplay = document.getElementById('time-setting-display');
         const decreaseTimeBtn = document.getElementById('decrease-time');
         const increaseTimeBtn = document.getElementById('increase-time');
@@ -455,6 +456,13 @@
             }
        }
 
+       function fixSettingsPanelHeight() {
+            if (!settingsPanel.dataset.fixedHeight) {
+                settingsPanel.style.height = `${settingsPanel.offsetHeight}px`;
+                settingsPanel.dataset.fixedHeight = 'true';
+            }
+       }
+
        function updateStartModalUI() {
             const subjectButtons = subjectSelector.querySelectorAll('.btn');
             const topic = gameState.selectedTopic;
@@ -717,6 +725,7 @@
                adjustCreativeInputWidths();
                adjustEnglishInputWidths();
                adjustBasicTopicInputWidths();
+               fixSettingsPanelHeight();
            }
 
            setCharacterState('idle');
@@ -1321,6 +1330,7 @@
             guideModal.classList.remove('active');
             startModal.classList.add('active');
             updateStartModalUI();
+            fixSettingsPanelHeight();
         });
 
         closeProgressModalBtn.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -698,6 +698,7 @@ td input.activity-input:not(:first-child) {
         width: 600px;
         max-width: 600px;
         flex-shrink: 0;
+        overflow-y: auto;
     }
     #heatmap-panel {
         max-width: 260px;


### PR DESCRIPTION
## Summary
- Fix start modal resizing by locking settings panel height on first open
- Allow settings panel to scroll when content exceeds fixed size

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958447c050832cba880df1219a6541