### PR TITLE
Remove extraneous moral sections from competency topic

### DIFF
--- a/index.html
+++ b/index.html
@@ -12227,58 +12227,6 @@
 
         </div>
 
-        <div class="moral-block">
-
-          <h3>교수⋅학습 방법</h3>
-
-          <div class="grade-container">
-
-            <div>
-
-              <p><input data-answer="역할교환" aria-label="역할교환" placeholder="빈칸">, <input data-answer="관점 채택" aria-label="관점 채택" placeholder="빈칸"> 등을 통해 서로의 생각과 감정을 이해하고 공감하며 민주적으로 소통하는 허용적인 학습 분위기를 조성하여 학생들이 교수⋅학습 과정에 자기주도적으로 참여할 수 있도록 한다.</p>
-
-              
-
-              <p>초등학교 도덕과 교수⋅학습은 <input data-answer="학생의 발달 수준" aria-label="학생의 발달 수준" placeholder="빈칸">에 맞게 도덕적 행위의 실천을 위한 가치나 태도를 강화하는 방향으로 나아가야 하며, 이를 위해 3~4학년군은 적절한 <input data-answer="강화기제" aria-label="강화기제" placeholder="빈칸"> 활용을 통한 도덕적 가치⋅규범의 <input data-answer="모방" aria-label="모방" placeholder="빈칸"> 및 <input data-answer="수용" aria-label="수용" placeholder="빈칸">에, 5~6학년군은 도덕적 가치⋅규범의 <input data-answer="자율적" aria-label="자율적" placeholder="빈칸">이고 <input data-answer="합리적" aria-label="합리적" placeholder="빈칸">인 <input data-answer="이해" aria-label="이해" placeholder="빈칸">에 역점을 둔다. 아울러, 과정⋅기능에 기반한 도덕과 교수⋅학습 방법에서 3~4학년군은 <input data-answer="단일한" aria-label="단일한" placeholder="빈칸"> 과정⋅기능에, 5~6학년군은 <input data-answer="복합적인" aria-label="복합적인" placeholder="빈칸"> 과정⋅기능에 역점을 두어 지도한다.</p>
-
-            </div>
-
-          </div>
-
-        </div>
-
-        <div class="moral-block">
-
-          <h3>평가의 방향</h3>
-
-          <div class="grade-container">
-
-            <div>
-
-              <p>일상에서 직면하는 도덕 문제를 해결할 수 있는 <input data-answer="도덕적 문제 해결 능력" aria-label="도덕적 문제 해결 능력" placeholder="빈칸">을 평가한다. 이를 위해 도덕 판단의 기준과 이유를 찾는 <input data-answer="비판적 사고" aria-label="비판적 사고" placeholder="빈칸">, 다양한 도덕적 대안들을 찾는 <input data-answer="창의적 사고" aria-label="창의적 사고" placeholder="빈칸">, 타인의 감정과 필요에 주의를 기울이는 <input data-answer="배려적 사고" aria-label="배려적 사고" placeholder="빈칸">, 공동체를 존중하며 타인과 협력할 수 있는 <input data-answer="공동체적 사고" aria-label="공동체적 사고" placeholder="빈칸">, 도덕적 가치와 덕목을 준거로 삶을 윤리적으로 반성하는 <input data-answer="성찰적 사고" aria-label="성찰적 사고" placeholder="빈칸"> 등을 평가한다.</p>
-
-              
-
-              <p>학습의 결과뿐만 아니라 학습의 <input data-answer="과정" aria-label="과정" placeholder="빈칸">을 평가할 수 있는 <input data-answer="수행평가" aria-label="수행평가" placeholder="빈칸"> 방법을 활용한다. 수행평가의 기준은 성취기준 도달 여부를 측정할 수 있는 것이어야 하고, 교사와 교사, 교사와 학생 사이의 소통을 통해 평가기준의 <input data-answer="상호주관성" aria-label="상호주관성" placeholder="빈칸">을 확보하기 위해 노력한다.</p>
-
-              
-
-              <p>교육공동체는 교사의 평가 전문성을 신뢰하고 존중하는 학교 문화를 구축하고, 이를 위한 제도적 차원의 노력을 기울여야 한다. 이를 토대로 교사는 평가 전문성을 바탕으로 학생의 발달 수준과 학교 현장의 다양성, 특수성을 고려하여 질적 평가를 수행함으로써 학생들의 <input data-answer="도덕적 성장" aria-label="도덕적 성장" placeholder="빈칸">을 촉진한다.</p>
-
-              
-
-              <p>평가의 과정 및 결과를 분석하여 교수⋅학습 과정, 평가 방법을 개선하고, 학생의 <input data-answer="도덕적 성장" aria-label="도덕적 성장" placeholder="빈칸">을 위한 맞춤형 피드백을 제공한다.</p>
-
-              
-
-              <p>초등학교 도덕과 평가는 <input data-answer="담임교사" aria-label="담임교사" placeholder="빈칸">가 중심이 되어 범교과 활동이나 바른생활과 등 인접 교과와 연계하여 통합적으로 평가함으로써, 학생의 도덕성 형성 수준을 보다 균형 있고 종합적인 관점에서 확인하고, <input data-answer="도덕적 성장" aria-label="도덕적 성장" placeholder="빈칸">을 자극하고 돕는 방향으로 이루어지도록 한다.</p>
-
-            </div>
-
-          </div>
-
-        </div>
-
       </div>
 
     </section>


### PR DESCRIPTION
## Summary
- Remove stray "교수⋅학습 방법" and "평가의 방향" blocks from the moral section in the competency topic

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad524a0a64832ca3cad89dc1998c03