### PR TITLE
Use innerHTML for typewriter to support line breaks

### DIFF
--- a/app.js
+++ b/app.js
@@ -287,11 +287,12 @@
             if (gameState.typingInterval) {
                 clearInterval(gameState.typingInterval);
             }
-            element.textContent = '';
+            element.innerHTML = '';
             let i = 0;
             gameState.typingInterval = setInterval(() => {
                 if (i < text.length) {
-                    element.textContent += text.charAt(i);
+                    const char = text.charAt(i);
+                    element.innerHTML += char === '\n' ? '<br>' : char;
                     i++;
                 } else {
                     clearInterval(gameState.typingInterval);


### PR DESCRIPTION
## Summary
- Update typewriter effect to build text with `innerHTML`
- Interpret `\n` as `<br>` so newlines render

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68960b68ddc8832cb80cab78fd38378c