### PR TITLE
Fix learning domain order for peer teaching model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@
         </td></tr>
         <tr><th>학습영역</th><td>
           <input data-answer="학습자: 심동 > 인지 > 정의" aria-label="학습자: 심동 > 인지 > 정의" placeholder="정답">
-          <input data-answer="동료교사: 인지 > 정의 > 행동" aria-label="동료교사: 인지 > 정의 > 행동" placeholder="정답">
+          <input data-answer="동료교사: 인지 > 정의 > 심동" aria-label="동료교사: 인지 > 정의 > 심동" placeholder="정답">
         </td></tr>
       </tbody></table></div></div>
     </section>


### PR DESCRIPTION
## Summary
- Correct peer teacher learning-domain sequence to `인지 > 정의 > 심동`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a232e6ae4832c98b31e52e5707a83