### PR TITLE
Add math course curriculum

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,7 @@
                 CREATIVE: 'creative',
                 OVERVIEW: 'overview',
                 INTEGRATED_COURSE: 'integrated-course',
+                MATH_COURSE: 'math-course',
                 MORAL_COURSE: 'moral-course',
                 MORAL_PRINCIPLES: 'moral-principles',
                 MUSIC_ELEMENTS: 'music-elements',
@@ -116,6 +117,7 @@
             [CONSTANTS.SUBJECTS.CREATIVE]: '창체',
             [CONSTANTS.SUBJECTS.OVERVIEW]: '총론',
             [CONSTANTS.SUBJECTS.INTEGRATED_COURSE]: '통합',
+            [CONSTANTS.SUBJECTS.MATH_COURSE]: '수학',
             [CONSTANTS.SUBJECTS.MORAL_COURSE]: '도덕',
             [CONSTANTS.SUBJECTS.MORAL_PRINCIPLES]: '원리와 방법',
             [CONSTANTS.SUBJECTS.MUSIC_ELEMENTS]: '음악요소',
@@ -1093,6 +1095,7 @@
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.CREATIVE ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.OVERVIEW ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.INTEGRATED_COURSE ||
+                gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_COURSE ||
                                 CONSTANTS.SUBJECTS.MORAL_COURSE ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.MORAL_COURSE ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD ||
@@ -1931,6 +1934,7 @@
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.CREATIVE ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.OVERVIEW ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.INTEGRATED_COURSE ||
+                    gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_COURSE ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.MORAL_COURSE ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.PRACTICAL_STD ||
@@ -1955,6 +1959,7 @@
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.CREATIVE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.OVERVIEW ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.INTEGRATED_COURSE ||
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.MORAL_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.PRACTICAL_STD ||
@@ -2015,6 +2020,7 @@
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.CREATIVE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.OVERVIEW ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.INTEGRATED_COURSE ||
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.MORAL_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.PRACTICAL_STD

--- a/index.html
+++ b/index.html
@@ -1832,6 +1832,130 @@
 
   </main>
 
