### PR TITLE
Fix typo in English reading instruction section

### DIFF
--- a/index.html
+++ b/index.html
@@ -10584,7 +10584,7 @@
 
                       <li class="inline-item">2: <input class="fit-answer" data-answer="reading aloud" aria-label="reading aloud" placeholder="정답"> → <input class="fit-answer" data-answer="실제성" aria-label="실제성" placeholder="정답">↓, <input class="fit-answer" data-answer="내용 이해" aria-label="내용 이해" placeholder="정답"> 어려움</li>
 
-                      <li class="inline-item">2: <input class="fit-answer" data-answer="silent rading" aria-label="silent rading" placeholder="정답"></li>
+                      <li class="inline-item">2: <input class="fit-answer" data-answer="silent reading" aria-label="silent reading" placeholder="정답"></li>
 
                       <li>3: <input class="fit-answer" data-answer="repeated reading" aria-label="repeated reading" placeholder="정답"> → <input class="fit-answer" data-answer="readers' theatre" aria-label="readers' theatre" placeholder="정답">
 


### PR DESCRIPTION
## Summary
- correct "silent rading" to "silent reading" in functional language teaching section

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b172cf8c98832c9600a05e8930d9ca