### PR TITLE
feat: add header copy result button

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,6 +151,7 @@
         const progressModal = document.getElementById('progress-modal');
         const closeProgressModalBtn = document.getElementById('close-progress-modal-btn');
         const scrapResultImageBtn = document.getElementById('scrap-result-image-btn');
+        const scrapResultImageBtnTop = document.getElementById('scrap-result-image-btn-top');
         const startModal = document.getElementById('start-modal');
         const guideModal = document.getElementById('guide-modal');
         const closeGuideBtn = document.getElementById('close-guide-btn');
@@ -758,6 +759,7 @@
             comboCounter.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             showAnswersBtn.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             showAnswersBtn.disabled = false;
+            scrapResultImageBtnTop.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             resetBtn.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             forceQuitBtn.classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
             document.getElementById('timer-container').classList.add(CONSTANTS.CSS_CLASSES.HIDDEN);
@@ -1411,11 +1413,16 @@
         closeProgressModalBtn.addEventListener('click', () => {
             progressModal.classList.remove('active');
             showAnswersBtn.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
+            scrapResultImageBtnTop.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
             resetBtn.classList.remove(CONSTANTS.CSS_CLASSES.HIDDEN);
         });
 
-        scrapResultImageBtn.addEventListener('click', () => {
+        const handleScrapResultImage = () => {
             const modalContent = document.querySelector('#progress-modal .modal-content');
+            const wasHidden = !progressModal.classList.contains(CONSTANTS.CSS_CLASSES.ACTIVE);
+            if (wasHidden) {
+                progressModal.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
+            }
             html2canvas(modalContent)
                 .then(async canvas => {
                     if (navigator.clipboard && navigator.clipboard.write && window.ClipboardItem) {
@@ -1465,8 +1472,17 @@
                 })
                 .catch(() => {
                     alert('이미지 캡처에 실패했습니다.');
+                })
+                .finally(() => {
+                    if (wasHidden) {
+                        progressModal.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE);
+                    }
                 });
-        });
+        };
+
+        [scrapResultImageBtn, scrapResultImageBtnTop].forEach(btn =>
+            btn.addEventListener('click', handleScrapResultImage)
+        );
 
         decreaseTimeBtn.addEventListener('click', () => {
             playSound(clickAudio);

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     </div>
     <div class="hud-right">
       <button id="force-quit-btn" class="btn hidden">강제 종료</button>
+      <button id="scrap-result-image-btn-top" class="btn hidden">결과창 복사</button>
       <button id="show-answers-btn" class="btn hidden">정답 보기</button>
       <button id="reset-btn" class="btn hidden">처음으로</button>
     </div>


### PR DESCRIPTION
## Summary
- add a "결과창 복사" button next to "정답 보기" in the header
- allow copying results even after the result modal is closed
- unify screenshot logic to work from either copy button and temporarily show the hidden modal

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0908444cc832c95084e0dfb1ec96d