### PR TITLE
Add features to sports education model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1627,6 +1627,14 @@
           <input data-answer="코치 (인지 > 정의 > 심동)" aria-label="코치 (인지 > 정의 > 심동)" placeholder="정답">
           <input data-answer="팀원 (정의 > 인지 > 심동)" aria-label="팀원 (정의 > 인지 > 심동)" placeholder="정답">
         </td></tr>
+        <tr><th>특징</th><td>
+          <input data-answer="축제화" aria-label="축제화" placeholder="정답">
+          <input data-answer="시즌" aria-label="시즌" placeholder="정답">
+          <input data-answer="팀 소속" aria-label="팀 소속" placeholder="정답">
+          <input data-answer="공식 경기" aria-label="공식 경기" placeholder="정답">
+          <input data-answer="결승전 행사" aria-label="결승전 행사" placeholder="정답">
+          <input data-answer="기록 보존" aria-label="기록 보존" placeholder="정답">
+        </td></tr>
       </tbody></table></div></div>
     </section>
     <section id="psr-pe">


### PR DESCRIPTION
## Summary
- add feature blanks for 축제화, 시즌, 팀 소속, 공식 경기, 결승전 행사, 기록 보존 to 스포츠교육모형

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a11ee442c832c9d9e146096dd1c83