### PR TITLE
Support flexible moral principles answers and tidy layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,7 +135,8 @@
 
         const SPECIAL_SUBJECTS = new Set([
             CONSTANTS.SUBJECTS.COMPETENCY,
-            CONSTANTS.SUBJECTS.AREA
+            CONSTANTS.SUBJECTS.AREA,
+            CONSTANTS.SUBJECTS.MORAL_PRINCIPLES
         ]);
 
         // Used to keep track of which answers have been matched in competency/area sections

--- a/styles.css
+++ b/styles.css
@@ -1260,6 +1260,26 @@ td input.activity-input:not(:first-child) {
   gap: 0.5rem;
 }
 
+#moral-principles-quiz-main .assessment-list {
+  list-style: none;
+  margin: 0;
+  gap: 0.5rem;
+}
+
+#moral-principles-quiz-main .sub-list {
+  list-style: none;
+  margin-left: 1rem;
+  gap: 0.5rem;
+}
+
+#moral-principles-quiz-main .grade-container {
+  gap: 1.5rem;
+}
+
+#moral-principles-quiz-main .grade-container > div {
+  padding: 1rem;
+}
+
 /* Deeper sub-list levels for English quiz */
 #english-quiz-main .sub-list .sub-list {
   margin-left: 3rem;


### PR DESCRIPTION
## Summary
- Allow 도덕 원리와 방법 answers to be evaluated in any order
- Tighten spacing and padding on 도덕 원리와 방법 lists for clearer UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4a4c3be60832c8378c8721751e6e3