### PR TITLE
feat: add model names warmup

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,13 +129,15 @@
         const character = document.getElementById('character-assistant');
         const headerTitle = document.getElementById('header-title');
         const stageClearModal = document.getElementById('stage-clear-modal');
-        const progressModal = document.getElementById('progress-modal');
-        const closeProgressModalBtn = document.getElementById('close-progress-modal-btn');
-        const scrapResultImageBtn = document.getElementById('scrap-result-image-btn');
-        const startModal = document.getElementById('start-modal');
-        const guideModal = document.getElementById('guide-modal');
-        const closeGuideBtn = document.getElementById('close-guide-btn');
-        const settingsPanel = document.getElementById('settings-panel');
+       const progressModal = document.getElementById('progress-modal');
+       const closeProgressModalBtn = document.getElementById('close-progress-modal-btn');
+       const scrapResultImageBtn = document.getElementById('scrap-result-image-btn');
+       const startModal = document.getElementById('start-modal');
+       const guideModal = document.getElementById('guide-modal');
+       const closeGuideBtn = document.getElementById('close-guide-btn');
+       const modelNamesModal = document.getElementById('model-names-modal');
+       const closeModelNamesBtn = document.getElementById('close-model-names-btn');
+       const settingsPanel = document.getElementById('settings-panel');
         const timeSettingDisplay = document.getElementById('time-setting-display');
         const decreaseTimeBtn = document.getElementById('decrease-time');
         const increaseTimeBtn = document.getElementById('increase-time');
@@ -698,12 +700,12 @@
             gameState.timerId = null;
             
             quizContainers.forEach(main => main.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN));
-            document.querySelectorAll('input[data-answer]').forEach(i => {
-                i.disabled = true;
-                i.value = '';
-                i.className = '';
-            });
-            resetUsedAnswers();
+           document.querySelectorAll('input[data-answer]').forEach(i => {
+               i.disabled = true;
+               i.value = '';
+               i.className = '';
+           });
+           resetUsedAnswers();
             
             gameState.combo = 0;
             updateMushroomGrowth();
@@ -713,8 +715,9 @@
             showAnswersBtn.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             showAnswersBtn.disabled = false;
             resetBtn.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
-            forceQuitBtn.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
-            document.getElementById('timer-container').classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
+           forceQuitBtn.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
+           document.getElementById('timer-container').classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
+           modelNamesModal.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE);
 
             // Reset competency tab states
            document.querySelectorAll('.competency-tab.cleared')
@@ -786,7 +789,20 @@
             }
 
            const activeSection = document.querySelector(`#${gameState.selectedSubject}-quiz-main section.active`);
-           if (activeSection) focusFirstInput(activeSection);
+
+           if (gameState.selectedTopic === CONSTANTS.TOPICS.MODEL) {
+               modelNamesModal.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+               document
+                   .querySelectorAll('#model-names-modal .model-names')
+                   .forEach(sec => {
+                       const current = sec.dataset.subject === gameState.selectedSubject;
+                       sec.classList.toggle(CONSTANTS.CSS_CLASSES.HIDDEN, !current);
+                       sec.querySelectorAll('input[data-answer]').forEach(i => (i.disabled = false));
+                       if (current) focusFirstInput(sec);
+                   });
+           } else if (activeSection) {
+               focusFirstInput(activeSection);
+           }
             slotMachine.start();
        }
 
@@ -919,10 +935,14 @@
             const section = input.closest('section');
             const userAnswer = normalizeAnswer(input.value);
 
+            const isCompetency = gameState.selectedSubject === CONSTANTS.SUBJECTS.COMPETENCY;
+            const isUnordered = section.classList.contains('unordered');
+            const isModelNames = section.classList.contains('model-names');
+
             let isCorrect = false;
             let displayAnswer = input.dataset.answer;
 
-            if (gameState.selectedSubject === CONSTANTS.SUBJECTS.COMPETENCY) {
+            if (isCompetency || isUnordered) {
                 if (!usedAnswersMap.has(section)) usedAnswersMap.set(section, new Set());
                 const usedSet = usedAnswersMap.get(section);
 
@@ -931,9 +951,11 @@
                     const original = inp.dataset.answer.trim();
                     const normalized = normalizeAnswer(original);
                     answerMap.set(normalized, original);
-                    const alias = normalized.replace(/역량$/, '');
-                    if (alias !== normalized) {
-                        answerMap.set(alias, original);
+                    if (isCompetency) {
+                        const alias = normalized.replace(/역량$/, '');
+                        if (alias !== normalized) {
+                            answerMap.set(alias, original);
+                        }
                     }
                 });
 
@@ -996,7 +1018,7 @@
                     input.classList.remove(CONSTANTS.CSS_CLASSES.SHAKE);
                 }, { once: true });
 
