### PR TITLE
feat: highlight math competency blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1971,20 +1971,20 @@
       <h2>핵심아이디어</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
-          <div class="overview-question">(1) 수와 연산</div>
+          <div class="overview-question standard-emphasis">(1) 수와 연산</div>
           <div class="overview-question">⋅<input data-answer="사물의 양" aria-label="사물의 양" placeholder="정답">은 <input data-answer="자연수" aria-label="자연수" placeholder="정답">, <input data-answer="분수" aria-label="분수" placeholder="정답">, <input data-answer="소수" aria-label="소수" placeholder="정답"> 등으로 표현되며, <input data-answer="수" aria-label="수" placeholder="정답">는 <input data-answer="자연수" aria-label="자연수" placeholder="정답">에서 <input data-answer="정수" aria-label="정수" placeholder="정답">, <input data-answer="유리수" aria-label="유리수" placeholder="정답">, 실수로 확장된다.</div>
           <div class="overview-question">⋅<input data-answer="사칙계산" aria-label="사칙계산" placeholder="정답">은 <input data-answer="자연수" aria-label="자연수" placeholder="정답">에 대해 정의되며 <input data-answer="정수" aria-label="정수" placeholder="정답">, <input data-answer="유리수" aria-label="유리수" placeholder="정답">, 실수의 사칙계산으로 확장되고 이때 <input data-answer="연산의 성질" aria-label="연산의 성질" placeholder="정답">이 일관되게 성립한다.</div>
           <div class="overview-question">⋅<input data-answer="수" aria-label="수" placeholder="정답">와 <input data-answer="사칙계산" aria-label="사칙계산" placeholder="정답">은 수학 학습의 기본이 되며, 실생활 문제를 포함한 다양한 문제를 해결하는 데 유용하게 활용된다.</div>
-          <div class="overview-question">(2) 변화와 관계</div>
+          <div class="overview-question standard-emphasis">(2) 변화와 관계</div>
           <div class="overview-question">⋅변화하는 현상에 반복적인 요소로 들어있는 <input data-answer="규칙" aria-label="규칙" placeholder="정답">은 <input data-answer="수" aria-label="수" placeholder="정답">나 <input data-answer="식" aria-label="식" placeholder="정답">으로 표현될 수 있으며, <input data-answer="규칙" aria-label="규칙" placeholder="정답">을 탐구하는 것은 수학적으로 추측하고 일반화하는 데 기반이 된다.</div>
           <div class="overview-question">⋅<input data-answer="동치" aria-label="동치" placeholder="정답"> 관계, <input data-answer="대응" aria-label="대응" placeholder="정답"> 관계, <input data-answer="비례" aria-label="비례" placeholder="정답"> 관계 등은 여러 현상에 들어있는 대상들 사이의 다양한 관계를 기술하고 복잡한 문제를 해결하는 데 유용하게 활용된다.</div>
           <div class="overview-question">⋅수와 그 계산은 문자와 식을 사용하여 일반화되며, 특정한 관계를 만족시키는 미지의 값은 방정식과 부등식을 해결하는 적절한 절차를 거쳐 구해진다.</div>
           <div class="overview-question">⋅<input data-answer="한 양" aria-label="한 양" placeholder="정답">이 변함에 따라 <input data-answer="다른 양" aria-label="다른 양" placeholder="정답">이 하나씩 정해지는 두 양 사이의 <input data-answer="대응" aria-label="대응" placeholder="정답"> 관계를 나타내는 함수와 그 그래프는 변화하는 현상 속의 다양한 관계를 수학적으로 표현한다.</div>
-          <div class="overview-question">(3) 도형과 측정</div>
+          <div class="overview-question standard-emphasis">(3) 도형과 측정</div>
           <div class="overview-question">⋅평면도형과 입체도형은 여러 가지 <input data-answer="모양" aria-label="모양" placeholder="정답">을 <input data-answer="범주화" aria-label="범주화" placeholder="정답">한 것이며, 각각의 평면도형과 입체도형은 고유한 <input data-answer="성질" aria-label="성질" placeholder="정답">을 갖는다.</div>
           <div class="overview-question">⋅도형의 성질과 관계를 탐구하고 정당화하는 것은 논리적이고 비판적으로 사고하는 데 기반이 된다.</div>
           <div class="overview-question">⋅측정은 여러 가지 속성의 양을 <input data-answer="비교" aria-label="비교" placeholder="정답">하고 속성에 따른 <input data-answer="단위" aria-label="단위" placeholder="정답">를 이용하여 양을 <input data-answer="수치화" aria-label="수치화" placeholder="정답">함으로써 여러 가지 현상을 해석하거나 실생활 문제를 해결하는 데 활용된다.</div>
