### PR TITLE
Add blank inputs for model area names

### DIFF
--- a/index.html
+++ b/index.html
@@ -989,7 +989,7 @@
       <div class="tab" data-target="p4c">철학적 탐구 공동체</div>
     </div>
     <section id="roleplay" class="active">
-      <h2>역할놀이 수업모형</h2>
+      <h2><input data-answer="역할놀이" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="역할놀이 준비" aria-label="역할놀이 준비" placeholder="단계명">
         <input data-answer="역할놀이 참가자 선정" aria-label="역할놀이 참가자 선정" placeholder="단계명">
@@ -1002,7 +1002,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="concept-analysis">
-      <h2>개념 분석 수업모형</h2>
+      <h2><input data-answer="개념 분석" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="분석될 가치 개념의 확인" aria-label="분석될 가치 개념의 확인" placeholder="단계명">
         <input data-answer="개념의 전형적인 사례와 개념에 반대되는 사례 탐구" aria-label="개념의 전형적인 사례와 개념에 반대되는 사례 탐구" placeholder="단계명">
@@ -1013,7 +1013,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="value-analysis">
-      <h2>가치 분석 수업모형</h2>
+      <h2><input data-answer="가치 분석" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
         <input data-answer="가치 문제의 확인과 명료화" aria-label="가치 문제의 확인과 명료화" placeholder="단계명">
@@ -1024,7 +1024,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="conflict-resolution">
-      <h2>가치 갈등 해결 수업모형</h2>
+      <h2><input data-answer="가치 갈등 해결" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
         <input data-answer="관련 규범 확인 및 의미 파악" aria-label="관련 규범 확인 및 의미 파악" placeholder="단계명">
@@ -1034,7 +1034,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="value-clarification">
-      <h2>가치 명료화 수업모형</h2>
+      <h2><input data-answer="가치 명료화" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
         <input data-answer="자유롭게 선택하기" aria-label="자유롭게 선택하기" placeholder="단계명">
@@ -1047,7 +1047,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="rational-decision">
-      <h2>합리적 의사 결정 수업모형</h2>
+      <h2><input data-answer="합리적 의사 결정" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시와 분석" aria-label="도덕적 문제 사태의 제시와 분석" placeholder="단계명">
         <input data-answer="관련 규범의 확인 및 그 의미와 타당성 파악" aria-label="관련 규범의 확인 및 그 의미와 타당성 파악" placeholder="단계명">
@@ -1057,7 +1057,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="moral-discussion">
-      <h2>도덕적 토론 수업모형</h2>
+      <h2><input data-answer="도덕적 토론" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="도덕적 문제 사태의 제시" aria-label="도덕적 문제 사태의 제시" placeholder="단계명">
         <input data-answer="도덕적 토론의 도입" aria-label="도덕적 토론의 도입" placeholder="단계명">
@@ -1073,7 +1073,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="moral-story">
-      <h2>도덕 이야기 수업모형</h2>
+      <h2><input data-answer="도덕 이야기" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="학습 문제 인식과 동기 유발" aria-label="학습 문제 인식과 동기 유발" placeholder="단계명">
         <input data-answer="도덕 이야기의 제시와 주요 내용 파악" aria-label="도덕 이야기의 제시와 주요 내용 파악" placeholder="단계명">
@@ -1083,7 +1083,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="experience-learning">
-      <h2>경험 학습 수업모형</h2>
+      <h2><input data-answer="경험 학습" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="경험 학습의 주제 설정하기" aria-label="경험 학습의 주제 설정하기" placeholder="단계명">
         <input data-answer="경험 학습 계획 세우기" aria-label="경험 학습 계획 세우기" placeholder="단계명">
@@ -1093,7 +1093,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="group-inquiry">
-      <h2>집단 탐구 수업모형</h2>
+      <h2><input data-answer="집단 탐구" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="탐구 문제의 설정" aria-label="탐구 문제의 설정" placeholder="단계명">
         <input data-answer="탐구 계획의 수립" aria-label="탐구 계획의 수립" placeholder="단계명">
@@ -1103,7 +1103,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="p4c">
-      <h2>철학적 탐구 공동체 수업모형</h2>
+      <h2><input data-answer="철학적 탐구 공동체" aria-label="모형명" placeholder="모형명"> 수업모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="생각 열기" aria-label="생각 열기" placeholder="단계명">
         <input data-answer="교재 읽기" aria-label="교재 읽기" placeholder="단계명">
@@ -1125,7 +1125,7 @@
       <div class="tab" data-target="technical-problem-solving">기술적 문제해결 과정</div>
     </div>
     <section id="problem-solving" class="active">
-      <h2>문제 해결 교수·학습 방법</h2>
+      <h2><input data-answer="문제 해결" aria-label="모형명" placeholder="모형명"> 교수·학습 방법</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 인식" aria-label="문제 인식" placeholder="단계명">
         <input data-answer="정보의 수집을 통한 문제 해결 방안의 마련과 선택의 준비" aria-label="정보의 수집을 통한 문제 해결 방안의 마련과 선택의 준비" placeholder="단계명">
