### PR TITLE
feat: update default timer to 20 minutes

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,7 +105,7 @@
                 SHAKE: 'shake',
                 CORRECT_PULSE: 'correct-pulse'
             },
-            DEFAULT_DURATION: 900,
+            DEFAULT_DURATION: 1200,
             HARD_CORE_DURATION: 60,
             HARD_CORE_TIME_BONUS: 5,
             RANDOM_ANIMATION_DURATION: 2000,

--- a/index.html
+++ b/index.html
@@ -619,7 +619,7 @@
 
         <div id="timer-container" class="kitsch-box hidden">
 
-            <div id="time">15:00</div>
+            <div id="time">20:00</div>
 
             <div id="bar"><div></div></div>
 
@@ -13072,7 +13072,7 @@
 
                     <button id="decrease-time" class="btn time-control-btn">-</button>
 
-                    <div id="time-setting-display">15:00</div>
+                    <div id="time-setting-display">20:00</div>
 
                     <button id="increase-time" class="btn time-control-btn">+</button>
 


### PR DESCRIPTION
## Summary
- extend default quiz timer from 15 to 20 minutes
- update displayed initial time to 20:00

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b13596066c832c80c077c96f214e8d