### PR TITLE
Allow wider speech bubble and preserve manual line breaks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -972,7 +972,7 @@ td input.activity-input:not(:first-child) {
         border-radius: .4em;
         padding: 1.5rem;
         min-width: 250px;
-        max-width: 300px;
+        max-width: 90vw;
         text-align: left;
         border: 2px solid var(--primary);
     }
@@ -994,6 +994,8 @@ td input.activity-input:not(:first-child) {
         margin: 0;
         font-size: 1.6rem;
         line-height: 1.6;
+        white-space: pre-line;
+        word-break: keep-all;
     }
     #result-title {
         font-size: 2.5rem !important;
@@ -1053,6 +1055,12 @@ td input.activity-input:not(:first-child) {
         }
         #result-character-container {
             flex-direction: column;
+        }
+        .speech-bubble {
+            max-width: 90vw;
+        }
+        #result-dialogue {
+            font-size: 1.4rem;
         }
         .speech-bubble:after {
             top: 0;


### PR DESCRIPTION
## Summary
- allow speech bubble to expand to viewport width
- preserve manual line breaks and prevent Korean word breaks
- adjust mobile styling for wider bubbles and smaller text

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68960b671c04832c85fdbcfbe9e5909a