### PR TITLE
style: align science course UI with overview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2166,7 +2166,8 @@ td input.activity-input:not(:first-child) {
 #overview-quiz-main .creative-block,
 #integrated-course-quiz-main .creative-block,
 #social-course-quiz-main .creative-block,
-#moral-course-quiz-main .creative-block {
+#moral-course-quiz-main .creative-block,
+#science-course-quiz-main .creative-block {
   margin-bottom: 2rem;
   padding: 1rem;
   background: var(--bg-light);
@@ -2236,7 +2237,8 @@ td input.activity-input:not(:first-child) {
 #overview-quiz-main .outline-title,
 #integrated-course-quiz-main .outline-title,
 #social-course-quiz-main .outline-title,
-#moral-course-quiz-main .outline-title {
+#moral-course-quiz-main .outline-title,
+#science-course-quiz-main .outline-title {
   font-size: 2rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -2245,7 +2247,8 @@ td input.activity-input:not(:first-child) {
 #overview-quiz-main .sub-title,
 #integrated-course-quiz-main .sub-title,
 #social-course-quiz-main .sub-title,
-#moral-course-quiz-main .sub-title {
+#moral-course-quiz-main .sub-title,
+#science-course-quiz-main .sub-title {
   font-size: 1.8rem;
   font-weight: 600;
   margin: 1rem 0;
@@ -2269,6 +2272,7 @@ td input.activity-input:not(:first-child) {
 #integrated-course-quiz-main .overview-question,
 #social-course-quiz-main .overview-question,
 #moral-course-quiz-main .overview-question,
+#science-course-quiz-main .overview-question,
 #science-std-quiz-main .overview-question,
 #practical-std-quiz-main .overview-question,
 #math-operation-quiz-main .overview-question,
@@ -2302,6 +2306,7 @@ td input.activity-input:not(:first-child) {
 #integrated-course-quiz-main .overview-question:last-child,
 #social-course-quiz-main .overview-question:last-child,
 #moral-course-quiz-main .overview-question:last-child,
+#science-course-quiz-main .overview-question:last-child,
 #science-std-quiz-main .overview-question:last-child,
 #practical-std-quiz-main .overview-question:last-child,
 #math-operation-quiz-main .overview-question:last-child,
@@ -2327,6 +2332,7 @@ td input.activity-input:not(:first-child) {
   #integrated-course-quiz-main .overview-question,
   #social-course-quiz-main .overview-question,
   #moral-course-quiz-main .overview-question,
+  #science-course-quiz-main .overview-question,
   #science-std-quiz-main .overview-question,
   #practical-std-quiz-main .overview-question,
   #math-operation-quiz-main .overview-question,
@@ -2342,6 +2348,7 @@ td input.activity-input:not(:first-child) {
   #integrated-course-quiz-main .overview-question input,
   #social-course-quiz-main .overview-question input,
   #moral-course-quiz-main .overview-question input,
+  #science-course-quiz-main .overview-question input,
   #science-std-quiz-main .overview-question input,
   #practical-std-quiz-main .overview-question input,
   #math-operation-quiz-main .overview-question input,
@@ -2408,6 +2415,7 @@ td input.activity-input:not(:first-child) {
 #integrated-course-quiz-main .overview-question input,
 #social-course-quiz-main .overview-question input,
 #moral-course-quiz-main .overview-question input,
+#science-course-quiz-main .overview-question input,
 #science-std-quiz-main .overview-question input,
 #practical-std-quiz-main .overview-question input,
 #math-operation-quiz-main .overview-question input,
@@ -2501,6 +2509,7 @@ td input.activity-input:not(:first-child) {
 #integrated-course-quiz-main .overview-question input:focus,
 #social-course-quiz-main .overview-question input:focus,
 #moral-course-quiz-main .overview-question input:focus,
+#science-course-quiz-main .overview-question input:focus,
 #science-std-quiz-main .overview-question input:focus,
 #practical-std-quiz-main .overview-question input:focus,
 #math-operation-quiz-main .overview-question input:focus,
@@ -2523,6 +2532,7 @@ td input.activity-input:not(:first-child) {
 #integrated-course-quiz-main .overview-question input.correct,
 #social-course-quiz-main .overview-question input.correct,
 #moral-course-quiz-main .overview-question input.correct,
+#science-course-quiz-main .overview-question input.correct,
 #science-std-quiz-main .overview-question input.correct,
 #practical-std-quiz-main .overview-question input.correct,
 #math-operation-quiz-main .overview-question input.correct,
@@ -2544,6 +2554,7 @@ td input.activity-input:not(:first-child) {
 #integrated-course-quiz-main .overview-question input.incorrect,
 #social-course-quiz-main .overview-question input.incorrect,
 #moral-course-quiz-main .overview-question input.incorrect,
+#science-course-quiz-main .overview-question input.incorrect,
 #science-std-quiz-main .overview-question input.incorrect,
 #practical-std-quiz-main .overview-question input.incorrect,
 #math-operation-quiz-main .overview-question input.incorrect,
@@ -2565,6 +2576,7 @@ td input.activity-input:not(:first-child) {
 #integrated-course-quiz-main .overview-question input.retrying,
 #social-course-quiz-main .overview-question input.retrying,
 #moral-course-quiz-main .overview-question input.retrying,
+#science-course-quiz-main .overview-question input.retrying,
 #science-std-quiz-main .overview-question input.retrying,
 #practical-std-quiz-main .overview-question input.retrying,
 #math-operation-quiz-main .overview-question input.retrying,
@@ -2584,6 +2596,7 @@ td input.activity-input:not(:first-child) {
 #integrated-course-quiz-main .overview-question input.revealed,
 #social-course-quiz-main .overview-question input.revealed,
 #moral-course-quiz-main .overview-question input.revealed,
+#science-course-quiz-main .overview-question input.revealed,
 #science-std-quiz-main .overview-question input.revealed,
 #practical-std-quiz-main .overview-question input.revealed,
 #math-operation-quiz-main .overview-question input.revealed,


### PR DESCRIPTION
## Summary
- Ensure science-course content uses the same block and question styling as overview
- Include science course in shared input state styles

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aec7e89a58832cafa9481fea3dead6