### PR TITLE
Fix random subject button placement for curriculum topic

### DIFF
--- a/index.html
+++ b/index.html
@@ -4556,6 +4556,7 @@
             </div>
             <h2>과목 선택</h2>
             <div class="subject-selector">
+                <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model basic achievement">랜덤</button>
                 <button class="btn subject-btn" data-subject="korean" data-topic="curriculum">국어</button>
                 <button class="btn subject-btn selected" data-subject="music" data-topic="curriculum">음악</button>
                 <button class="btn subject-btn" data-subject="art" data-topic="curriculum">미술</button>
@@ -4563,7 +4564,6 @@
                 <button class="btn subject-btn" data-subject="pe-lite" data-topic="curriculum">체육(lite)</button>
                 <div id="curriculum-break" class="subject-break"></div>
                 <button class="btn subject-btn" data-subject="ethics-lite" data-topic="curriculum">도덕(lite)</button>
-                <button id="random-subject-btn" class="btn" data-subject="random" data-topic="curriculum course model basic achievement">랜덤</button>
                 <button class="btn subject-btn" data-subject="life" data-topic="curriculum">바생</button>
                 <button class="btn subject-btn" data-subject="wise" data-topic="curriculum">슬생</button>
                 <button class="btn subject-btn" data-subject="joy" data-topic="curriculum">즐생</button>


### PR DESCRIPTION
## Summary
- Move the random subject button to the front of the subject selector so it's always first in the curriculum topic

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4a1e59ac832cac5fcce85b418725