+  <main id="math-course-quiz-main" class="hidden">
+
+    <div class="tabs">
+      <div class="tab active" data-target="math-intro">앞교</div>
+      <div class="tab" data-target="math-core-idea">핵심아이디어</div>
+      <div class="tab" data-target="math-teaching-competency">교수⋅학습 방법 - 교과 역량 함양</div>
+      <div class="tab" data-target="math-teaching-method">교수⋅학습 방법 - 교수⋅학습 방안</div>
+      <div class="tab" data-target="math-evaluation-competency">평가 방법 - 교과 역량을 평가</div>
+      <div class="tab" data-target="math-evaluation-method">평가 방법 - 다양한 평가 방안</div>
+    </div>
+
+    <section id="math-intro" class="active">
+      <h2>앞교</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">핵심 아이디어는 수학 학습 과정에서 <input data-answer="전이가가 높은" aria-label="전이가가 높은" placeholder="정답"> 내용을 담은 문장으로 기술하였다.</div>
+          <div class="overview-question">(1) 수학적 지식을 이해하고 활용하여 적극적이고 자신감 있게 여러 가지 <input data-answer="문제" aria-label="문제" placeholder="정답">를 <input data-answer="해결" aria-label="해결" placeholder="정답">한다.</div>
+          <div class="overview-question">(2) 수학적 사실에 대해 흥미와 관심을 갖고 <input data-answer="추측" aria-label="추측" placeholder="정답">과 <input data-answer="정당화" aria-label="정당화" placeholder="정답">를 통해 <input data-answer="추론" aria-label="추론" placeholder="정답">한다.</div>
+          <div class="overview-question">(3) 수학적 사고와 전략에 대해 <input data-answer="의사소통" aria-label="의사소통" placeholder="정답">하고 <input data-answer="수학적 표현" aria-label="수학적 표현" placeholder="정답">의 <input data-answer="편리함" aria-label="편리함" placeholder="정답">을 인식한다.</div>
+          <div class="overview-question">(4) 수학의 개념, 원리, 법칙 간의 <input data-answer="관련성" aria-label="관련성" placeholder="정답">을 탐구하고 <input data-answer="실생활" aria-label="실생활" placeholder="정답">이나 <input data-answer="타 교과" aria-label="타 교과" placeholder="정답">에 수학을 적용하여 수학의 <input data-answer="유용성" aria-label="유용성" placeholder="정답">을 인식한다.</div>
+          <div class="overview-question">(5) 목적에 맞게 <input data-answer="교구" aria-label="교구" placeholder="정답">나 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 활용하며 자료를 수집하고 처리하여 정보에 근거한 합리적 의사 결정을 한다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="math-core-idea">
+      <h2>핵심아이디어</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">(1) 수와 연산</div>
+          <div class="overview-question">⋅<input data-answer="사물의 양" aria-label="사물의 양" placeholder="정답">은 <input data-answer="자연수" aria-label="자연수" placeholder="정답">, <input data-answer="분수" aria-label="분수" placeholder="정답">, <input data-answer="소수" aria-label="소수" placeholder="정답"> 등으로 표현되며, <input data-answer="수" aria-label="수" placeholder="정답">는 <input data-answer="자연수" aria-label="자연수" placeholder="정답">에서 <input data-answer="정수" aria-label="정수" placeholder="정답">, <input data-answer="유리수" aria-label="유리수" placeholder="정답">, 실수로 확장된다.</div>
+          <div class="overview-question">⋅<input data-answer="사칙계산" aria-label="사칙계산" placeholder="정답">은 <input data-answer="자연수" aria-label="자연수" placeholder="정답">에 대해 정의되며 <input data-answer="정수" aria-label="정수" placeholder="정답">, <input data-answer="유리수" aria-label="유리수" placeholder="정답">, 실수의 사칙계산으로 확장되고 이때 <input data-answer="연산의 성질" aria-label="연산의 성질" placeholder="정답">이 일관되게 성립한다.</div>
+          <div class="overview-question">⋅<input data-answer="수" aria-label="수" placeholder="정답">와 <input data-answer="사칙계산" aria-label="사칙계산" placeholder="정답">은 수학 학습의 기본이 되며, 실생활 문제를 포함한 다양한 문제를 해결하는 데 유용하게 활용된다.</div>
+          <div class="overview-question">(2) 변화와 관계</div>
+          <div class="overview-question">⋅변화하는 현상에 반복적인 요소로 들어있는 <input data-answer="규칙" aria-label="규칙" placeholder="정답">은 <input data-answer="수" aria-label="수" placeholder="정답">나 <input data-answer="식" aria-label="식" placeholder="정답">으로 표현될 수 있으며, <input data-answer="규칙" aria-label="규칙" placeholder="정답">을 탐구하는 것은 수학적으로 추측하고 일반화하는 데 기반이 된다.</div>
+          <div class="overview-question">⋅<input data-answer="동치" aria-label="동치" placeholder="정답"> 관계, <input data-answer="대응" aria-label="대응" placeholder="정답"> 관계, <input data-answer="비례" aria-label="비례" placeholder="정답"> 관계 등은 여러 현상에 들어있는 대상들 사이의 다양한 관계를 기술하고 복잡한 문제를 해결하는 데 유용하게 활용된다.</div>
+          <div class="overview-question">⋅수와 그 계산은 문자와 식을 사용하여 일반화되며, 특정한 관계를 만족시키는 미지의 값은 방정식과 부등식을 해결하는 적절한 절차를 거쳐 구해진다.</div>
+          <div class="overview-question">⋅<input data-answer="한 양" aria-label="한 양" placeholder="정답">이 변함에 따라 <input data-answer="다른 양" aria-label="다른 양" placeholder="정답">이 하나씩 정해지는 두 양 사이의 <input data-answer="대응" aria-label="대응" placeholder="정답"> 관계를 나타내는 함수와 그 그래프는 변화하는 현상 속의 다양한 관계를 수학적으로 표현한다.</div>
+          <div class="overview-question">(3) 도형과 측정</div>
+          <div class="overview-question">⋅평면도형과 입체도형은 여러 가지 <input data-answer="모양" aria-label="모양" placeholder="정답">을 <input data-answer="범주화" aria-label="범주화" placeholder="정답">한 것이며, 각각의 평면도형과 입체도형은 고유한 <input data-answer="성질" aria-label="성질" placeholder="정답">을 갖는다.</div>
+          <div class="overview-question">⋅도형의 성질과 관계를 탐구하고 정당화하는 것은 논리적이고 비판적으로 사고하는 데 기반이 된다.</div>
+          <div class="overview-question">⋅측정은 여러 가지 속성의 양을 <input data-answer="비교" aria-label="비교" placeholder="정답">하고 속성에 따른 <input data-answer="단위" aria-label="단위" placeholder="정답">를 이용하여 양을 <input data-answer="수치화" aria-label="수치화" placeholder="정답">함으로써 여러 가지 현상을 해석하거나 실생활 문제를 해결하는 데 활용된다.</div>
+          <div class="overview-question">(4) 자료와 가능성</div>
+          <div class="overview-question">⋅자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">, <input data-answer="정리" aria-label="정리" placeholder="정답">, <input data-answer="해석" aria-label="해석" placeholder="정답">하는 <input data-answer="통계" aria-label="통계" placeholder="정답">는 자료의 특징을 파악하고 두 집단을 비교하며 자료의 관계를 탐구하는 데 활용된다.</div>
+          <div class="overview-question">⋅사건이 일어날 <input data-answer="가능성" aria-label="가능성" placeholder="정답">을 여러 가지 방법으로 표현하는 것은 불확실성을 이해하는 데 도움이 되며, 가능성을 확률로 수치화하면 불확실성을 수학적으로 다룰 수 있게 된다.</div>
+          <div class="overview-question">⋅자료를 이용하여 통계적 문제해결 과정을 실천하고 생활 속의 가능성을 탐구하는 것은 미래를 예측하고 합리적인 의사 결정을 하는 데 기반이 된다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="math-teaching-competency">
+      <h2>교수⋅학습 방법 - 교과 역량 함양</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">① 다음과 같은 교수⋅학습 방법을 통해 문제해결 역량을 함양하게 한다.</div>
+          <div class="overview-question">㉠ 수학의 개념, 원리, 법칙을 이용하여 해결 가능한 문제를 학생에게 제시한다. 이때 <input data-answer="다양한 방법" aria-label="다양한 방법" placeholder="정답">으로 해결 가능한 문제, <input data-answer="여러 가지 해답" aria-label="여러 가지 해답" placeholder="정답">이 나올 수 있는 문제 등을 활용할 수 있다.</div>
+          <div class="overview-question">㉡ 문제에 주어진 조건과 정보를 분석하고 적절한 문제해결 계획을 수립하고 실행하며 문제해결 과정을 반성하도록 구체적인 <input data-answer="발문" aria-label="발문" placeholder="정답">과 <input data-answer="권고" aria-label="권고" placeholder="정답">를 제시한다.</div>
+          <div class="overview-question">㉢ 문제해결 과정 및 결과의 의미를 재해석하여 주어진 문제를 <input data-answer="변형" aria-label="변형" placeholder="정답">하거나 <input data-answer="새로운" aria-label="새로운" placeholder="정답"> 문제를 만들어 해결하게 한다.</div>
+          <div class="overview-question">㉣ 성공적인 문제해결 경험을 바탕으로 적극적이고 자신감 있게 문제해결에 참여하게 하고, 단번에 답이 나오지 않는 문제라도 끈기 있게 도전하여 성취감을 느끼게 한다.</div>
+          <div class="overview-question">② 다음과 같은 교수⋅학습 방법을 통해 추론 역량을 함양하게 한다.</div>
+          <div class="overview-question">㉠ 관찰, 실험, 측정 등 구체적 조작 활동을 통해 수학의 개념, 원리, 법칙에 흥미와 관심을 갖고 다양한 방법으로 탐구하고 이해하게 한다.</div>
+          <div class="overview-question">㉡ <input data-answer="귀납" aria-label="귀납" placeholder="정답">, <input data-answer="유추" aria-label="유추" placeholder="정답"> 등의 <input data-answer="개연적" aria-label="개연적" placeholder="정답"> 추론을 통해 수학적 추측을 제기하고 정당화하며, 수학적 증거와 논리적 근거를 바탕으로 비판적으로 사고하는 태도를 갖게 한다.</div>
+          <div class="overview-question">㉢ 수학의 개념, 원리, 법칙을 도출하는 과정과 수학적 절차를 <input data-answer="논리적" aria-label="논리적" placeholder="정답">이고 체계적으로 수행하고 반성하게 한다.</div>
+          <div class="overview-question">③ 다음과 같은 교수⋅학습 방법을 통해 의사소통 역량을 함양하게 한다.</div>
+          <div class="overview-question">㉠ 수학 용어, 기호, 표, 그래프 등의 <input data-answer="수학적 표현" aria-label="수학적 표현" placeholder="정답">을 <input data-answer="정확" aria-label="정확" placeholder="정답">하게 사용하고 표현끼리 변환하게 한다.</div>
+          <div class="overview-question">㉡ 학생이 자신의 사고와 전략을 수학적 표현으로 나타내고 설명하면서 수학적 표현의 편리함을 인식하게 한다.</div>
+          <div class="overview-question">㉢ 학생 간 상호 작용과 질문이 활발한 교실 문화를 조성하고 수학적으로 의미 있는 의사소통이 이루어지도록 적절한 과제를 제시하고 안내한다.</div>
+          <div class="overview-question">㉣ 수학적 아이디어에 대해 상호 작용하는 과정에서 타인을 <input data-answer="배려" aria-label="배려" placeholder="정답">하고 의견을 <input data-answer="존중" aria-label="존중" placeholder="정답">하는 태도를 기르게 한다.</div>
+          <div class="overview-question">④ 다음과 같은 교수⋅학습 방법을 통해 연결 역량을 함양하게 한다.</div>
+          <div class="overview-question">㉠ 영역이나 학년 내용 간에 관련된 수학의 개념, 원리, 법칙 등을 유기적으로 <input data-answer="연계" aria-label="연계" placeholder="정답">하여 <input data-answer="새로운" aria-label="새로운" placeholder="정답"> 지식을 생성하면서 <input data-answer="창의성" aria-label="창의성" placeholder="정답">을 기르게 한다.</div>
+          <div class="overview-question">㉡ 수학과 <input data-answer="실생활" aria-label="실생활" placeholder="정답">, 사회 및 자연 현상, <input data-answer="타 교과" aria-label="타 교과" placeholder="정답">의 내용을 연계하는 과제를 활용하여 수학의 유용성을 인식하게 한다.</div>
+          <div class="overview-question">⑤ 다음과 같은 교수⋅학습 방법을 통해 정보처리 역량을 함양하게 한다.</div>
+          <div class="overview-question">㉠ 실생활 및 수학적 문제 상황에서 자료를 탐색하고 수집하며 수학적으로 처리하여 합리적인 의사 결정을 하는 태도를 기르게 한다.</div>
+          <div class="overview-question">㉡ <input data-answer="교구" aria-label="교구" placeholder="정답">나 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 활용하여 추상적인 수학 내용을 시각화하고 수학의 개념, 원리, 법칙에 대한 직관적 이해와 논리적 사고를 돕는다.</div>
+          <div class="overview-question">㉢ 학생이 주도적으로 <input data-answer="교구" aria-label="교구" placeholder="정답">나 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 활용하여 탐구하게 한다.</div>
+          <div class="overview-question">㉣ <input data-answer="계산 기능 함양" aria-label="계산 기능 함양" placeholder="정답">을 목표로 하지 않는 교수⋅학습 상황에서는 <input data-answer="복잡한" aria-label="복잡한" placeholder="정답"> 계산을 할 때 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 이용할 수 있게 한다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="math-teaching-method">
+      <h2>교수⋅학습 방법 - 교수⋅학습 방안</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">① <input data-answer="설명식 교수" aria-label="설명식 교수" placeholder="정답">는 교사가 설명과 시연을 통해 수업을 주도하는 교수⋅학습 방안으로, 수업 내용을 구조화하여 체계적으로 지도하는 데 효과적이다. 이때, 교사는 학생의 적극적인 수업 참여를 유도하고, 사고를 촉진하는 발문을 적절히 활용한다.</div>
+          <div class="overview-question">② <input data-answer="토의⋅토론 학습" aria-label="토의⋅토론 학습" placeholder="정답">은 특정 주제에 대해 협의하거나 논의하는 교수⋅학습 방안으로, 학생들이 수학 내용을 폭넓게 이해하고 자신의 주장을 효과적으로 표현하고 다른 사람의 의견을 비판적 사고를 통해 수용하여 합리적으로 의사 결정하는 태도를 기를 수 있게 한다.</div>
+          <div class="overview-question">③ <input data-answer="협력 학습" aria-label="협력 학습" placeholder="정답">은 모둠 내의 상호 작용, 의사소통, 참여를 통해 공동의 학습 목표에 도달하도록 하는 교수⋅학습 방안으로, 다른 사람을 존중하고 배려하며 모둠 내의 역할을 수행하고 책임감을 기를 수 있게 한다.</div>
+          <div class="overview-question">④ <input data-answer="탐구 학습" aria-label="탐구 학습" placeholder="정답">은 학생이 중심이 되어 수학의 개념, 원리, 법칙을 발견하고 구성하는 교수⋅학습 방안으로, 학생 스스로 자료와 정보로부터 지식을 도출하거나 지식의 타당성을 확인하는 것이 중요함을 알게 할 수 있다.</div>
+          <div class="overview-question">⑤ <input data-answer="프로젝트 학습" aria-label="프로젝트 학습" placeholder="정답">은 학생 스스로 특정 주제나 과제를 탐구하고 해결하기 위해 계획을 수립하고 수행하여 결과물을 산출하고 공유하는 교수⋅학습 방안으로, 자기주도적으로 수학 지식과 경험을 통합하게 할 수 있다.</div>
+          <div class="overview-question">⑥ <input data-answer="수학적 모델링" aria-label="수학적 모델링" placeholder="정답">은 학생의 삶과 연계된 현상을 다양한 수학적 표현 방식을 이용하여 수학적 모델로 만들고 수학적 모델을 다시 실생활이나 사회 및 자연 현상에 적용하는 교수⋅학습 방안으로, 수학의 응용에 대한 넓은 안목을 갖게 할 수 있다.</div>
+          <div class="overview-question">⑦ <input data-answer="놀이 및 게임 학습" aria-label="놀이 및 게임 학습" placeholder="정답">은 호기심과 흥미를 유발하는 놀이 및 게임 활동을 활용하는 교수⋅학습 방안으로, 활동 속에서 수학 개념이나 원리를 탐구하고 동료와 경쟁 또는 협력하면서 자연스럽게 수학에 접근하고 수학 학습에 대한 자신감 및 의사소통 역량을 기르게 할 수 있다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="math-evaluation-competency">
+      <h2>평가 방법 - 교과 역량을 평가</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">① 문제해결 역량의 평가는 수학의 개념, 원리, 법칙을 문제 상황에 적절히 활용하는지, 주어진 조건과 정보를 분석하고 적절한 해결 전략을 탐색하여 해결하는지, 문제해결 과정을 돌아보며 절차에 따라 타당하게 결과를 얻어내고 이를 <input data-answer="반성" aria-label="반성" placeholder="정답">하는지, 적극적이고 자신감 있게 문제해결에 참여하는지, 적절한 방법을 찾기 위해 끈기 있게 도전하는지 등을 고려한다.</div>
+          <div class="overview-question">② 추론 역량의 평가는 수학의 개념, 원리, 법칙을 이해하는지, 논리적으로 절차를 수행하는지, 수학적 지식을 다양한 방법으로 탐구하는지, <input data-answer="관찰" aria-label="관찰" placeholder="정답">에 근거하여 <input data-answer="추측" aria-label="추측" placeholder="정답">하고 <input data-answer="일반화" aria-label="일반화" placeholder="정답">를 할 수 있는지, 추측의 근거를 제시하는지, 타당한 정당화를 하는지, 수학에 대한 흥미와 관심을 갖는지, 체계적으로 사고하려는 성향이 있는지, 수학적 증거와 논리적 근거를 바탕으로 비판적으로 사고하는 태도를 갖는지 등을 고려한다.</div>
+          <div class="overview-question">③ 의사소통 역량의 평가는 수학 용어, 기호, 표, 그래프 등 <input data-answer="수학적 표현" aria-label="수학적 표현" placeholder="정답">을 이해하고 <input data-answer="정확" aria-label="정확" placeholder="정답">하게 사용하는지, 적절한 수학적 표현을 선택할 수 있는지, 수학적 표현 간에 변환을 할 수 있는지, 수학적 아이디어나 수학 학습 과정 및 결과에 대해 표현하고 다른 사람의 견해를 이해하는지, 수학적 표현의 편리함을 인식하는지, 타인을 배려하고 의견을 존중하는지 등을 고려한다.</div>
+          <div class="overview-question">④ 연결 역량의 평가는 영역이나 학년 내용 사이에서 개념, 원리, 법칙을 적절하게 관련지어 이해하는지, 수학의 개념, 원리, 법칙을 <input data-answer="연계" aria-label="연계" placeholder="정답">하여 <input data-answer="새로운" aria-label="새로운" placeholder="정답"> 지식을 생성할 수 있는지, 수학을 <input data-answer="실생활" aria-label="실생활" placeholder="정답">이나 <input data-answer="타 교과" aria-label="타 교과" placeholder="정답">의 지식, 기능, 경험에 <input data-answer="적용" aria-label="적용" placeholder="정답">할 수 있는지, 실생활이나 타 교과의 지식, 기능, 경험을 수학적으로 해석할 수 있는지, 수학을 바탕으로 창의적으로 관련성을 찾을 수 있는지, 수학의 유용성을 인식하는지 등을 고려한다.</div>
+          <div class="overview-question">⑤ 정보처리 역량의 평가는 자료와 정보를 목적에 맞게 수집하고 변환하고 정리하는지, 자료를 바탕으로 도출한 결론이 적절한지, <input data-answer="교구" aria-label="교구" placeholder="정답">나 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 적절하게 활용하는지, 수학적 근거를 바탕으로 합리적으로 의사 결정하는 태도를 갖는지 등을 고려한다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="math-evaluation-method">
+      <h2>평가 방법 - 다양한 평가 방안</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">① <input data-answer="지필평가" aria-label="지필평가" placeholder="정답">는 수학 내용 체계의 지식⋅이해, 과정⋅기능을 평가하는 데 활용할 수 있고, 선택형, 단답형, 서⋅논술형 등의 다양한 문항 유형을 사용할 수 있다.</div>
+          <div class="overview-question">② <input data-answer="프로젝트 평가" aria-label="프로젝트 평가" placeholder="정답">는 학생 스스로 특정 주제나 과제를 탐구하고 해결하기 위해 계획을 수립하고 수행하는 과정과 그 결과물을 평가하는 방안으로, 수학 내용 체계의 세 범주를 종합적으로 평가할 때 활용할 수 있다.</div>
+          <div class="overview-question">③ <input data-answer="포트폴리오 평가" aria-label="포트폴리오 평가" placeholder="정답">는 학생의 성장에 대한 정보를 얻기 위해 수학 학습 수행과 그 결과물을 일정 기간 수집하여 평가하는 방안으로, 수학 교과 역량의 발달을 종합적으로 평가할 때 활용할 수 있다.</div>
+          <div class="overview-question">④ <input data-answer="관찰 평가" aria-label="관찰 평가" placeholder="정답">, <input data-answer="면담 평가" aria-label="면담 평가" placeholder="정답">, <input data-answer="구술 평가" aria-label="구술 평가" placeholder="정답">는 학생 개인 및 소집단을 <input data-answer="관찰" aria-label="관찰" placeholder="정답">, 학생과의 <input data-answer="질의응답" aria-label="질의응답" placeholder="정답">, 학생의 <input data-answer="발표" aria-label="발표" placeholder="정답">를 통해 평가하는 방안으로, 학생의 사고 방법, 수행 과정, 수학 내용 체계의 가치⋅태도 등을 평가할 때 활용할 수 있다.</div>
+          <div class="overview-question">⑤ <input data-answer="자기 평가" aria-label="자기 평가" placeholder="정답">는 학생 스스로 자신의 학습 과정과 결과를 평가하는 방안으로, 수학 내용의 이해와 수행 과정, 문제해결과 추론 과정의 반성, 자신의 생각 표현, 수학 내용 체계의 가치⋅태도 등을 평가할 때 활용할 수 있다.</div>
+          <div class="overview-question">⑥ <input data-answer="동료 평가" aria-label="동료 평가" placeholder="정답">는 동료 학생들이 상대방을 서로 평가하는 방안으로, 협력 학습 상황에서 학생 개개인의 역할 수행이나 집단 활동의 기여를 평가할 때 활용할 수 있다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+  </main>
+
   <main id="moral-principles-quiz-main" class="hidden">
 
     <div class="tabs">
@@ -12566,6 +12690,8 @@
                 <button class="btn subject-btn" data-subject="integrated-course" data-topic="course">통합</button>
 
                 <button class="btn subject-btn" data-subject="moral-course" data-topic="course">도덕</button>
+
+                <button class="btn subject-btn" data-subject="math-course" data-topic="course">수학</button>
 
                 <button class="btn subject-btn" data-subject="moral-principles" data-topic="moral">도덕과 학습 지도 원리와 방법</button>
 


### PR DESCRIPTION
## Summary
- Add new math course quiz sections with tabs for core ideas, teaching strategies, and assessment guidance.
- Register `math-course` subject so interface and width adjustments handle it.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5212cac8832ca83a21eb26461e5d