### PR TITLE
Add sub-step inputs to technical problem solving section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1191,6 +1191,10 @@
       <div class="grade-container"><div><table><tbody><tr><th>단계</th><td>
         <input data-answer="문제 확인" aria-label="문제 확인" placeholder="단계명">
         <input data-answer="아이디어 탐색 및 구체화" aria-label="아이디어 탐색 및 구체화" placeholder="단계명">
+        <input class="sub-step" data-answer="정보 수집" aria-label="정보 수집" placeholder="하위 단계">
+        <input class="sub-step" data-answer="아이디어 구상" aria-label="아이디어 구상" placeholder="하위 단계">
+        <input class="sub-step" data-answer="아이디어 평가 및 선정" aria-label="아이디어 평가 및 선정" placeholder="하위 단계">
+        <input class="sub-step" data-answer="아이디어 구체화" aria-label="아이디어 구체화" placeholder="하위 단계">
         <input data-answer="실행" aria-label="실행" placeholder="단계명">
         <input data-answer="평가" aria-label="평가" placeholder="단계명">
       </td></tr></tbody></table></div></div>

--- a/styles.css
+++ b/styles.css
@@ -484,6 +484,13 @@ td input.example-input {
   border-left: 5px dotted var(--primary);
 }
 
+td input.sub-step {
+  margin-left: 1rem;
+  width: calc(100% - 1rem);
+  border: 2px dashed var(--primary);
+  background: var(--bg-light);
+}
+
 td input.activity-input:not(:first-child) {
   margin-top: 1.5rem;
 }


### PR DESCRIPTION
## Summary
- Add four sub-step input fields after the "아이디어 탐색 및 구체화" step in the technical problem-solving table
- Style sub-step inputs with a new `.sub-step` class for visual distinction
- Highlight sub-step input borders with the primary color for clearer separation from main steps

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899ec3902a0832c8ac764b6f3c84459