### PR TITLE
fix: prevent curriculum text overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -422,6 +422,7 @@ table {
   width: 100%;
   border-collapse: separate;
   border-spacing: 0 1.5rem;
+  table-layout: fixed; /* prevent wide content from expanding container */
 }
 th,
 td {
@@ -443,6 +444,7 @@ td {
   display: flex;
   flex-direction: column;
   gap: 1rem; /* Consistent spacing between inputs */
+  word-break: break-word; /* ensure long text wraps within cell */
 }
 
 td.two-col-answers {


### PR DESCRIPTION
## Summary
- prevent curriculum tables from exceeding viewport width
- allow long text to wrap within curriculum cells

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a699bf09a4832cb9cc5c20d16dd53e