### PR TITLE
style: enlarge result modal

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -563,6 +563,8 @@ td input.activity-input:not(:first-child) {
         text-align: center;
         gap: 0.8rem;
         margin-bottom: 2rem;
+        flex: 1;
+        justify-content: center;
     }
     #result-details {
         display: flex;
@@ -931,6 +933,11 @@ td input.activity-input:not(:first-child) {
     #progress-modal .modal-content {
         position: relative;
         padding-top: 1rem;
+        width: min(80vmin, 500px);
+        aspect-ratio: 1 / 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
     }
     #result-character-container {
         display: flex;
@@ -939,6 +946,7 @@ td input.activity-input:not(:first-child) {
         gap: 2rem;
         margin-bottom: 2rem;
         min-height: 100px;
+        flex: 1;
     }
     #modal-character-placeholder {
         width: 80px;


### PR DESCRIPTION
## Summary
- Make result modal square and distribute internal content evenly
- Allow result details and character container to expand to fill modal height

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689585154eb4832cbf03de689a2ca6a7