### PR TITLE
Add Feldman and Lowenfeld vs Eisner sections to art basic theory

### DIFF
--- a/index.html
+++ b/index.html
@@ -4477,6 +4477,8 @@
       <div class="tab active" data-target="stage-name">단계명</div>
       <div class="tab" data-target="lowenfeld">로웬펠드</div>
       <div class="tab" data-target="gardner">가드너</div>
+      <div class="tab" data-target="feldman">펠드만</div>
+      <div class="tab" data-target="lowenfeld-vs-eisner">로웬펠드vs아이스너</div>
     </div>
     <section id="stage-name" class="active">
       <h2>단계명</h2>
@@ -4596,6 +4598,65 @@
             <ul class="sub-list">
               <li class="inline-item"><input class="fit-answer" data-answer="표현양식(에 대한 관심)" aria-label="표현양식(에 대한 관심)" placeholder="정답" style="min-width:18ch;"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="재료와 기법(에 대한 관심)" aria-label="재료와 기법(에 대한 관심)" placeholder="정답" style="min-width:18ch;"></li>
+            </ul>
+          </li>
+        </ul>
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="feldman">
+      <h2>펠드만</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <ul class="assessment-list">
+          <li>펠드만의 <input class="fit-answer" data-answer="미술 비평 지도과정" aria-label="미술 비평 지도과정" placeholder="정답"></li>
+          <li>서술 단계 <input class="fit-answer" data-answer="발문" aria-label="발문" placeholder="정답">
+            <ul class="sub-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="첫 느낌이 어떠한가?" aria-label="첫 느낌이 어떠한가?" placeholder="정답" style="min-width:20ch;"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="어떤 것이 보이는가?" aria-label="어떤 것이 보이는가?" placeholder="정답" style="min-width:20ch;"></li>
+            </ul>
+          </li>
+          <li>분석 단계 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+            <ul class="sub-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="형식적 특성" aria-label="형식적 특성" placeholder="정답"></li>
+            </ul>
+          </li>
+          <li>해석 단계 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+            <ul class="sub-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="내용적 특성" aria-label="내용적 특성" placeholder="정답"></li>
+            </ul>
+          </li>
+          <li>평가 단계 <input class="fit-answer" data-answer="발문" aria-label="발문" placeholder="정답">
+            <ul class="sub-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="작품에 대해 어떻게 생각하는가? 왜 그런가?" aria-label="작품에 대해 어떻게 생각하는가? 왜 그런가?" placeholder="정답" style="min-width:30ch;"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="이 작품이 좋은가, 싫은가, 왜 그런가?" aria-label="이 작품이 좋은가, 싫은가, 왜 그런가?" placeholder="정답" style="min-width:30ch;"></li>
+            </ul>
+          </li>
+        </ul>
+      </td></tr></tbody></table></div></div>
+    </section>
+    <section id="lowenfeld-vs-eisner">
+      <h2>로웬펠드 vs 아이스너</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <ul class="assessment-list">
+          <li>로웬펠드 <input class="fit-answer" data-answer="타이틀" aria-label="타이틀" placeholder="정답">
+            <ul class="sub-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="자유로운 자기표현을 통한 창의성 형성" aria-label="자유로운 자기표현을 통한 창의성 형성" placeholder="정답" style="min-width:28ch;"></li>
+            </ul>
+          </li>
+          <li>로웬펠드 <input class="fit-answer" data-answer="비판점" aria-label="비판점" placeholder="정답">
+            <ul class="sub-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="표현만 강조" aria-label="표현만 강조" placeholder="정답"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="과정만 강조" aria-label="과정만 강조" placeholder="정답"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="교사 소극적" aria-label="교사 소극적" placeholder="정답"></li>
+            </ul>
+          </li>
+          <li>아이스너 <input class="fit-answer" data-answer="타이틀" aria-label="타이틀" placeholder="정답">
+            <ul class="sub-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="미술이해교육과 미술감상교육 강화" aria-label="미술이해교육과 미술감상교육 강화" placeholder="정답" style="min-width:28ch;"></li>
+            </ul>
+          </li>
+          <li>아이스너 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+            <ul class="sub-list">
+              <li class="inline-item"><input class="fit-answer" data-answer="교사 적극적" aria-label="교사 적극적" placeholder="정답"></li>
             </ul>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- extend art basic quiz tabs with Feldman and Lowenfeld vs Eisner topics
- add Feldman art criticism process with stage prompts and characteristics
- compare Lowenfeld and Eisner including titles, critiques, and teacher roles

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6e3cf5680832c84df3a58bbf2d761