### PR TITLE
Reduce blank width for social course answers

### DIFF
--- a/app.js
+++ b/app.js
@@ -191,13 +191,15 @@
             });
         }
 
-        function initAutoWidthPractical() {
-            const practicalMain = document.getElementById('practical-quiz-main');
-            applyAutoWidthForContainer(practicalMain);
+        function initAutoWidthCourse() {
+            ['practical-quiz-main', 'overview-quiz-main', 'social-course-quiz-main'].forEach(id => {
+                const container = document.getElementById(id);
+                applyAutoWidthForContainer(container);
+            });
         }
 
         // Defer until rendering is settled
-        requestAnimationFrame(() => { initAutoWidthPractical(); });
+        requestAnimationFrame(() => { initAutoWidthCourse(); });
 
         // --- GAME STATE ---
         const gameState = {

--- a/styles.css
+++ b/styles.css
@@ -2089,6 +2089,10 @@ td input.activity-input:not(:first-child) {
   transition: all 0.2s ease; /* 부드러운 전환 효과 */
 }
 
+#social-course-quiz-main .overview-question input {
+  min-width: 5ch;
+}
+
 /* 실과 모형: 인라인 빈칸과 카드 크기 축소 (총론 대비) */
 #practical-quiz-main .overview-question {
   padding: 1.6rem; /* 카드 패딩 축소 */


### PR DESCRIPTION
## Summary
- Ensure auto-width calculation runs for overview and social course sections
- Shrink minimum width of blanks in social course to better match answers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5c035898832c96e52a97b89a0af1