### PR TITLE
Fix competency topic subject display

### DIFF
--- a/app.js
+++ b/app.js
@@ -1341,12 +1341,12 @@
                 main.querySelectorAll('section').forEach(sec => sec.classList.remove(CONSTANTS.CSS_CLASSES.ACTIVE));
                 const sectionIds = sectionGroups[targetId] || [targetId];
                 sectionIds.forEach(id => {
-                    const targetSection = document.getElementById(id);
+                    const targetSection = main.querySelector(`#${id}`);
                     if (targetSection) {
                         targetSection.classList.add(CONSTANTS.CSS_CLASSES.ACTIVE);
                     }
                 });
-                const firstSection = document.getElementById(sectionIds[0]);
+                const firstSection = main.querySelector(`#${sectionIds[0]}`);
                 if (firstSection) {
                     focusFirstInput(firstSection);
                 }


### PR DESCRIPTION
## Summary
- Fix competency tab handler to query sections within its own container
- Ensure competency topic shows the correct subject content

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4047e8a3c832c8e39740d4e11c7eb