### PR TITLE
fix: copy result image to clipboard on more devices

### DIFF
--- a/app.js
+++ b/app.js
@@ -1342,18 +1342,18 @@
         scrapResultImageBtn.addEventListener('click', () => {
             const modalContent = document.querySelector('#progress-modal .modal-content');
             html2canvas(modalContent)
-                .then(canvas => {
+                .then(async canvas => {
                     if (navigator.clipboard && navigator.clipboard.write && window.ClipboardItem) {
-                        canvas.toBlob(async blob => {
-                            try {
-                                await navigator.clipboard.write([
-                                    new ClipboardItem({ 'image/png': blob })
-                                ]);
-                                alert('결과 이미지가 복사되었습니다!');
-                            } catch (err) {
-                                alert('이미지 복사에 실패했습니다.');
-                            }
-                        });
+                        try {
+                            const dataUrl = canvas.toDataURL('image/png');
+                            const blob = await (await fetch(dataUrl)).blob();
+                            await navigator.clipboard.write([
+                                new ClipboardItem({ [blob.type]: blob })
+                            ]);
+                            alert('결과 이미지가 복사되었습니다!');
+                        } catch (err) {
+                            alert('이미지 복사에 실패했습니다.');
+                        }
                     } else {
                         const dataUrl = canvas.toDataURL('image/png');
                         const hiddenDiv = document.createElement('div');


### PR DESCRIPTION
## Summary
- attempt to copy result modal image to clipboard using data URL conversion
- keep DOM-based fallback for unsupported clipboard APIs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895a7a8000c832ca43dbadeb255754a