### PR TITLE
Display integrated competency sections side-by-side

### DIFF
--- a/index.html
+++ b/index.html
@@ -4294,22 +4294,24 @@
       <h2>실과</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="실천적 문제 해결 능력" aria-label="실천적 문제 해결 능력" placeholder="정답"><input data-answer="생활 자립 능력" aria-label="생활 자립 능력" placeholder="정답"><input data-answer="관계 형성 능력" aria-label="관계 형성 능력" placeholder="정답"><input data-answer="기술적 실천 능력" aria-label="기술적 실천 능력" placeholder="정답"><input data-answer="기술적 문제해결 능력" aria-label="기술적 문제해결 능력" placeholder="정답"><input data-answer="기술학적 지식의 이해 능력" aria-label="기술학적 지식의 이해 능력" placeholder="정답"></td></tr></tbody></table></div></div>
     </section>
-    <section id="integrated">
-      <h2>통합</h2>
-    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="지금-여기-우리 삶" aria-label="지금-여기-우리 삶" placeholder="정답"></td></tr></tbody></table></div></div>
-    </section>
-    <section id="goodlife">
-      <h2>통합-바생(총론)</h2>
-    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="자기관리 역량" aria-label="자기관리 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
-    </section>
-    <section id="sociality">
-      <h2>통합-슬생(총론)</h2>
-    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="지식정보처리 역량" aria-label="지식정보처리 역량" placeholder="정답"><input data-answer="창의적 사고 역량" aria-label="창의적 사고 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
-    </section>
-    <section id="joyful">
-      <h2>통합-즐생(총론)</h2>
-    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
-    </section>
+    <div class="integrated-sections">
+      <section id="integrated">
+        <h2>통합</h2>
+        <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="지금-여기-우리 삶" aria-label="지금-여기-우리 삶" placeholder="정답"></td></tr></tbody></table></div></div>
+      </section>
+      <section id="goodlife">
+        <h2>통합-바생(총론)</h2>
+        <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="자기관리 역량" aria-label="자기관리 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+      </section>
+      <section id="sociality">
+        <h2>통합-슬생(총론)</h2>
+        <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="지식정보처리 역량" aria-label="지식정보처리 역량" placeholder="정답"><input data-answer="창의적 사고 역량" aria-label="창의적 사고 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+      </section>
+      <section id="joyful">
+        <h2>통합-즐생(총론)</h2>
+        <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
+      </section>
+    </div>
     <section id="moral-future">
       <h2>도덕-미래사회가 요구하는 역량</h2>
     <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="비판적·배려적 사고력" aria-label="비판적·배려적 사고력" placeholder="정답"><input data-answer="도덕적 상상력" aria-label="도덕적 상상력" placeholder="정답"><input data-answer="도덕 판단 능력" aria-label="도덕 판단 능력" placeholder="정답"><input data-answer="인공 지능 및 디지털 윤리" aria-label="인공 지능 및 디지털 윤리" placeholder="정답"><input data-answer="도덕 공동체 의식" aria-label="도덕 공동체 의식" placeholder="정답"></td></tr></tbody></table></div></div>

--- a/styles.css
+++ b/styles.css
@@ -1200,6 +1200,17 @@ td input.activity-input:not(:first-child) {
     color: var(--bg-dark);
 }
 
+#competency-quiz-main .integrated-sections {
+    display: flex;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+#competency-quiz-main .integrated-sections section {
+    flex: 1;
+    min-width: 260px;
+}
+
 .inline-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Arrange the 통합 competency sections horizontally for improved readability
- Add flexbox styling for the new horizontal layout

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb2e413d8832c97140ab016cd1242