### PR TITLE
feat: add grade six english achievement section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1785,7 +1785,57 @@
 
       </td></tr></tbody></table></div></div>
 
-    </section>
+      <h2>이해(56)</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="achievement-block">
+
+        <div class="outline-title">[성취기준]</div>
+
+        <div class="overview-question">[6영01-01] 간단한 단어, 어구, 문장을 듣고 <input data-answer="강세" aria-label="강세" placeholder="정답">, <input data-answer="리듬" aria-label="리듬" placeholder="정답">, <input data-answer="억양" aria-label="억양" placeholder="정답">을 <input data-answer="식별" aria-label="식별" placeholder="정답">한다.</div>
+
+        <div class="overview-question">[6영01-02] 간단한 단어, 어구, 문장을 <input data-answer="강세" aria-label="강세" placeholder="정답">, <input data-answer="리듬" aria-label="리듬" placeholder="정답">, <input data-answer="억양" aria-label="억양" placeholder="정답">에 맞게 <input data-answer="소리 내어" aria-label="소리 내어" placeholder="정답"> 읽는다.</div>
+        <div class="overview-question">• 소리 내어 읽기를 위해 혼자 읽기, 반 전체가 함께 읽기, 짝이나 모둠원과 번갈아 읽기, 모둠에게 읽어 주기, 시간을 정하여 읽기 등 다양한 방법을 활용한다. <input data-answer="소리 내어" aria-label="소리 내어" placeholder="정답"> 읽기의 목적은 단어, 어구, 문장을 빠르고 정확하게 읽도록 연습하는 데 있으므로, <input data-answer="의미" aria-label="의미" placeholder="정답"> 중심의 읽기를 위한 발판의 역할로 사용하는 것이 좋다.</div>
+
+        <div class="overview-question">[6영01-03] 간단한 단어, 어구, 문장의 <input data-answer="의미" aria-label="의미" placeholder="정답">를 이해한다.</div>
+        <div class="overview-question">[6영01-04] 일상생활 주제에 관한 담화나 글의 <input data-answer="세부 정보" aria-label="세부 정보" placeholder="정답">를 파악한다.</div>
+        <div class="overview-question">[6영01-05] 일상생활 주제에 관한 담화나 글의 <input data-answer="중심 내용" aria-label="중심 내용" placeholder="정답">을 파악한다.</div>
+        <div class="overview-question">• 초등학교 5~6학년군에서는 <input data-answer="일상생활" aria-label="일상생활" placeholder="정답">에서 자주 접할 수 있는 주제-장래 희망, 여행, 취미, 건강 등-를 중심으로 3~4학년군보다 다양한 주제와 의사소통 상황을 포함한 듣기, 읽기 자료를 구성하여 활용한다. 자연스러운 의사소통의 맥락에서 학습자가 다양한 문화권에 속한 사람들의 의사소통 방식이나 일상생활도 접할 수 있도록 한다.</div>
+        <div class="overview-question">• 담화나 글의 내용을 파악할 때는 인물, 행동, 장소, 시간, 감정 등 명시적으로 언급된 <input data-answer="세부 정보" aria-label="세부 정보" placeholder="정답">뿐만 아니라, 담화나 글의 맥락, 주제 및 요지 등의 <input data-answer="중심 내용" aria-label="중심 내용" placeholder="정답">, 일이나 사건의 <input data-answer="전후" aria-label="전후" placeholder="정답"> 관계 등을 파악하도록 지도한다. 예를 들어 담화나 글의 줄거리 파악하기, 듣거나 읽은 문장을 순서대로 배열하기, 간단한 메모 작성하기 등 학습자의 흥미를 불러일으킬 수 있는 유의미하고 다양한 학습 활동을 사용한다.</div>
+
+        <div class="overview-question">[6영01-06] 일상생활 주제에 관한 담화나 글에서 일이나 사건의 <input data-answer="순서" aria-label="순서" placeholder="정답">를 파악한다.</div>
+        <div class="overview-question">• [6영01-06] 이 성취기준은 말이나 대화, 글의 흐름을 파악하는 데 초점을 둔 것으로, 주요한 일이나 사건의 전후 관계 및 시간적 순서를 파악하는 것을 의미한다. 그림이나 만화 등을 이용하여 사건이 일어난 순서에 따라 연결하거나 배열하기, 일이 일어난 순서대로 <input data-answer="번호" aria-label="번호" placeholder="정답"> 쓰기 등의 활동을 하는 수준을 말한다.</div>
+
+        <div class="overview-question">[6영01-07] 적절한 <input data-answer="전략" aria-label="전략" placeholder="정답">을 활용하여 일상생활 주제에 관한 담화나 글을 듣거나 읽는다.</div>
+        <div class="overview-question">• [6영01-07] 이 성취기준은 듣기나 읽기 전⋅중⋅후 과정에서 다양한 단서를 활용하여 담화나 글의 내용을 <input data-answer="예측하기" aria-label="예측하기" placeholder="정답">, 특정 정보를 <input data-answer="찾아" aria-label="찾아" placeholder="정답"> 듣거나 읽기, 내용 확인을 위해 <input data-answer="다시" aria-label="다시" placeholder="정답"> 듣거나 읽기 등의 전략을 활용하는 것을 의미한다.</div>
+        <div class="overview-question">• 일상생활 주제의 담화나 글을 이해하기 위해 듣기 및 읽기 전⋅중⋅후 활동에서 적절한 전략을 활용할 수 있다. 즉, 듣기⋅읽기 전 활동에서는 <input data-answer="시각 단서" aria-label="시각 단서" placeholder="정답">를 활용하여 듣거나 읽을 내용을 <input data-answer="예측" aria-label="예측" placeholder="정답">하는 전략, 듣기⋅읽기 중 활동에서는 특정 정보에 <input data-answer="주목" aria-label="주목" placeholder="정답">하여 듣거나 읽는 전략, 듣기⋅읽기 후 활동에서는 듣거나 읽은 내용을 <input data-answer="점검" aria-label="점검" placeholder="정답">하고 필요한 내용을 <input data-answer="다시" aria-label="다시" placeholder="정답"> 듣거나 읽는 전략 등을 단계별로 지도한다.</div>
+
+        <div class="overview-question">[6영01-08] 다양한 <input data-answer="매체" aria-label="매체" placeholder="정답">로 표현된 담화나 글을 <input data-answer="흥미" aria-label="흥미" placeholder="정답">와 <input data-answer="자신감" aria-label="자신감" placeholder="정답">을 가지고 듣거나 읽는다.</div>
+        <div class="overview-question">• [6영01-08] 이 성취기준은 일상생활 주제에 관해 다양한 매체로 표현된 학습 자료를 듣거나 읽으면서 영어에 대한 흥미와 자신감을 높이고, 학습자 스스로 자신의 수준에 맞는 다양한 영어 자료를 <input data-answer="자기주도적" aria-label="자기주도적" placeholder="정답">으로 찾아 즐기는 것을 의미한다.</div>
+        <div class="overview-question">• <input data-answer="에듀테크" aria-label="에듀테크" placeholder="정답">의 발달과 함께 듣기, 읽기 도구도 다양해지고 있으므로 다양한 디지털 매체를 활용한 듣기와 읽기에 익숙해질 수 있도록 한다. 인공지능이나 앱, 번역기 등의 <input data-answer="디지털" aria-label="디지털" placeholder="정답"> 도구를 활용하여 학습자의 수준에 맞는 <input data-answer="맞춤형" aria-label="맞춤형" placeholder="정답"> 학습을 제공할 수도 있다.</div>
+
+        <div class="overview-question">[6영01-09] <input data-answer="시" aria-label="시" placeholder="정답">, <input data-answer="노래" aria-label="노래" placeholder="정답">, <input data-answer="이야기" aria-label="이야기" placeholder="정답">를 공감하며 듣거나 읽는다.</div>
+
+        <div class="overview-question">[6영01-10] 일상생활 주제나 <input data-answer="문화" aria-label="문화" placeholder="정답">에 관한 담화나 글을 <input data-answer="포용" aria-label="포용" placeholder="정답">의 태도로 듣거나 읽는다.</div>
+        <div class="overview-question">• [6영01-10] 이 성취기준은 공동체 구성원으로서의 가치⋅태도와 관련된 것으로, 일상생활 주제나 문화에 관한 담화나 글을 듣거나 읽으면서 다른 사람의 생각과 의견을 <input data-answer="존중" aria-label="존중" placeholder="정답">하고 <input data-answer="이해" aria-label="이해" placeholder="정답">하는 태도를 갖는 것을 의미한다. 이는 우리나라와 다른 <input data-answer="문화권" aria-label="문화권" placeholder="정답">의 다양한 의사소통 방식과 생활 양식을 수용하는 것을 포함한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title">[성취기준 적용 시 고려사항]</div>
+
+        <div class="overview-question">• 듣기와 읽기 능력을 균형 있게 향상하는 데 중점을 두어 지도한다. 또한 이해 영역의 듣기와 읽기를 연계한 활동뿐만 아니라 이해한 내용을 말하거나 쓰기, 질문하며 답하기 등의 활동을 활용하여 이해 영역 활동이 표현 영역 활동에 자연스럽게 연결되도록 <input data-answer="통합" aria-label="통합" placeholder="정답">적으로 지도한다.</div>
+        <div class="overview-question">• 듣기⋅읽기 평가는 <input data-answer="일괄" aria-label="일괄" placeholder="정답">적으로 실시하는 것보다 평가 <input data-answer="목적" aria-label="목적" placeholder="정답">과 <input data-answer="대상" aria-label="대상" placeholder="정답">, <input data-answer="방법" aria-label="방법" placeholder="정답">에 따라 다양하게 실시하는 것이 바람직하며, 단어, 어구, 문장, 글 등 학습자의 수준에 적절한 언어 재료를 다양하게 활용하는 방안을 고려할 수 있다.</div>
+        <div class="overview-question">• 듣기⋅읽기 평가는 지필평가, 수행평가, 교사 평가, 동료 평가, 자기 평가 등을 다양하게 적용하여 학습의 <input data-answer="과정" aria-label="과정" placeholder="정답">이 드러나도록 한다. 학습 과정을 <input data-answer="누가" aria-label="누가" placeholder="정답"> 기록할 수 있도록 다양한 도구를 활용하고, 이를 바탕으로 학습자에게 적절한 피드백을 제공한다. 학습자가 <input data-answer="피드백" aria-label="피드백" placeholder="정답">을 활용하여 자신의 현재 수준과 학습의 목표 사이의 <input data-answer="간격" aria-label="간격" placeholder="정답">을 줄이도록 지도한다.</div>
+        <div class="overview-question">• 듣기⋅읽기의 가치⋅태도를 평가할 때는 해당 성취기준을 <input data-answer="독립" aria-label="독립" placeholder="정답">적으로 평가하기보다는 다른 성취기준과 <input data-answer="통합" aria-label="통합" placeholder="정답">하여 평가하는 것을 권장한다. 자기 평가나 동료 평가 등을 통해 학습자 <input data-answer="스스로" aria-label="스스로" placeholder="정답"> 듣기나 읽기 태도를 확인하고 점검하게 할 수 있다. 또한 듣기⋅읽기 태도가 자신의 영어 듣기⋅읽기 능력 향상과 어떠한 관련이 있는지를 스스로 <input data-answer="성찰" aria-label="성찰" placeholder="정답">해 볼 수 있도록 지도한다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+      </section>
 
   </main>
 


### PR DESCRIPTION
## Summary
- add "이해(56)" achievement standards section for English
- document strategic reading/listening guidance for grades 5-6

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b12f313718832c9e13fa9103ea91a6