### PR TITLE
Speed up stage transition after clearing

### DIFF
--- a/app.js
+++ b/app.js
@@ -868,7 +868,7 @@
                 gameState.timerId = null;
             }
 
-            const duration = 1 * 1000;
+            const duration = 500; // faster transition after stage clear
             const animationEnd = Date.now() + duration;
             const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 201 };
             function randomInRange(min, max) { return Math.random() * (max - min) + min; }
@@ -921,7 +921,7 @@
                 clearInterval(gameState.timerId);
                 gameState.timerId = null;
             }
-            const duration = 2000;
+            const duration = 1000; // faster transition after competency clear
             const animationEnd = Date.now() + duration;
             const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 201 };
             function randomInRange(min, max) { return Math.random() * (max - min) + min; }


### PR DESCRIPTION
## Summary
- shorten stage clear celebrations so progression begins in 0.5s
- shorten competency section celebrations to 1s for quicker flow

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f407f99d8832ca9d9167a6a9108b4