### PR TITLE
fix: adjust result modal spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -936,17 +936,16 @@ td input.activity-input:not(:first-child) {
         position: relative;
         padding-top: 1rem;
         width: min(80vmin, 500px);
-        aspect-ratio: 1 / 1;
         display: flex;
         flex-direction: column;
-        justify-content: space-between;
+        justify-content: center;
+        gap: 1.5rem;
     }
     #result-character-container {
         display: flex;
         justify-content: center;
         align-items: center;
         gap: 2rem;
-        margin-bottom: 2rem;
         min-height: 100px;
         flex: 1;
     }


### PR DESCRIPTION
## Summary
- center and space contents in the result modal to avoid blank middle area

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895864a063c832cad1c0d79d4904e33