### PR TITLE
Add moral principles and methods subject

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@
                 OVERVIEW: 'overview',
                 INTEGRATED_COURSE: 'integrated-course',
                 MORAL_COURSE: 'moral-course',
+                MORAL_METHOD: 'moral-method',
                 COMPETENCY: 'competency',
                 AREA: 'area',
                 RANDOM: 'random'
@@ -51,7 +52,8 @@
                 MODEL: 'model',
                 COURSE: 'course',
                 BASIC: 'basic',
-                ACHIEVEMENT: 'achievement'
+                ACHIEVEMENT: 'achievement',
+                PRINCIPLE_METHOD: 'principle-method'
             },
             MODES: {
                 NORMAL: 'normal',
@@ -102,6 +104,7 @@
             [CONSTANTS.SUBJECTS.OVERVIEW]: '총론',
             [CONSTANTS.SUBJECTS.INTEGRATED_COURSE]: '통합',
             [CONSTANTS.SUBJECTS.MORAL_COURSE]: '도덕',
+            [CONSTANTS.SUBJECTS.MORAL_METHOD]: '도덕(원리와 방법)',
             [CONSTANTS.SUBJECTS.COMPETENCY]: '역량',
             [CONSTANTS.SUBJECTS.AREA]: '영역'
         };
@@ -113,7 +116,8 @@
             [CONSTANTS.TOPICS.MODEL]: '모형',
             [CONSTANTS.TOPICS.COURSE]: '교육과정',
             [CONSTANTS.TOPICS.BASIC]: '기본이론',
-            [CONSTANTS.TOPICS.ACHIEVEMENT]: '성취기준'
+            [CONSTANTS.TOPICS.ACHIEVEMENT]: '성취기준',
+            [CONSTANTS.TOPICS.PRINCIPLE_METHOD]: '원리와 방법'
         };
 
         // --- GAME STATE ---
