### PR TITLE
Allow PE model answers without chevrons

### DIFF
--- a/app.js
+++ b/app.js
@@ -280,11 +280,21 @@
                     )
                 );
             const pattern = ignoreParticleEui ? /[\s⋅·의]+/g : /[\s⋅·]+/g;
-            return str
+            const removeChevrons =
+                gameState.selectedTopic === CONSTANTS.TOPICS.MODEL &&
+                gameState.selectedSubject === CONSTANTS.SUBJECTS.PE_MODEL;
+
+            let result = str
                 .replace(/\([^)]*\)/g, '')
                 .trim()
                 .replace(pattern, '')
                 .toLowerCase();
+
+            if (removeChevrons) {
+                result = result.replace(/>/g, '');
+            }
+
+            return result;
         }
 
         function typewriter(element, text) {


### PR DESCRIPTION
## Summary
- Accept PE model answers with or without '>' by normalizing chevrons

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a21b7bd40832cadb3b7412cd294bd