### PR TITLE
Add science course curriculum section

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,6 +47,7 @@
                 INTEGRATED_COURSE: 'integrated-course',
                 SOCIAL_COURSE: 'social-course',
                 MATH_COURSE: 'math-course',
+                SCIENCE_COURSE: 'science-course',
                 MORAL_COURSE: 'moral-course',
                 MORAL_PRINCIPLES: 'moral-principles',
                 MUSIC_ELEMENTS: 'music-elements',
@@ -122,13 +123,13 @@
             [CONSTANTS.SUBJECTS.INTEGRATED_COURSE]: '통합',
             [CONSTANTS.SUBJECTS.SOCIAL_COURSE]: '사회',
             [CONSTANTS.SUBJECTS.MATH_COURSE]: '수학',
+            [CONSTANTS.SUBJECTS.SCIENCE_COURSE]: '과학',
             [CONSTANTS.SUBJECTS.MORAL_COURSE]: '도덕',
             [CONSTANTS.SUBJECTS.MORAL_PRINCIPLES]: '원리와 방법',
             [CONSTANTS.SUBJECTS.MUSIC_ELEMENTS]: '음악요소',
             [CONSTANTS.SUBJECTS.PHYSICAL_ACTIVITY]: '신체활동 예시',
             [CONSTANTS.SUBJECTS.COMPETENCY]: '역량',