@@ -456,7 +460,7 @@
        }
 
        function adjustBasicTopicInputWidths() {
-            if (gameState.selectedTopic !== CONSTANTS.TOPICS.BASIC) return;
+            if (![CONSTANTS.TOPICS.BASIC, CONSTANTS.TOPICS.PRINCIPLE_METHOD].includes(gameState.selectedTopic)) return;
             const mainId = `${gameState.selectedSubject}-quiz-main`;
             document
                 .querySelectorAll(`#${mainId} input[data-answer]`)

--- a/index.html
+++ b/index.html
@@ -1142,6 +1142,66 @@
       </tbody></table></div></div>
     </section>
   </main>
+  <main id="moral-method-quiz-main" class="hidden">
+    <div class="tabs">
+      <div class="tab active" data-target="moral-principles">도덕과 학습 지도의 원리</div>
+      <div class="tab" data-target="moral-methods">도덕과 학습 지도 방법</div>
+    </div>
+    <section id="moral-principles" class="active">
+      <h2>도덕과 학습 지도의 원리</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <ul class="assessment-list">
+          <li><input data-answer="정합성의 원리" aria-label="정합성의 원리" placeholder="정답"></li>
+          <li><input data-answer="인지화의 원리" aria-label="인지화의 원리" placeholder="정답"></li>
+          <li><input data-answer="행동화의 원리" aria-label="행동화의 원리" placeholder="정답"></li>
+          <li><input data-answer="심정화의 원리" aria-label="심정화의 원리" placeholder="정답"></li>
+          <li><input data-answer="통합성의 원리" aria-label="통합성의 원리" placeholder="정답"></li>
+          <li><input data-answer="지적·도덕적 발단 단계 고려의 원리" aria-label="지적·도덕적 발단 단계 고려의 원리" placeholder="정답"></li>
+          <li><input data-answer="자율적 탐구 학습의 원리" aria-label="자율적 탐구 학습의 원리" placeholder="정답"></li>
+          <li><input data-answer="주체적 자각화와 개별화의 원리" aria-label="주체적 자각화와 개별화의 원리" placeholder="정답"></li>
+          <li><input data-answer="구체성과 현실성의 원리" aria-label="구체성과 현실성의 원리" placeholder="정답"></li>
+          <li><input data-answer="능동적 참여와 토론 학습의 원리" aria-label="능동적 참여와 토론 학습의 원리" placeholder="정답"></li>
+          <li><input data-answer="반복과 계속성의 원리" aria-label="반복과 계속성의 원리" placeholder="정답"></li>
+          <li><input data-answer="집단적 활동의 원리" aria-label="집단적 활동의 원리" placeholder="정답"></li>
+          <li><input data-answer="학교·가정·지역 사회와 연계한 지도의 원리" aria-label="학교·가정·지역 사회와 연계한 지도의 원리" placeholder="정답"></li>
+        </ul>
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="moral-methods">
+      <h2>도덕과 학습 지도 방법</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <ul class="assessment-list">
+          <li>직접적 가치 전수 방법
+            <ul class="sub-list">
+              <li><input data-answer="강의(설명)" aria-label="강의(설명)" placeholder="정답"></li>
+              <li><input data-answer="도덕 이야기" aria-label="도덕 이야기" placeholder="정답"></li>
+              <li><input data-answer="에듀테크 활용" aria-label="에듀테크 활용" placeholder="정답"></li>
+              <li><input data-answer="모형 제시" aria-label="모형 제시" placeholder="정답"></li>
+              <li><input data-answer="독서" aria-label="독서" placeholder="정답"></li>
+            </ul>
+          </li>
+          <li>간접적 가치 탐구 방법
+            <ul class="sub-list">
+              <li><input data-answer="토론·토의" aria-label="토론·토의" placeholder="정답"></li>
+              <li><input data-answer="문답" aria-label="문답" placeholder="정답"></li>
+              <li><input data-answer="역할놀이" aria-label="역할놀이" placeholder="정답"></li>
+              <li><input data-answer="집단 탐구" aria-label="집단 탐구" placeholder="정답"></li>
+              <li><input data-answer="글쓰기" aria-label="글쓰기" placeholder="정답"></li>
+            </ul>
+          </li>
+          <li>실천·체험을 통한 가치 학습 방법
+            <ul class="sub-list">
+              <li><input data-answer="실습 실연" aria-label="실습 실연" placeholder="정답"></li>
+              <li><input data-answer="현장 학습" aria-label="현장 학습" placeholder="정답"></li>
+              <li><input data-answer="덕목 실천 학습" aria-label="덕목 실천 학습" placeholder="정답"></li>
+              <li><input data-answer="집단 수련 활동" aria-label="집단 수련 활동" placeholder="정답"></li>
+              <li><input data-answer="참여적 실천 체험 활동" aria-label="참여적 실천 체험 활동" placeholder="정답"></li>
+            </ul>
+          </li>
+        </ul>
+      </td></tr></tbody></table></div></div>
+    </section>
+  </main>
   <main id="practical-quiz-main" class="hidden">
     <div class="tabs">
       <div class="tab active" data-target="problem-solving">문제 해결</div>
@@ -4582,6 +4642,7 @@
                 <button class="btn subject-btn" data-subject="overview" data-topic="course">총론</button>
                 <button class="btn subject-btn" data-subject="integrated-course" data-topic="course">통합</button>
                 <button class="btn subject-btn" data-subject="moral-course" data-topic="course">도덕</button>
+                <button class="btn subject-btn" data-subject="moral-method" data-topic="principle-method">도덕(원리와 방법)</button>
             </div>
             <h2>게임 모드</h2>
             <div class="mode-selector">


### PR DESCRIPTION
## Summary
- add new 도덕 subject for 원리와 방법 with dedicated sections for 지도 원리와 지도 방법
- support new subject selection and topic constants
- adjust input sizing logic for principle-method topic

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4a005d7cc832ca458375f2277caea