### PR TITLE
feat: add responsibility levels to sports education model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1627,6 +1627,14 @@
           <input data-answer="코치 (인지 > 정의 > 심동)" aria-label="코치 (인지 > 정의 > 심동)" placeholder="정답">
           <input data-answer="팀원 (정의 > 인지 > 심동)" aria-label="팀원 (정의 > 인지 > 심동)" placeholder="정답">
         </td></tr>
+        <tr><th>책임감 수준</th><td>
+          0 <input data-answer="무책임" aria-label="0: 무책임" placeholder="정답">
+          1 <input data-answer="타인의 권리와 감정 존중" aria-label="1: 타인의 권리와 감정 존중" placeholder="정답">
+          2 <input data-answer="참여와 노력" aria-label="2: 참여와 노력" placeholder="정답">
+          3 <input data-answer="자기 책임" aria-label="3: 자기 책임" placeholder="정답">
+          4 <input data-answer="배려 (타인을 배려하고 돕기)" aria-label="4: 배려 (타인을 배려하고 돕기)" placeholder="정답">
+          5 <input data-answer="전이 (체육 수업 밖으로의 전이)" aria-label="5: 전이 (체육 수업 밖으로의 전이)" placeholder="정답">
+        </td></tr>
       </tbody></table></div></div>
     </section>
     <section id="psr-pe">


### PR DESCRIPTION
## Summary
- expand sports education model with responsibility level blanks (0-5)

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a124efd84832c941f9ba1e87e04ea