### PR TITLE
Adjust topic button layout to two columns

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -693,10 +693,10 @@ td input.activity-input:not(:first-child) {
         height: 0;
     }
 
-    /* Arrange topic buttons in two rows with three per row */
+    /* Arrange topic buttons in two rows with two per row */
     .topic-selector {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(2, 1fr);
     }
     .topic-btn {
         width: 100%;


### PR DESCRIPTION
## Summary
- Display topic selection buttons in two columns for improved readability

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f42595054832cab283e97f32ec195