### PR TITLE
Prevent wrapping in results modal

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -571,6 +571,7 @@ td input.activity-input:not(:first-child) {
         align-items: center;
         justify-content: center;
         gap: 0.8rem;
+        flex-wrap: nowrap;
     }
     #result-info p {
         font-size: 1.6rem;
@@ -580,6 +581,8 @@ td input.activity-input:not(:first-child) {
         border: 2px solid var(--primary);
         box-shadow: 2px 2px 0 var(--bg-dark);
         border-radius: 6px;
+        flex-shrink: 0;
+        white-space: nowrap;
     }
     #result-info .label {
         font-weight: bold;


### PR DESCRIPTION
## Summary
- Ensure result modal details remain on a single row
- Prevent result info entries from shrinking or wrapping

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689588efd69c832cbb3454fffcffb357