### PR TITLE
Reorder model subject buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4308,12 +4308,12 @@
                 <button class="btn subject-btn" data-subject="wise" data-topic="curriculum">슬기로운 생활</button>
                 <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐거운 생활</button>
                 <button class="btn subject-btn" data-subject="english" data-topic="basic">영어</button>
-                <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
                 <button class="btn subject-btn" data-subject="practical" data-topic="model">실과</button>
+                <button class="btn subject-btn" data-subject="pe-model" data-topic="model">체육</button>
+                <button class="btn subject-btn" data-subject="ethics" data-topic="model">도덕</button>
+                <button class="btn subject-btn" data-subject="korean-model" data-topic="model">국어</button>
                 <button class="btn subject-btn" data-subject="social" data-topic="model">사회</button>
                 <button class="btn subject-btn" data-subject="science" data-topic="model">과학</button>
-                <button class="btn subject-btn" data-subject="korean-model" data-topic="model">국어</button>
-                <button class="btn subject-btn" data-subject="pe-model" data-topic="model">체육</button>
                 <button class="btn subject-btn" data-subject="science-std" data-topic="achievement">과학</button>
                 <button class="btn subject-btn" data-subject="practical-std" data-topic="achievement">실과</button>
                 <button class="btn subject-btn" data-subject="pe-back" data-topic="course">체육(뒷교)</button>


### PR DESCRIPTION
## Summary
- Arrange model topic subject buttons as 실과, 체육, 도덕, 국어, 사회, 과학

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a018b4220832c8c89b6c9fc6900e4