@@ -1135,7 +1135,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="project">
-      <h2>프로젝트 교수·학습 방법</h2>
+      <h2><input data-answer="프로젝트" aria-label="모형명" placeholder="모형명"> 교수·학습 방법</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="목적 설정" aria-label="목적 설정" placeholder="단계명">
         <input data-answer="계획" aria-label="계획" placeholder="단계명">
@@ -1144,7 +1144,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="practice-centered">
-      <h2>실습 중심 교수·학습 방법</h2>
+      <h2><input data-answer="실습 중심" aria-label="모형명" placeholder="모형명"> 교수·학습 방법</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="실습 활동의 목적 및 관련 지식 이해" aria-label="실습 활동의 목적 및 관련 지식 이해" placeholder="단계명">
         <input data-answer="실습 과정의 제시" aria-label="실습 과정의 제시" placeholder="단계명">
@@ -1154,7 +1154,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="cooperative">
-      <h2>협동 학습 교수·학습 방법</h2>
+      <h2><input data-answer="협동 학습" aria-label="모형명" placeholder="모형명"> 교수·학습 방법</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="모둠 구성" aria-label="모둠 구성" placeholder="단계명">
         <input data-answer="과제 제시 및 선택" aria-label="과제 제시 및 선택" placeholder="단계명">
@@ -1164,7 +1164,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="home-project">
-      <h2>홈 프로젝트 모형 (가정 실습형)</h2>
+      <h2><input data-answer="홈 프로젝트" aria-label="모형명" placeholder="모형명"> 모형 (가정 실습형)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
         <input data-answer="실습 계획 수립" aria-label="실습 계획 수립" placeholder="단계명">
@@ -1177,7 +1177,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="practical-problem">
-      <h2>실천적 문제 중심 학습</h2>
+      <h2><input data-answer="실천적 문제 중심 학습" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 정의" aria-label="문제 정의" placeholder="단계명">
         <input data-answer="문제 해결을 위한 정보 수집" aria-label="문제 해결을 위한 정보 수집" placeholder="단계명">
@@ -1187,7 +1187,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="technical-problem-solving">
-      <h2>기술적 문제해결 과정</h2>
+      <h2><input data-answer="기술적 문제해결 과정" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 확인" aria-label="문제 확인" placeholder="단계명">
         <input data-answer="아이디어 탐색 및 구체화" aria-label="아이디어 탐색 및 구체화" placeholder="단계명">
@@ -1212,7 +1212,7 @@
       <div class="tab" data-target="stad">STAD</div>
     </div>
     <section id="attribute" class="active">
-      <h2>속성 모형 (개념학습모형)</h2>
+      <h2><input data-answer="속성 모형" aria-label="모형명" placeholder="모형명"> (개념학습모형)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
         <input data-answer="속성 제시와 정의" aria-label="속성 제시와 정의" placeholder="단계명">
@@ -1225,7 +1225,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="prototype">
-      <h2>원형모형 (개념학습모형)</h2>
+      <h2><input data-answer="원형모형" aria-label="모형명" placeholder="모형명"> (개념학습모형)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
         <input data-answer="개념의 원형과 정의 제시" aria-label="개념의 원형과 정의 제시" placeholder="단계명">
@@ -1237,7 +1237,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="context">
-      <h2>상황모형 (개념학습모형)</h2>
+      <h2><input data-answer="상황모형" aria-label="모형명" placeholder="모형명"> (개념학습모형)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
         <input data-answer="상황 및 경험의 제시" aria-label="상황 및 경험의 제시" placeholder="단계명">
@@ -1249,7 +1249,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="inquiry-mc">
-      <h2>탐구학습모형 (마시알라스, 콕스)</h2>
+      <h2><input data-answer="탐구학습(마시알라스)" aria-label="모형명" placeholder="모형명"> 모형 (콕스)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="탐구 문제 파악" aria-label="탐구 문제 파악" placeholder="단계명">
         <input data-answer="가설 설정" aria-label="가설 설정" placeholder="단계명">
@@ -1259,7 +1259,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="inquiry-banks">
-      <h2>탐구학습모형 (뱅크스, 차경수)</h2>
+      <h2><input data-answer="탐구학습(뱅크스)" aria-label="모형명" placeholder="모형명"> 모형 (차경수)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
         <input data-answer="가설 설정" aria-label="가설 설정" placeholder="단계명">
@@ -1270,7 +1270,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="problem-solving">
-      <h2>문제해결학습모형</h2>
+      <h2><input data-answer="문제해결학습" aria-label="모형명" placeholder="모형명">모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 확인" aria-label="문제 확인" placeholder="단계명">
         <input data-answer="문제 발생 원인 파악" aria-label="문제 발생 원인 파악" placeholder="단계명">
@@ -1280,7 +1280,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="rational-banks">
-      <h2>합리적 의사결정 모형 (뱅크스)</h2>
+      <h2><input data-answer="합리적 의사결정" aria-label="모형명" placeholder="모형명"> 모형 (뱅크스)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
         <input data-answer="사회 탐구" aria-label="사회 탐구" placeholder="단계명">