-                if (gameState.selectedSubject === CONSTANTS.SUBJECTS.COMPETENCY) {
+                if (isCompetency || isUnordered) {
                     input.classList.remove(CONSTANTS.CSS_CLASSES.RETRYING);
                     input.classList.add(CONSTANTS.CSS_CLASSES.INCORRECT);
 
@@ -1014,7 +1036,7 @@
                 }
             }
 
-            if (shouldAdvance && isSectionComplete(section)) {
+            if (shouldAdvance && isSectionComplete(section) && !isModelNames) {
                 if (checkStageClear(section)) {
                     if (gameState.selectedSubject === CONSTANTS.SUBJECTS.COMPETENCY) {
                         setTimeout(() => celebrateCompetencySection(section), 300);
@@ -1032,16 +1054,14 @@
             }
 
             if (shouldAdvance) {
-                const main = input.closest('main');
-                if (main) {
-                    const inputs = Array.from(main.querySelectorAll('input[data-answer]'));
-                    const idx = inputs.indexOf(input);
-                    for (let i = idx + 1; i < inputs.length; i++) {
-                        if (!inputs[i].disabled) {
-                            inputs[i].focus();
-                            inputs[i].scrollIntoView({ behavior: 'smooth', block: 'center' });
-                            break;
-                        }
+                const container = input.closest('main') || section;
+                const inputs = Array.from(container.querySelectorAll('input[data-answer]'));
+                const idx = inputs.indexOf(input);
+                for (let i = idx + 1; i < inputs.length; i++) {
+                    if (!inputs[i].disabled) {
+                        inputs[i].focus();
+                        inputs[i].scrollIntoView({ behavior: 'smooth', block: 'center' });
+                        break;
                     }
                 }
             }
@@ -1322,6 +1342,30 @@
                 }
             });
         });
