### PR TITLE
Align transition delay after incorrect answers with stage clear speed

### DIFF
--- a/app.js
+++ b/app.js
@@ -1083,7 +1083,7 @@
                         if (gameState.total > 0 && gameState.timerId === null) {
                             gameState.timerId = setInterval(tick, 1000);
                         }
-                    }, 300);
+                    }, 800); // match stage clear timing
                 }
             }
 


### PR DESCRIPTION
## Summary
- Slow down auto-transition to next section when answers are incorrect
- Match transition timing to stage-clear flow for consistent pacing

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f64990b80832c9280a9481d2d49e8