### PR TITLE
Fix skill integration typo in English guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -10482,7 +10482,7 @@
 
                       <li class="inline-item">중: <input class="fit-answer" data-answer="의미이해" aria-label="의미이해" placeholder="정답">를 도움</li>
 
-                      <li class="inline-item">후: <input class="fit-answer" data-answer="이해확인" aria-label="이해확인" placeholder="정답">, <input class="fit-answer" data-answer="상향식 이해처리 연습" aria-label="상향식 이해처리 연습" placeholder="정답">, <input class="fit-answer" data-answer="skillintegration" aria-label="skillintegration" placeholder="정답"></li>
+                      <li class="inline-item">후: <input class="fit-answer" data-answer="이해확인" aria-label="이해확인" placeholder="정답">, <input class="fit-answer" data-answer="상향식 이해처리 연습" aria-label="상향식 이해처리 연습" placeholder="정답">, <input class="fit-answer" data-answer="skill integration" aria-label="skill integration" placeholder="정답"></li>
 
                     </ul>
 


### PR DESCRIPTION
## Summary
- fix missing space in "skill integration" answer label

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b171c74240832cb35bb66ce88404a0