@@ -1290,7 +1290,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="decision-matrix">
-      <h2>의사결정 매트릭스 모형</h2>
+      <h2><input data-answer="의사결정 매트릭스" aria-label="모형명" placeholder="모형명"> 모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 정의" aria-label="문제 정의" placeholder="단계명">
         <input data-answer="대안 나열" aria-label="대안 나열" placeholder="단계명">
@@ -1300,7 +1300,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="controversy">
-      <h2>논쟁문제 학습모형</h2>
+      <h2><input data-answer="논쟁문제" aria-label="모형명" placeholder="모형명"> 학습모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
         <input data-answer="개념의 명확화" aria-label="개념의 명확화" placeholder="단계명">
@@ -1310,7 +1310,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="controversy-minor">
-      <h2>논쟁문제 학습모형(Minor)</h2>
+      <h2><input data-answer="논쟁문제(Minor)" aria-label="모형명" placeholder="모형명"> 학습모형</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 제기" aria-label="문제 제기" placeholder="단계명">
         <input data-answer="가치 문제 확인" aria-label="가치 문제 확인" placeholder="단계명">
@@ -1323,7 +1323,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="jigsaw2">
-      <h2>직소Ⅱ (협동학습모형)</h2>
+      <h2><input data-answer="직소Ⅱ" aria-label="모형명" placeholder="모형명"> (협동학습모형)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="소집단 구성" aria-label="소집단 구성" placeholder="단계명">
         <input data-answer="전체 학습지와 자료 배부" aria-label="전체 학습지와 자료 배부" placeholder="단계명">
@@ -1334,7 +1334,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="stad">
-      <h2>STAD (협동학습모형)</h2>
+      <h2><input data-answer="STAD" aria-label="모형명" placeholder="모형명"> (협동학습모형)</h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="집단 구성" aria-label="집단 구성" placeholder="단계명">
         <input data-answer="교사의 수업 안내와 학습지 배부" aria-label="교사의 수업 안내와 학습지 배부" placeholder="단계명">
@@ -1356,7 +1356,7 @@
       <div class="tab" data-target="sts-learning">STS 학습 모형</div>
     </div>
     <section id="experience-learning" class="active">
-      <h2>경험 학습 모형</h2>
+      <h2><input data-answer="경험 학습 모형" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="자유 탐색" aria-label="자유 탐색" placeholder="단계명">
         <input data-answer="탐색 결과 발표" aria-label="탐색 결과 발표" placeholder="단계명">
@@ -1365,7 +1365,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="discovery-learning">
-      <h2>발견 학습 모형</h2>
+      <h2><input data-answer="발견 학습 모형" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="탐색 및 문제 파악" aria-label="탐색 및 문제 파악" placeholder="단계명">
         <input data-answer="자료 제시 및 관찰 탐색" aria-label="자료 제시 및 관찰 탐색" placeholder="단계명">
@@ -1375,7 +1375,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="inquiry-learning">
-      <h2>탐구 학습 모형</h2>
+      <h2><input data-answer="탐구 학습 모형" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="탐색 및 문제 파악" aria-label="탐색 및 문제 파악" placeholder="단계명">
         <input data-answer="가설 설정" aria-label="가설 설정" placeholder="단계명">
@@ -1386,7 +1386,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="learning-cycle">
-      <h2>순환 학습 모형</h2>
+      <h2><input data-answer="순환 학습 모형" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="탐색" aria-label="탐색" placeholder="단계명">
         <input data-answer="개념 도입" aria-label="개념 도입" placeholder="단계명">
@@ -1394,7 +1394,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="poe">
-      <h2>POE</h2>
+      <h2><input data-answer="POE" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="예상" aria-label="예상" placeholder="단계명">
         <input data-answer="관찰" aria-label="관찰" placeholder="단계명">
@@ -1402,7 +1402,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="five-e">
-      <h2>5E</h2>
+      <h2><input data-answer="5E" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="참여" aria-label="참여" placeholder="단계명">
         <input data-answer="탐색" aria-label="탐색" placeholder="단계명">
@@ -1412,7 +1412,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="conceptual-change">
-      <h2>개념 변화 학습 모형</h2>
+      <h2><input data-answer="개념 변화 학습 모형" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="개념 표현" aria-label="개념 표현" placeholder="단계명">
         <input data-answer="개념 재구성" aria-label="개념 재구성" placeholder="단계명">
@@ -1425,7 +1425,7 @@
       </td></tr></tbody></table></div></div>
     </section>
     <section id="sts-learning">
-      <h2>STS 학습 모형</h2>
+      <h2><input data-answer="STS 학습 모형" aria-label="모형명" placeholder="모형명"></h2>
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 소개" aria-label="문제 소개" placeholder="단계명">
         <input data-answer="탐색" aria-label="탐색" placeholder="단계명">


### PR DESCRIPTION
## Summary
- Allow typing of model area names in ethics, practical, social, and science model sections

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b7e6a78c832c87532cccb0bb8e7c