### PR TITLE
Make activity example fields stand out

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@
       --accent: #533483;
       --text-light: #F0F0F0;
       --text-dark: #A0A0A0;
+      --pure-white: #FFFFFF;
       --correct: #39FF14; /* Neon Green */
       --incorrect: #FF5733; /* Bright Orange-Red */
       --retrying: #FFC300; /* Amber/Yellow for retry */
@@ -429,7 +430,7 @@ th input.sub-area-input {
 }
 
 td input.activity-input {
-  border: 3px solid var(--accent);
+  border: 3px solid var(--pure-white);
   background: var(--primary);
   font-weight: 800;
   color: var(--text-light);


### PR DESCRIPTION
## Summary
- add a `--pure-white` color token to the design system
- use the new color for `신체활동 예시` input borders so they stand out from other blanks

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689984167e88832ca1e39cad98fd6204