### PR TITLE
Remove etc placeholders from music elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@
               </tr>
               <tr>
                 <th>형식</th>
-                <td><input data-answer="형식(메기고 받는 형식, ab 등)" aria-label="형식(메기고 받는 형식, ab 등)" placeholder="정답"></td>
+                <td><input data-answer="형식(메기고 받는 형식, ab)" aria-label="형식(메기고 받는 형식, ab)" placeholder="정답"></td>
               </tr>
               <tr>
                 <th>셈여림</th>
@@ -347,7 +347,7 @@
               </tr>
               <tr>
                 <th>형식</th>
-                <td><input data-answer="형식(긴자진 형식, 시조 형식, aba, AB 등)" aria-label="형식(긴자진 형식, 시조 형식, aba, AB 등)" placeholder="정답"></td>
+                <td><input data-answer="형식(긴자진 형식, 시조 형식, aba, AB)" aria-label="형식(긴자진 형식, 시조 형식, aba, AB)" placeholder="정답"></td>
               </tr>
               <tr>
                 <th>셈여림</th>


### PR DESCRIPTION
## Summary
- require full music form descriptions without 'etc' placeholders

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a68599c96c832c9a792cc05ed8aea4