### PR TITLE
Display moral competency subsections side by side

### DIFF
--- a/index.html
+++ b/index.html
@@ -4239,8 +4239,7 @@
         <button class="competency-tab tab" data-target="english">영어</button>
         <button class="competency-tab tab active" data-target="summary">총론</button>
         <button class="competency-tab tab" data-target="social">사회</button>
-        <button class="competency-tab tab" data-target="moral-future">도덕-미래사회가 요구하는 역량</button>
-        <button class="competency-tab tab" data-target="moral-emphasis">도덕-도덕과 강조점</button>
+        <button class="competency-tab tab" data-target="moral">도덕</button>
         <button class="competency-tab tab" data-target="practical">실과</button>
       </div>
       <div class="competency-row">
@@ -4312,14 +4311,19 @@
         <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="심미적 감성 역량" aria-label="심미적 감성 역량" placeholder="정답"><input data-answer="공동체 역량" aria-label="공동체 역량" placeholder="정답"><input data-answer="협력적 소통 역량" aria-label="협력적 소통 역량" placeholder="정답"></td></tr></tbody></table></div></div>
       </section>
     </div>
-    <section id="moral-future">
-      <h2>도덕-미래사회가 요구하는 역량</h2>
-    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="비판적·배려적 사고력" aria-label="비판적·배려적 사고력" placeholder="정답"><input data-answer="도덕적 상상력" aria-label="도덕적 상상력" placeholder="정답"><input data-answer="도덕 판단 능력" aria-label="도덕 판단 능력" placeholder="정답"><input data-answer="인공 지능 및 디지털 윤리" aria-label="인공 지능 및 디지털 윤리" placeholder="정답"><input data-answer="도덕 공동체 의식" aria-label="도덕 공동체 의식" placeholder="정답"></td></tr></tbody></table></div></div>
+    <section id="moral">
+      <h2>도덕</h2>
+      <div class="moral-wrapper">
+        <div class="moral-block">
+          <h3>미래사회가 요구하는 역량</h3>
+          <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="비판적·배려적 사고력" aria-label="비판적·배려적 사고력" placeholder="정답"><input data-answer="도덕적 상상력" aria-label="도덕적 상상력" placeholder="정답"><input data-answer="도덕 판단 능력" aria-label="도덕 판단 능력" placeholder="정답"><input data-answer="인공 지능 및 디지털 윤리" aria-label="인공 지능 및 디지털 윤리" placeholder="정답"><input data-answer="도덕 공동체 의식" aria-label="도덕 공동체 의식" placeholder="정답"></td></tr></tbody></table></div></div>
+        </div>
+        <div class="moral-block">
+          <h3>도덕과 강조점</h3>
+          <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="도덕 현상에 관한 탐구" aria-label="도덕 현상에 관한 탐구" placeholder="정답"><input data-answer="일상의 실천" aria-label="일상의 실천" placeholder="정답"><input data-answer="내면의 도덕성에 대한 성찰" aria-label="내면의 도덕성에 대한 성찰" placeholder="정답"></td></tr></tbody></table></div></div>
+        </div>
+      </div>
     </section>
-    <section id="moral-emphasis">
-      <h2>도덕-도덕과 강조점</h2>
-    <div class="grade-container"><div><table><tbody><tr><th>역량</th><td class="two-col-answers"><input data-answer="도덕 현상에 관한 탐구" aria-label="도덕 현상에 관한 탐구" placeholder="정답"><input data-answer="일상의 실천" aria-label="일상의 실천" placeholder="정답"><input data-answer="내면의 도덕성에 대한 성찰" aria-label="내면의 도덕성에 대한 성찰" placeholder="정답"></td></tr></tbody></table></div></div>
-  </section>
 </main>
 <!-- competency main end -->
 

--- a/styles.css
+++ b/styles.css
@@ -1481,3 +1481,21 @@ td input.activity-input:not(:first-child) {
   min-width: 0;
   flex: 1 0 auto;
 }
+#moral .moral-wrapper {
+    display: flex;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+#moral .moral-block {
+    flex: 1;
+    min-width: 260px;
+}
+
+#moral .moral-block h3 {
+    margin: 0 0 1rem;
+}
+
+#moral .grade-container > div {
+    padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- Show 도덕-미래사회가 요구하는 역량 and 도덕-도덕과 강조점 next to each other to cut vertical scrolling
- Trim padding around moral grade containers for a more compact view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb6091890832cbb5189e5f4780086