### PR TITLE
fix: correct art topic typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4510,7 +4510,7 @@
             <ul class="sub-list">
               <li class="inline-item"><input class="fit-answer" data-answer="마음열기" aria-label="마음열기" placeholder="정답"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="자세히 보기" aria-label="자세히 보기" placeholder="정답"></li>
-              <li class="inline-item"><input class="fit-answer" data-answer="작가의 마음해아리기" aria-label="작가의 마음해아리기" placeholder="정답"></li>
+              <li class="inline-item"><input class="fit-answer" data-answer="작가의 마음 헤아리기" aria-label="작가의 마음 헤아리기" placeholder="정답"></li>
               <li class="inline-item"><input class="fit-answer" data-answer="생각하고 판단하기" aria-label="생각하고 판단하기" placeholder="정답"></li>
             </ul>
           </li>


### PR DESCRIPTION
## Summary
- fix typo in art topic phrase "작가의 마음 해아리기" -> "작가의 마음 헤아리기"

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6e4f4f158832ca1aa79880545f8ca