### PR TITLE
feat: add blank input UI for music course

### DIFF
--- a/app.js
+++ b/app.js
@@ -323,7 +323,7 @@
         }
 
         function initAutoWidthCourse() {
-            ['practical-quiz-main', 'overview-quiz-main', 'social-course-quiz-main', 'science-course-quiz-main', 'english-course-quiz-main'].forEach(id => {
+            ['practical-quiz-main', 'overview-quiz-main', 'social-course-quiz-main', 'science-course-quiz-main', 'english-course-quiz-main', 'music-course-quiz-main'].forEach(id => {
                 const container = document.getElementById(id);
                 applyAutoWidthForContainer(container);
             });
@@ -1051,7 +1051,7 @@
        }
 
        function adjustCreativeInputWidths() {
-           document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #moral-course-quiz-main .overview-question input[data-answer], #science-std-quiz-main .overview-question input[data-answer], #english-std-quiz-main .overview-question input[data-answer], #practical-std-quiz-main .overview-question input[data-answer], #math-operation-quiz-main .overview-question input[data-answer], #math-course-quiz-main .overview-question input[data-answer], #science-course-quiz-main .overview-question input[data-answer], #english-course-quiz-main .overview-question input[data-answer]')
+           document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #moral-course-quiz-main .overview-question input[data-answer], #science-std-quiz-main .overview-question input[data-answer], #english-std-quiz-main .overview-question input[data-answer], #practical-std-quiz-main .overview-question input[data-answer], #math-operation-quiz-main .overview-question input[data-answer], #math-course-quiz-main .overview-question input[data-answer], #science-course-quiz-main .overview-question input[data-answer], #music-course-quiz-main .overview-question input[data-answer], #english-course-quiz-main .overview-question input[data-answer]')
                 .forEach(input => {
                     const answer = input.dataset.answer || '';
                     const answerLen = answer.length;
@@ -2010,13 +2010,13 @@
                         input.value = input.dataset.answer;
                         input.disabled = true;
                         shouldAdvance = true;
-                        showRevealButtonForIntegrated(input);
-                    } else if (isInCourseOverview(input) || isInCourseCreative(input) || isInCourseSocial(input) || isInCourseScience(input) || isInCourseEnglish(input)) {
-                        // 교육과정-총론, 교육과정-창체: 2차 오답 시 빨간색(incorrect) + 답 공개 + 버튼 제공(정답 처리 가능)
-                        input.value = input.dataset.answer;
-                        input.disabled = true;
-                        shouldAdvance = true;
-                        showRevealButtonForIntegrated(input);
+                    showRevealButtonForIntegrated(input);
+                } else if (isInCourseOverview(input) || isInCourseCreative(input) || isInCourseSocial(input) || isInCourseScience(input) || isInCourseEnglish(input) || isInCourseMusic(input)) {
+                    // 교육과정-총론, 교육과정-창체: 2차 오답 시 빨간색(incorrect) + 답 공개 + 버튼 제공(정답 처리 가능)
+                    input.value = input.dataset.answer;
+                    input.disabled = true;
+                    shouldAdvance = true;
+                    showRevealButtonForIntegrated(input);
                     } else if (
                         gameState.selectedTopic !== CONSTANTS.TOPICS.CURRICULUM &&
                         gameState.selectedTopic !== CONSTANTS.TOPICS.COMPETENCY &&
@@ -2119,6 +2119,11 @@
         function isInCourseEnglish(el) {
             const main = el.closest('main');
             return !!main && main.id === 'english-course-quiz-main';
+        }
+
+        function isInCourseMusic(el) {
+            const main = el.closest('main');
+            return !!main && main.id === 'music-course-quiz-main';
         }
 
         function isIntegratedTitle(el) {

--- a/styles.css
+++ b/styles.css
@@ -2404,7 +2404,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #social-course-quiz-main .creative-block,
 #moral-course-quiz-main .creative-block,
 #science-course-quiz-main .creative-block,
-#english-course-quiz-main .creative-block {
+#english-course-quiz-main .creative-block,
+#music-course-quiz-main .creative-block {
   margin-bottom: 2rem;
   padding: 1rem;
   background: var(--bg-light);
@@ -2481,6 +2482,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .outline-title,
 #science-course-quiz-main .outline-title,
 #english-course-quiz-main .outline-title,
+#music-course-quiz-main .outline-title,
 #spelling-quiz-main .outline-title {
   font-size: 2rem;
   font-weight: 700;
@@ -2493,6 +2495,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .sub-title,
 #science-course-quiz-main .sub-title,
 #english-course-quiz-main .sub-title,
+#music-course-quiz-main .sub-title,
 #spelling-quiz-main .sub-title {
   font-size: 1.8rem;
   font-weight: 600;
@@ -2519,6 +2522,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .overview-question,
 #science-course-quiz-main .overview-question,
 #english-course-quiz-main .overview-question,
+#music-course-quiz-main .overview-question,
 #science-std-quiz-main .overview-question,
 #english-std-quiz-main .overview-question,
 #practical-std-quiz-main .overview-question,
@@ -2556,6 +2560,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .overview-question:last-child,
 #science-course-quiz-main .overview-question:last-child,
 #english-course-quiz-main .overview-question:last-child,
+#music-course-quiz-main .overview-question:last-child,
 #science-std-quiz-main .overview-question:last-child,
 #english-std-quiz-main .overview-question:last-child,
 #practical-std-quiz-main .overview-question:last-child,
@@ -2585,6 +2590,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
   #moral-course-quiz-main .overview-question,
   #science-course-quiz-main .overview-question,
   #english-course-quiz-main .overview-question,
+  #music-course-quiz-main .overview-question,
   #science-std-quiz-main .overview-question,
   #english-std-quiz-main .overview-question,
   #practical-std-quiz-main .overview-question,
@@ -2604,6 +2610,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
   #moral-course-quiz-main .overview-question input,
   #science-course-quiz-main .overview-question input,
   #english-course-quiz-main .overview-question input,
+  #music-course-quiz-main .overview-question input,
   #science-std-quiz-main .overview-question input,
   #english-std-quiz-main .overview-question input,
   #practical-std-quiz-main .overview-question input,
@@ -2676,6 +2683,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .overview-question input,
 #science-course-quiz-main .overview-question input,
 #english-course-quiz-main .overview-question input,
+#music-course-quiz-main .overview-question input,
 #science-std-quiz-main .overview-question input,
 #english-std-quiz-main .overview-question input,
 #practical-std-quiz-main .overview-question input,
@@ -2784,6 +2792,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .overview-question input:focus,
 #science-course-quiz-main .overview-question input:focus,
 #english-course-quiz-main .overview-question input:focus,
+#music-course-quiz-main .overview-question input:focus,
 #science-std-quiz-main .overview-question input:focus,
 #english-std-quiz-main .overview-question input:focus,
 #practical-std-quiz-main .overview-question input:focus,
@@ -2812,6 +2821,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .overview-question input.correct,
 #science-course-quiz-main .overview-question input.correct,
 #english-course-quiz-main .overview-question input.correct,
+#music-course-quiz-main .overview-question input.correct,
 #science-std-quiz-main .overview-question input.correct,
 #english-std-quiz-main .overview-question input.correct,
 #practical-std-quiz-main .overview-question input.correct,
@@ -2839,6 +2849,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .overview-question input.incorrect,
 #science-course-quiz-main .overview-question input.incorrect,
 #english-course-quiz-main .overview-question input.incorrect,
+#music-course-quiz-main .overview-question input.incorrect,
 #science-std-quiz-main .overview-question input.incorrect,
 #english-std-quiz-main .overview-question input.incorrect,
 #practical-std-quiz-main .overview-question input.incorrect,
@@ -2866,6 +2877,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .overview-question input.retrying,
 #science-course-quiz-main .overview-question input.retrying,
 #english-course-quiz-main .overview-question input.retrying,
+#music-course-quiz-main .overview-question input.retrying,
 #science-std-quiz-main .overview-question input.retrying,
 #english-std-quiz-main .overview-question input.retrying,
 #practical-std-quiz-main .overview-question input.retrying,
@@ -2891,6 +2903,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #moral-course-quiz-main .overview-question input.revealed,
 #science-course-quiz-main .overview-question input.revealed,
 #english-course-quiz-main .overview-question input.revealed,
+#music-course-quiz-main .overview-question input.revealed,
 #science-std-quiz-main .overview-question input.revealed,
 #english-std-quiz-main .overview-question input.revealed,
 #practical-std-quiz-main .overview-question input.revealed,


### PR DESCRIPTION
## Summary
- handle music course blanks like other curriculum subjects
- style music course sections and blank states consistently

## Testing
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d07ea298832c88fc5318c34a6d59