### PR TITLE
Fix hidden table header text in quizzes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -436,7 +436,7 @@ td {
 th {
   padding-right: 1.5rem;
   color: var(--text-dark);
-  width: 1%; /* Prevent th from taking too much space */
+  min-width: 8rem; /* Ensure header text is fully visible */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Ensure table header labels like "지식·이해" remain visible by giving header cells a minimum width

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6a37f7c30832cb4b068a3cec0a1b7