-            [CONSTANTS.SUBJECTS.AREA]: '영역',
-            'science-course': '과학'
+            [CONSTANTS.SUBJECTS.AREA]: '영역'
         };
 
         const TOPIC_NAMES = {

--- a/index.html
+++ b/index.html
@@ -2068,6 +2068,85 @@
 
   </main>
 
+  <main id="science-course-quiz-main" class="hidden">
+
+    <div class="tabs">
+      <div class="tab active" data-target="science-overview">교육과정 설계의 개요</div>
+      <div class="tab" data-target="science-character">성격</div>
+      <div class="tab" data-target="science-goal">목표</div>
+      <div class="tab" data-target="science-teaching">교수⋅학습 방법</div>
+      <div class="tab" data-target="science-evaluation">평가 방법</div>
+    </div>
+
+    <section id="science-overview" class="active">
+      <h2>교육과정 설계의 개요</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">과학과 교육과정에서는 자기관리, 지식정보처리, 창의적 사고, 심미적 감성, 협력적 소통, 공동체 역량 등과 같은 범교과적이고 일반적인 총론의 역량과 연계하여 <input data-answer="과학적 탐구와 문제해결 능력" aria-label="과학적 탐구와 문제해결 능력" placeholder="정답">, <input data-answer="과학적 의사결정 능력" aria-label="과학적 의사결정 능력" placeholder="정답"> 등을 기르는 데 초점을 둔다.</div>
+          <div class="overview-question">과학과 지식⋅이해는 과학과 영역별로 학생이 알고 이해해야 하는 내용을 학년군별로 제시하였다.</div>
+          <div class="overview-question">과학과 과정⋅기능은 학생들이 과학 학습을 통해 개발할 것으로 기대하는 과학과 탐구 기능과 과정에 해당하는 것으로, <input data-answer="문제 인식 및 가설 설정" aria-label="문제 인식 및 가설 설정" placeholder="정답">, <input data-answer="탐구 설계 및 수행" aria-label="탐구 설계 및 수행" placeholder="정답">, <input data-answer="자료 수집⋅분석 및 해석" aria-label="자료 수집⋅분석 및 해석" placeholder="정답">, <input data-answer="결론 도출 및 일반화" aria-label="결론 도출 및 일반화" placeholder="정답">, <input data-answer="의사소통과 협업" aria-label="의사소통과 협업" placeholder="정답">을 근간으로 영역별 특성을 반영하였다.</div>
+          <div class="overview-question">과학과 가치⋅태도는 <input data-answer="과학 가치" aria-label="과학 가치" placeholder="정답">-과학의 심미적 가치, 감수성 등-, <input data-answer="과학 태도" aria-label="과학 태도" placeholder="정답">-과학 창의성, 유용성, 윤리성, 개방성 등-, <input data-answer="참여와 실천" aria-label="참여와 실천" placeholder="정답">-과학문화 향유, 안전⋅지속가능 사회에 기여 등-으로 구성하였다.</div>
+          <div class="overview-question">특히, 미래 교육 환경에 적합한 다양한 교수⋅학습 활동을 통해 <input data-answer="디지털⋅인공지능 기초 소양" aria-label="디지털⋅인공지능 기초 소양" placeholder="정답">을 함양하도록 하였다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="science-character">
+      <h2>성격</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">‘과학’은 ‘<input data-answer="과학적 소양을 갖추고 더불어 살아가는 창의적인 사람" aria-label="과학적 소양을 갖추고 더불어 살아가는 창의적인 사람" placeholder="정답">’을 육성하기 위한 교과이다. ‘과학’ 교과에서는 모든 학생이 과학의 <input data-answer="기본 개념" aria-label="기본 개념" placeholder="정답">을 익히고, <input data-answer="과학 탐구 능력" aria-label="과학 탐구 능력" placeholder="정답">과 <input data-answer="태도" aria-label="태도" placeholder="정답">를 길러, 자연과 일상생활에서 접하는 현상을 과학적으로 이해하고, 민주 시민으로서 개인과 사회 문제를 과학적으로 해결하고 참여⋅실천하는 역량 함양에 중점을 둔다.</div>
+          <div class="overview-question">‘과학’에서는 다양한 탐구 중심의 학습을 통해 ‘과학’의 5개 영역과 관련된 지식⋅이해, 과정⋅기능, 가치⋅태도의 세 차원을 상호보완적으로 함양함으로써 영역별 핵심 아이디어를 습득하고, 행위 주체로서 갖추어야 할 <input data-answer="과학적 소양" aria-label="과학적 소양" placeholder="정답">을 기를 수 있을 것이다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="science-goal">
+      <h2>목표</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">자연 현상과 일상생활에 대하여 흥미와 호기심을 가지고 과학적 탐구를 통해 주변의 현상을 이해하고, 개인과 사회의 문제를 과학적이고 창의적으로 해결하는 데 민주 시민으로서 참여하고 실천하는 <input data-answer="과학적 소양" aria-label="과학적 소양" placeholder="정답">을 기른다.</div>
+          <div class="overview-question">(1) 자연 현상과 일상생활에 대한 <input data-answer="흥미" aria-label="흥미" placeholder="정답">와 <input data-answer="호기심" aria-label="호기심" placeholder="정답">을 바탕으로, 개인과 사회의 문제를 인식하고 과학적으로 해결하려는 태도를 기른다.</div>
+          <div class="overview-question">(2) 과학의 <input data-answer="탐구" aria-label="탐구" placeholder="정답"> 방법을 이해하고 자연 현상과 일상생활의 문제를 과학적으로 <input data-answer="탐구" aria-label="탐구" placeholder="정답">하는 능력을 기른다.</div>
+          <div class="overview-question">(3) 자연 현상과 일상생활을 과학적으로 탐구하여 과학의 <input data-answer="핵심 개념" aria-label="핵심 개념" placeholder="정답">을 이해한다.</div>
+          <div class="overview-question">(4) <input data-answer="과학" aria-label="과학" placeholder="정답">과 <input data-answer="기술" aria-label="기술" placeholder="정답"> 및 <input data-answer="사회" aria-label="사회" placeholder="정답">의 <input data-answer="상호 관계" aria-label="상호 관계" placeholder="정답">를 이해하고, 개인과 사회의 문제해결에 민주 시민으로서 <input data-answer="참여" aria-label="참여" placeholder="정답">하고 <input data-answer="실천" aria-label="실천" placeholder="정답">하는 능력을 기른다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="science-teaching">
+      <h2>교수⋅학습 방법</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">• <input data-answer="실험⋅실습" aria-label="실험⋅실습" placeholder="정답">에서 지속적인 관찰이 요구되는 내용을 지도할 때는 <input data-answer="자료 준비" aria-label="자료 준비" placeholder="정답">, <input data-answer="관찰자" aria-label="관찰자" placeholder="정답">, <input data-answer="관찰 내용" aria-label="관찰 내용" placeholder="정답"> 등에 관한 세부 계획을 미리 세운다.</div>
+          <div class="overview-question">• <input data-answer="융합적 사고" aria-label="융합적 사고" placeholder="정답">와 <input data-answer="과학적 창의성" aria-label="과학적 창의성" placeholder="정답">을 계발하기 위해 내용 연계성을 고려하여 과목 내 영역이나 수학, 기술, 공학, 예술 등 다른 교과와 통합 및 연계하여 지도할 수 있도록 계획한다.</div>
+          <div class="overview-question">• 학생의 지적 호기심과 학습 동기를 유발할 수 있도록 발문하고, <input data-answer="개방형 질문" aria-label="개방형 질문" placeholder="정답">을 적극적으로 활용한다.</div>
+          <div class="overview-question">• <input data-answer="교사 중심" aria-label="교사 중심" placeholder="정답">의 실험보다 <input data-answer="학생 중심" aria-label="학생 중심" placeholder="정답">의 탐구 활동을 설계하고, 동료들과의 협업을 통해 과제를 해결하는 과정에서 상호 협력이 중요함을 인식하도록 지도한다.</div>
+          <div class="overview-question">• 모형을 사용할 때는 <input data-answer="모형" aria-label="모형" placeholder="정답">과 <input data-answer="실제 자연 현상" aria-label="실제 자연 현상" placeholder="정답"> 사이에 <input data-answer="차이" aria-label="차이" placeholder="정답">가 있음을 이해할 수 있도록 한다.</div>
+          <div class="overview-question">• ‘과학’ 학습에 대한 학생의 이해를 돕고 흥미를 유발하며 구체적 조작 경험과 활동을 제공하기 위해 모형이나 시청각 자료, <input data-answer="가상 현실" aria-label="가상 현실" placeholder="정답">이나 <input data-answer="증강 현실" aria-label="증강 현실" placeholder="정답"> 자료, 소프트웨어, 컴퓨터 및 스마트 기기, 인터넷 등의 최신 정보 통신 기술과 기기 등을 실험과 탐구에 적절히 활용한다.</div>
+          <div class="overview-question">• <input data-answer="지능정보기술" aria-label="지능정보기술" placeholder="정답"> 등 첨단 과학기술 기반의 과학 교육이 이루어질 수 있도록 <input data-answer="지능형 과학실" aria-label="지능형 과학실" placeholder="정답">을 활용한 탐구 실험⋅실습 중심의 교수⋅학습 활동 계획을 수립하여 실행한다.</div>
+          <div class="overview-question">• ‘과학’ 관련 탐구 활동에서 다양한 센서나 기기 등 <input data-answer="디지털 탐구 도구" aria-label="디지털 탐구 도구" placeholder="정답">를 활용하여 실시간으로 자료를 측정하거나 기상청 등 공공기관에서 제공한 자료를 활용하여 자료를 수집하고 처리하는 기회를 제공한다.</div>
+          <div class="overview-question">• 학교의 지역적 특성을 고려하여 지역의 자연 환경, 지역 명소, 박물관, 과학관 등 <input data-answer="지역별 과학 교육 자원" aria-label="지역별 과학 교육 자원" placeholder="정답">을 적극적으로 활용한다.</div>
+          <div class="overview-question">• 야외 탐구 활동 및 현장 학습 시에는 <input data-answer="사전 답사" aria-label="사전 답사" placeholder="정답">를 하거나 관련 자료를 조사하여 안전한 활동을 실행한다.</div>
+          <div class="overview-question">• 범교과 학습, 생태전환교육, <input data-answer="디지털⋅인공지능 기초 소양" aria-label="디지털⋅인공지능 기초 소양" placeholder="정답"> 함양과 관련한 교육내용 중 해당 주제와 연계하여 지도할 수 있는 내용을 선정하여 함께 학습할 수 있도록 지도한다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+    <section id="science-evaluation">
+      <h2>평가 방법</h2>
+      <div class="grade-container"><div><table><tbody><tr><td>
+        <div class="creative-block">
+          <div class="overview-question">• ‘과학’의 <input data-answer="핵심 개념" aria-label="핵심 개념" placeholder="정답">을 이해하고 적용하는 능력을 평가한다.</div>
+          <div class="overview-question">• ‘과학’의 <input data-answer="과학적 탐구" aria-label="과학적 탐구" placeholder="정답">에 필요한 <input data-answer="문제 인식 및 가설 설정" aria-label="문제 인식 및 가설 설정" placeholder="정답">, <input data-answer="탐구 설계 및 수행" aria-label="탐구 설계 및 수행" placeholder="정답">, <input data-answer="자료 수집⋅분석 및 해석" aria-label="자료 수집⋅분석 및 해석" placeholder="정답">, <input data-answer="결론 도출 및 일반화" aria-label="결론 도출 및 일반화" placeholder="정답">, <input data-answer="의사소통과 협업" aria-label="의사소통과 협업" placeholder="정답"> 등과 관련된 과정⋅기능을 평가한다.</div>
+          <div class="overview-question">• ‘과학’에 대한 흥미와 가치 인식, 학습 참여의 적극성, 협동성, 과학적으로 문제를 해결하는 태도, 창의성 등을 평가한다.</div>
+          <div class="overview-question">• 평가 요소에 따라 <input data-answer="개별" aria-label="개별" placeholder="정답"> 평가와 <input data-answer="모둠" aria-label="모둠" placeholder="정답"> 평가를 실시하고, 자기 평가와 동료 평가도 활용할 수 있다.</div>
+        </div>
+      </td></tr></tbody></table></div></div>
+    </section>
+
+  </main>
+
   <main id="moral-principles-quiz-main" class="hidden">
 
     <div class="tabs">
@@ -12008,6 +12087,8 @@
                 <button class="btn subject-btn" data-subject="social-course" data-topic="course">사회</button>
 
                 <button class="btn subject-btn" data-subject="math-course" data-topic="course">수학</button>
+
+                <button class="btn subject-btn" data-subject="science-course" data-topic="course">과학</button>
 
                 <button class="btn subject-btn" data-subject="moral-principles" data-topic="moral">도덕과 학습 지도 원리와 방법</button>
 


### PR DESCRIPTION
## Summary
- add science course subject button and constants
- implement science curriculum section with overview, goals, teaching strategies, and evaluation

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aec4147a4c832c8c5cd2815dda6fa6