### PR TITLE
Add type-based steps for P4C ethics model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1112,6 +1112,29 @@
         <input data-answer="토의(토론)하기" aria-label="토의(토론)하기" placeholder="단계명">
         <input data-answer="생각 정리 및 표현하기" aria-label="생각 정리 및 표현하기" placeholder="단계명">
       </td></tr></tbody></table></div></div>
+      <div class="grade-container"><div><table><tbody>
+        <tr><th>유형 이름</th><th>단계명</th></tr>
+        <tr><th>개념탐구유형</th><td>
+          <input data-answer="예 들기" aria-label="예 들기" placeholder="단계명">
+          <input data-answer="공통점 찾기" aria-label="공통점 찾기" placeholder="단계명">
+          <input data-answer="정의하기" aria-label="정의하기" placeholder="단계명">
+        </td></tr>
+        <tr><th>대안탐구유형</th><td>
+          <input data-answer="가능한 대안 찾기" aria-label="가능한 대안 찾기" placeholder="단계명">
+          <input data-answer="장단점 비교하기" aria-label="장단점 비교하기" placeholder="단계명">
+          <input data-answer="최선안 선택하기" aria-label="최선안 선택하기" placeholder="단계명">
+        </td></tr>
+        <tr><th>갈등 탐구 유형</th><td>
+          <input data-answer="각 의견의 정당화" aria-label="각 의견의 정당화" placeholder="단계명">
+          <input data-answer="검토" aria-label="검토" placeholder="단계명">
+          <input data-answer="합의하기" aria-label="합의하기" placeholder="단계명">
+        </td></tr>
+        <tr><th>가치 탐구 유형</th><td>
+          <input data-answer="논증하기" aria-label="논증하기" placeholder="단계명">
+          <input data-answer="찬성, 반대 의견" aria-label="찬성, 반대 의견" placeholder="단계명">
+          <input data-answer="입장 정리하기" aria-label="입장 정리하기" placeholder="단계명">
+        </td></tr>
+      </tbody></table></div></div>
     </section>
   </main>
   <main id="practical-quiz-main" class="hidden">


### PR DESCRIPTION
## Summary
- Expand the 철학적 탐구 공동체 수업모형 section with a table of 유형 이름 and 단계명
- Cover four inquiry types: 개념탐구유형, 대안탐구유형, 갈등 탐구 유형, 가치 탐구 유형

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b18f6e704832c8dc1bf0199ffa366