### PR TITLE
Shrink table headers to maximize input width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -437,6 +437,7 @@ th {
   padding-right: 1.5rem;
   color: var(--text-dark);
   min-width: 8rem; /* Ensure header text is fully visible */
+  width: 1%; /* Shrink column so inputs can use remaining space */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- allow header cells to shrink so answer blanks can stretch wider

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6bef3df1c832c8c5243c2f8a0996e