### PR TITLE
Adjust integrated competency layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1211,6 +1211,10 @@ td input.activity-input:not(:first-child) {
     min-width: 260px;
 }
 
+#competency-quiz-main .integrated-sections section:first-child {
+    flex: 0 0 100%;
+}
+
 .inline-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Improve readability of integrated competency sections by placing the main `통합` block on its own row

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb5c1239c832c9304196d89236cba