### PR TITLE
Equalize result modal button widths

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -623,6 +623,10 @@ td input.activity-input:not(:first-child) {
         gap: 1rem;
     }
 
+    .result-buttons .btn {
+        width: 12rem;
+    }
+
     .time-setter, .subject-selector, .mode-selector, .topic-selector {
         display: flex;
         justify-content: center;


### PR DESCRIPTION
## Summary
- Ensure copy and confirm result buttons share the same width for a balanced layout.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895889eca68832cada0f38eb085d019