### PR TITLE
fix: remove Lowenfeld feature blanks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4522,14 +4522,14 @@
       <div class="grade-container"><div><table><tbody><tr><td>
         <ul class="assessment-list">
           <li>로웬펠드의 <input class="fit-answer" data-answer="표현 능력 발달 단계" aria-label="표현 능력 발달 단계" placeholder="정답"></li>
-          <li>난화기 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+          <li>난화기 특징
             <ul class="sub-list">
               <li class="inline-item"><input class="fit-answer" data-answer="무질서한 난화기" aria-label="무질서한 난화기" placeholder="정답"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="조절하는 난화기" aria-label="조절하는 난화기" placeholder="정답"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="명명하는 난화기" aria-label="명명하는 난화기" placeholder="정답"></li>
             </ul>
           </li>
-          <li>전도식기 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+          <li>전도식기 특징
             <ul class="sub-list">
               <li class="inline-item"><input class="fit-answer" data-answer="두족인의 표현" aria-label="두족인의 표현" placeholder="정답"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="자기중심적 표현" aria-label="자기중심적 표현" placeholder="정답"></li>
@@ -4542,7 +4542,7 @@
               <li class="inline-item"><input class="fit-answer" data-answer="사실적 표현" aria-label="사실적 표현" placeholder="정답"></li>
             </ul>
           </li>
-          <li>도식기 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+          <li>도식기 특징
             <ul class="sub-list">
               <li class="inline-item"><input class="fit-answer" data-answer="투영적 표현" aria-label="투영적 표현" placeholder="정답"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="기저선" aria-label="기저선" placeholder="정답"></li>
@@ -4551,7 +4551,7 @@
               <li class="inline-item"><input class="fit-answer" data-answer="중앙원근법적 표현" aria-label="중앙원근법적 표현" placeholder="정답"></li>
             </ul>
           </li>
-          <li>또래집단기 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+          <li>또래집단기 특징
             <ul class="sub-list">
               <li class="inline-item"><input class="fit-answer" data-answer="또래와의 상호작용" aria-label="또래와의 상호작용" placeholder="정답"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="중첩의 표현" aria-label="중첩의 표현" placeholder="정답"></li>
@@ -4562,13 +4562,13 @@
               <li class="inline-item"><input class="fit-answer" data-answer="오감을 통한 관찰" aria-label="오감을 통한 관찰" placeholder="정답"></li>
             </ul>
           </li>
-          <li>의사실기 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+          <li>의사실기 특징
             <ul class="sub-list">
               <li class="inline-item"><input class="fit-answer" data-answer="시각형(객관적, 사실적 표현)" aria-label="시각형(객관적, 사실적 표현)" placeholder="정답" style="min-width:22ch;"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="촉각형(주관적, 감정적 표현)" aria-label="촉각형(주관적, 감정적 표현)" placeholder="정답" style="min-width:22ch;"></li>
             </ul>
           </li>
-          <li>결정기 <input class="fit-answer" data-answer="특징" aria-label="특징" placeholder="정답">
+          <li>결정기 특징
             <ul class="sub-list">
               <li class="inline-item"><input class="fit-answer" data-answer="중간형(시각형과 촉각형 복합적)" aria-label="중간형(시각형과 촉각형 복합적)" placeholder="정답" style="min-width:22ch;"></li>
             </ul>


### PR DESCRIPTION
## Summary
- show '특징' labels for each Lowenfeld stage instead of blank inputs

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6e48e2790832c853ae914a69ef2a6