### PR TITLE
Adjust table header width for wider inputs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -437,6 +437,7 @@ th {
   padding-right: 1.5rem;
   color: var(--text-dark);
   min-width: 8rem; /* Ensure header text is fully visible */
+  width: 12rem; /* Reduce header column width so inputs can expand */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Narrow table header column so answer blanks are wider and closer to labels

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c5392e4c832cbe87c7656708f375