### PR TITLE
Adjust topic selector to two-row layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -693,10 +693,10 @@ td input.activity-input:not(:first-child) {
         height: 0;
     }
 
-    /* Arrange topic buttons in two rows with three per row */
+    /* Arrange topic buttons in two rows with up to four per row */
     .topic-selector {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(4, 1fr);
     }
     .topic-btn {
         width: 100%;


### PR DESCRIPTION
## Summary
- Narrow topic selection buttons by switching grid to four columns, resulting in a two-row layout.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f436a0644832cb8caf8b193f0c4e7