-          <div class="overview-question">(4) 자료와 가능성</div>
+          <div class="overview-question standard-emphasis">(4) 자료와 가능성</div>
           <div class="overview-question">⋅자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">, <input data-answer="정리" aria-label="정리" placeholder="정답">, <input data-answer="해석" aria-label="해석" placeholder="정답">하는 <input data-answer="통계" aria-label="통계" placeholder="정답">는 자료의 특징을 파악하고 두 집단을 비교하며 자료의 관계를 탐구하는 데 활용된다.</div>
           <div class="overview-question">⋅사건이 일어날 <input data-answer="가능성" aria-label="가능성" placeholder="정답">을 여러 가지 방법으로 표현하는 것은 불확실성을 이해하는 데 도움이 되며, 가능성을 확률로 수치화하면 불확실성을 수학적으로 다룰 수 있게 된다.</div>
           <div class="overview-question">⋅자료를 이용하여 통계적 문제해결 과정을 실천하고 생활 속의 가능성을 탐구하는 것은 미래를 예측하고 합리적인 의사 결정을 하는 데 기반이 된다.</div>
@@ -1996,24 +1996,24 @@
       <h2>교수⋅학습 방법 - 교과 역량 함양</h2>
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
-          <div class="overview-question">① 다음과 같은 교수⋅학습 방법을 통해 문제해결 역량을 함양하게 한다.</div>
+          <div class="overview-question standard-emphasis">① 다음과 같은 교수⋅학습 방법을 통해 문제해결 역량을 함양하게 한다.</div>
           <div class="overview-question">㉠ 수학의 개념, 원리, 법칙을 이용하여 해결 가능한 문제를 학생에게 제시한다. 이때 <input data-answer="다양한 방법" aria-label="다양한 방법" placeholder="정답">으로 해결 가능한 문제, <input data-answer="여러 가지 해답" aria-label="여러 가지 해답" placeholder="정답">이 나올 수 있는 문제 등을 활용할 수 있다.</div>
           <div class="overview-question">㉡ 문제에 주어진 조건과 정보를 분석하고 적절한 문제해결 계획을 수립하고 실행하며 문제해결 과정을 반성하도록 구체적인 <input data-answer="발문" aria-label="발문" placeholder="정답">과 <input data-answer="권고" aria-label="권고" placeholder="정답">를 제시한다.</div>
           <div class="overview-question">㉢ 문제해결 과정 및 결과의 의미를 재해석하여 주어진 문제를 <input data-answer="변형" aria-label="변형" placeholder="정답">하거나 <input data-answer="새로운" aria-label="새로운" placeholder="정답"> 문제를 만들어 해결하게 한다.</div>
           <div class="overview-question">㉣ 성공적인 문제해결 경험을 바탕으로 적극적이고 자신감 있게 문제해결에 참여하게 하고, 단번에 답이 나오지 않는 문제라도 끈기 있게 도전하여 성취감을 느끼게 한다.</div>
-          <div class="overview-question">② 다음과 같은 교수⋅학습 방법을 통해 추론 역량을 함양하게 한다.</div>
+          <div class="overview-question standard-emphasis">② 다음과 같은 교수⋅학습 방법을 통해 추론 역량을 함양하게 한다.</div>
           <div class="overview-question">㉠ 관찰, 실험, 측정 등 구체적 조작 활동을 통해 수학의 개념, 원리, 법칙에 흥미와 관심을 갖고 다양한 방법으로 탐구하고 이해하게 한다.</div>
           <div class="overview-question">㉡ <input data-answer="귀납" aria-label="귀납" placeholder="정답">, <input data-answer="유추" aria-label="유추" placeholder="정답"> 등의 <input data-answer="개연적" aria-label="개연적" placeholder="정답"> 추론을 통해 수학적 추측을 제기하고 정당화하며, 수학적 증거와 논리적 근거를 바탕으로 비판적으로 사고하는 태도를 갖게 한다.</div>
           <div class="overview-question">㉢ 수학의 개념, 원리, 법칙을 도출하는 과정과 수학적 절차를 <input data-answer="논리적" aria-label="논리적" placeholder="정답">이고 체계적으로 수행하고 반성하게 한다.</div>