+
+        document
+            .querySelectorAll('#model-names-modal .model-names')
+            .forEach(section => {
+                section.addEventListener('change', handleInputChange);
+                section.addEventListener('keydown', e => {
+                    if (e.key === 'Enter' && e.target.matches('input[data-answer]')) {
+                        handleInputChange({ target: e.target });
+                        if (e.target.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
+                            const inputs = Array.from(
+                                section.querySelectorAll('input[data-answer]')
+                            );
+                            const idx = inputs.indexOf(e.target);
+                            for (let i = idx + 1; i < inputs.length; i++) {
+                                if (!inputs[i].disabled) {
+                                    inputs[i].focus();
+                                    inputs[i].scrollIntoView({ behavior: 'smooth', block: 'center' });
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+            });
         
         startGameBtn.addEventListener('click', startGame);
         resetBtn.addEventListener('click', () => resetGame(true));
@@ -1334,10 +1378,16 @@
             fixSettingsPanelHeight();
         });
 
-        closeProgressModalBtn.addEventListener('click', () => {
-            progressModal.classList.remove('active');
-            showAnswersBtn.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
-            resetBtn.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+       closeProgressModalBtn.addEventListener('click', () => {
+           progressModal.classList.remove('active');
+           showAnswersBtn.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+           resetBtn.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+       });
+
+        closeModelNamesBtn.addEventListener('click', () => {
+            modelNamesModal.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE);
+            const activeSection = document.querySelector(`#${gameState.selectedSubject}-quiz-main section.active`);
+            if (activeSection) focusFirstInput(activeSection);
         });
 
         scrapResultImageBtn.addEventListener('click', () => {
@@ -1416,6 +1466,21 @@
             } else {
                 document
                     .querySelectorAll(`#${gameState.selectedSubject}-quiz-main input[data-answer]`)
+                    .forEach(input => {
+                        if (!input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
+                            input.value = input.dataset.answer;
+                            input.classList.remove(
+                                CONSTANTS.CSS_CLASSES.INCORRECT,
+                                CONSTANTS.CSS_CLASSES.RETRYING
+                            );
+                            input.classList.add(CONSTANTS.CSS_CLASSES.REVEALED);
+                        }
+                        input.disabled = true;
+                    });
+            }
+            if (gameState.selectedTopic === CONSTANTS.TOPICS.MODEL) {
+                document
+                    .querySelectorAll(`#model-names-modal .model-names[data-subject="${gameState.selectedSubject}"] input[data-answer]`)
                     .forEach(input => {
                         if (!input.classList.contains(CONSTANTS.CSS_CLASSES.CORRECT)) {
                             input.value = input.dataset.answer;

--- a/index.html
+++ b/index.html
@@ -4052,7 +4052,68 @@
           </div>
       </div>
   </div>
-  
+
+  <div id="model-names-modal" class="modal-overlay">
+      <div class="modal-content">
+          <h2>모형 영역</h2>
+          <section class="model-names unordered hidden" data-subject="ethics">
+              <div class="grade-container"><div><table><tbody><tr><th>영역명</th><td class="two-col-answers">
+                  <input data-answer="역할놀이" aria-label="역할놀이" placeholder="영역명">
+                  <input data-answer="개념 분석" aria-label="개념 분석" placeholder="영역명">
+                  <input data-answer="가치 분석" aria-label="가치 분석" placeholder="영역명">
+                  <input data-answer="가치 갈등 해결" aria-label="가치 갈등 해결" placeholder="영역명">
+                  <input data-answer="가치 명료화" aria-label="가치 명료화" placeholder="영역명">
+                  <input data-answer="합리적 의사 결정" aria-label="합리적 의사 결정" placeholder="영역명">
+                  <input data-answer="도덕적 토론" aria-label="도덕적 토론" placeholder="영역명">
+                  <input data-answer="도덕 이야기" aria-label="도덕 이야기" placeholder="영역명">
+                  <input data-answer="경험 학습" aria-label="경험 학습" placeholder="영역명">
+                  <input data-answer="집단 탐구" aria-label="집단 탐구" placeholder="영역명">
+                  <input data-answer="철학적 탐구 공동체" aria-label="철학적 탐구 공동체" placeholder="영역명">
+              </td></tr></tbody></table></div></div>
+          </section>
+          <section class="model-names unordered hidden" data-subject="practical">
+              <div class="grade-container"><div><table><tbody><tr><th>영역명</th><td class="two-col-answers">
+                  <input data-answer="문제 해결" aria-label="문제 해결" placeholder="영역명">
+                  <input data-answer="프로젝트" aria-label="프로젝트" placeholder="영역명">
+                  <input data-answer="실습 중심" aria-label="실습 중심" placeholder="영역명">
+                  <input data-answer="협동 학습" aria-label="협동 학습" placeholder="영역명">
+                  <input data-answer="홈 프로젝트" aria-label="홈 프로젝트" placeholder="영역명">
+                  <input data-answer="실천적 문제 중심 학습" aria-label="실천적 문제 중심 학습" placeholder="영역명">
+                  <input data-answer="기술적 문제해결 과정" aria-label="기술적 문제해결 과정" placeholder="영역명">
+              </td></tr></tbody></table></div></div>
+          </section>
+          <section class="model-names unordered hidden" data-subject="social">
+              <div class="grade-container"><div><table><tbody><tr><th>영역명</th><td class="two-col-answers">
+                  <input data-answer="속성 모형" aria-label="속성 모형" placeholder="영역명">
+                  <input data-answer="원형모형" aria-label="원형모형" placeholder="영역명">
+                  <input data-answer="상황모형" aria-label="상황모형" placeholder="영역명">
+                  <input data-answer="탐구학습(마시알라스)" aria-label="탐구학습(마시알라스)" placeholder="영역명">
+                  <input data-answer="탐구학습(뱅크스)" aria-label="탐구학습(뱅크스)" placeholder="영역명">
+                  <input data-answer="문제해결학습" aria-label="문제해결학습" placeholder="영역명">
+                  <input data-answer="합리적 의사결정" aria-label="합리적 의사결정" placeholder="영역명">
+                  <input data-answer="의사결정 매트릭스" aria-label="의사결정 매트릭스" placeholder="영역명">
+                  <input data-answer="논쟁문제" aria-label="논쟁문제" placeholder="영역명">
+                  <input data-answer="논쟁문제(Minor)" aria-label="논쟁문제(Minor)" placeholder="영역명">
+                  <input data-answer="직소Ⅱ" aria-label="직소Ⅱ" placeholder="영역명">
+                  <input data-answer="STAD" aria-label="STAD" placeholder="영역명">
+              </td></tr></tbody></table></div></div>
+          </section>
+          <section class="model-names unordered hidden" data-subject="science">
+              <div class="grade-container"><div><table><tbody><tr><th>영역명</th><td class="two-col-answers">
+                  <input data-answer="경험 학습 모형" aria-label="경험 학습 모형" placeholder="영역명">
+                  <input data-answer="발견 학습 모형" aria-label="발견 학습 모형" placeholder="영역명">
+                  <input data-answer="탐구 학습 모형" aria-label="탐구 학습 모형" placeholder="영역명">
+                  <input data-answer="순환 학습 모형" aria-label="순환 학습 모형" placeholder="영역명">
+                  <input data-answer="POE" aria-label="POE" placeholder="영역명">
+                  <input data-answer="5E" aria-label="5E" placeholder="영역명">
+                  <input data-answer="개념 변화 학습 모형" aria-label="개념 변화 학습 모형" placeholder="영역명">
+                  <input data-answer="STS 학습 모형" aria-label="STS 학습 모형" placeholder="영역명">
+              </td></tr></tbody></table></div></div>
+          </section>
+          <button id="close-model-names-btn" class="btn">확인</button>
+      </div>
+  </div>
+
   <div id="guide-modal" class="modal-overlay">
       <div class="modal-content">
           <h3>HOW TO PLAY</h3>


### PR DESCRIPTION
## Summary
- add model names modal for model topic subjects
- support order-agnostic grading for model names
- show answers for model name inputs
- enable scoring for model name warmup inputs using usedAnswersMap

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b2a093dc832c8774d6cd52586047