-          <div class="overview-question">③ 다음과 같은 교수⋅학습 방법을 통해 의사소통 역량을 함양하게 한다.</div>
+          <div class="overview-question standard-emphasis">③ 다음과 같은 교수⋅학습 방법을 통해 의사소통 역량을 함양하게 한다.</div>
           <div class="overview-question">㉠ 수학 용어, 기호, 표, 그래프 등의 <input data-answer="수학적 표현" aria-label="수학적 표현" placeholder="정답">을 <input data-answer="정확" aria-label="정확" placeholder="정답">하게 사용하고 표현끼리 변환하게 한다.</div>
           <div class="overview-question">㉡ 학생이 자신의 사고와 전략을 수학적 표현으로 나타내고 설명하면서 수학적 표현의 편리함을 인식하게 한다.</div>
           <div class="overview-question">㉢ 학생 간 상호 작용과 질문이 활발한 교실 문화를 조성하고 수학적으로 의미 있는 의사소통이 이루어지도록 적절한 과제를 제시하고 안내한다.</div>
           <div class="overview-question">㉣ 수학적 아이디어에 대해 상호 작용하는 과정에서 타인을 <input data-answer="배려" aria-label="배려" placeholder="정답">하고 의견을 <input data-answer="존중" aria-label="존중" placeholder="정답">하는 태도를 기르게 한다.</div>
-          <div class="overview-question">④ 다음과 같은 교수⋅학습 방법을 통해 연결 역량을 함양하게 한다.</div>
+          <div class="overview-question standard-emphasis">④ 다음과 같은 교수⋅학습 방법을 통해 연결 역량을 함양하게 한다.</div>
           <div class="overview-question">㉠ 영역이나 학년 내용 간에 관련된 수학의 개념, 원리, 법칙 등을 유기적으로 <input data-answer="연계" aria-label="연계" placeholder="정답">하여 <input data-answer="새로운" aria-label="새로운" placeholder="정답"> 지식을 생성하면서 <input data-answer="창의성" aria-label="창의성" placeholder="정답">을 기르게 한다.</div>
           <div class="overview-question">㉡ 수학과 <input data-answer="실생활" aria-label="실생활" placeholder="정답">, 사회 및 자연 현상, <input data-answer="타 교과" aria-label="타 교과" placeholder="정답">의 내용을 연계하는 과제를 활용하여 수학의 유용성을 인식하게 한다.</div>
-          <div class="overview-question">⑤ 다음과 같은 교수⋅학습 방법을 통해 정보처리 역량을 함양하게 한다.</div>
+          <div class="overview-question standard-emphasis">⑤ 다음과 같은 교수⋅학습 방법을 통해 정보처리 역량을 함양하게 한다.</div>
           <div class="overview-question">㉠ 실생활 및 수학적 문제 상황에서 자료를 탐색하고 수집하며 수학적으로 처리하여 합리적인 의사 결정을 하는 태도를 기르게 한다.</div>
           <div class="overview-question">㉡ <input data-answer="교구" aria-label="교구" placeholder="정답">나 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 활용하여 추상적인 수학 내용을 시각화하고 수학의 개념, 원리, 법칙에 대한 직관적 이해와 논리적 사고를 돕는다.</div>
           <div class="overview-question">㉢ 학생이 주도적으로 <input data-answer="교구" aria-label="교구" placeholder="정답">나 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 활용하여 탐구하게 한다.</div>

--- a/styles.css
+++ b/styles.css
@@ -1952,7 +1952,9 @@ td input.activity-input:not(:first-child) {
 }
 
 /* III > 2. 초등학교: 상위 숫자항목 강조 */
-#overview-quiz-main #standard .standard-emphasis {
+#overview-quiz-main #standard .standard-emphasis,
+#math-core-idea .standard-emphasis,
+#math-teaching-competency .standard-emphasis {
   border-color: var(--accent) !important; /* 보라색 테두리 */
   box-shadow: 0 0 0 2px rgba(83, 52, 131, 0.35);
 }


### PR DESCRIPTION
## Summary
- emphasize math core-idea and teaching-competency items with purple borders
- extend standard-emphasis styling to math sections

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad72eaa7c8832c9e2e26e672fa219f