### PR TITLE
Add art course curriculum section

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,6 +151,7 @@
             [CONSTANTS.SUBJECTS.MATH_COURSE]: '수학',
             [CONSTANTS.SUBJECTS.SCIENCE_COURSE]: '과학',
             [CONSTANTS.SUBJECTS.MUSIC_COURSE]: '음악',
+            [CONSTANTS.SUBJECTS.ART_COURSE]: '미술',
             [CONSTANTS.SUBJECTS.MORAL_COURSE]: '도덕',
             [CONSTANTS.SUBJECTS.MORAL_PRINCIPLES]: '원리와 방법',
             [CONSTANTS.SUBJECTS.MUSIC_ELEMENTS]: '음악요소',
@@ -323,7 +324,7 @@
         }
 
         function initAutoWidthCourse() {
-            ['practical-quiz-main', 'overview-quiz-main', 'social-course-quiz-main', 'science-course-quiz-main', 'english-course-quiz-main', 'music-course-quiz-main'].forEach(id => {
+            ['practical-quiz-main', 'overview-quiz-main', 'social-course-quiz-main', 'science-course-quiz-main', 'english-course-quiz-main', 'music-course-quiz-main', 'art-course-quiz-main'].forEach(id => {
                 const container = document.getElementById(id);
                 applyAutoWidthForContainer(container);
             });
@@ -1051,7 +1052,7 @@
        }
 
        function adjustCreativeInputWidths() {
-           document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #moral-course-quiz-main .overview-question input[data-answer], #science-std-quiz-main .overview-question input[data-answer], #english-std-quiz-main .overview-question input[data-answer], #practical-std-quiz-main .overview-question input[data-answer], #math-operation-quiz-main .overview-question input[data-answer], #math-course-quiz-main .overview-question input[data-answer], #science-course-quiz-main .overview-question input[data-answer], #music-course-quiz-main .overview-question input[data-answer], #english-course-quiz-main .overview-question input[data-answer]')
+           document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #moral-course-quiz-main .overview-question input[data-answer], #science-std-quiz-main .overview-question input[data-answer], #english-std-quiz-main .overview-question input[data-answer], #practical-std-quiz-main .overview-question input[data-answer], #math-operation-quiz-main .overview-question input[data-answer], #math-course-quiz-main .overview-question input[data-answer], #science-course-quiz-main .overview-question input[data-answer], #music-course-quiz-main .overview-question input[data-answer], #english-course-quiz-main .overview-question input[data-answer], #art-course-quiz-main .overview-question input[data-answer]')
                 .forEach(input => {
                     const answer = input.dataset.answer || '';
                     const answerLen = answer.length;
@@ -1550,6 +1551,7 @@
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.SOCIAL_COURSE ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_COURSE ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.MUSIC_COURSE ||
+                gameState.selectedSubject === CONSTANTS.SUBJECTS.ART_COURSE ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.MORAL_COURSE ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD ||
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.ENGLISH_STD ||
@@ -2011,7 +2013,7 @@
                         input.disabled = true;
                         shouldAdvance = true;
                     showRevealButtonForIntegrated(input);
-                } else if (isInCourseOverview(input) || isInCourseCreative(input) || isInCourseSocial(input) || isInCourseScience(input) || isInCourseEnglish(input) || isInCourseMusic(input)) {
+                } else if (isInCourseOverview(input) || isInCourseCreative(input) || isInCourseSocial(input) || isInCourseScience(input) || isInCourseEnglish(input) || isInCourseMusic(input) || isInCourseArt(input)) {
                     // 교육과정-총론, 교육과정-창체: 2차 오답 시 빨간색(incorrect) + 답 공개 + 버튼 제공(정답 처리 가능)
                     input.value = input.dataset.answer;
                     input.disabled = true;
@@ -2124,6 +2126,11 @@
         function isInCourseMusic(el) {
             const main = el.closest('main');
             return !!main && main.id === 'music-course-quiz-main';
+        }
+
+        function isInCourseArt(el) {
+            const main = el.closest('main');
+            return !!main && main.id === 'art-course-quiz-main';
         }
 
         function isIntegratedTitle(el) {
@@ -2460,6 +2467,7 @@
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.SOCIAL_COURSE ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_COURSE ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.MUSIC_COURSE ||
+                    gameState.selectedSubject === CONSTANTS.SUBJECTS.ART_COURSE ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.MORAL_COURSE ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD ||
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.ENGLISH_STD ||
@@ -2489,6 +2497,7 @@
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.SOCIAL_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.MUSIC_COURSE ||
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.ART_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.MORAL_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.ENGLISH_STD ||
@@ -2554,6 +2563,7 @@
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.SOCIAL_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.MUSIC_COURSE ||
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.ART_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.MORAL_COURSE ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.SCIENCE_STD ||
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.ENGLISH_STD ||

--- a/index.html
+++ b/index.html
@@ -2179,6 +2179,7 @@
 
   </main>
 
+
   <main id="moral-course-quiz-main" class="hidden">
 
     <div class="tabs">
@@ -2779,6 +2780,102 @@
           <div class="overview-question">국악 창작 활동은 시김새, 장단 등의 음악 요소를 드러낼 수 있는 기보법-<input data-answer="가락선 악보" aria-label="가락선 악보" placeholder="정답">, <input data-answer="정간보" aria-label="정간보" placeholder="정답">, <input data-answer="구음보" aria-label="구음보" placeholder="정답"> 등-을 활용하고, 그 결과를 국악의 <input data-answer="창법" aria-label="창법" placeholder="정답">을 살려 노래하거나 <input data-answer="국악기" aria-label="국악기" placeholder="정답">로 표현할 수 있도록 한다.</div>
         </div>
       </td></tr></tbody></table></div></div>
+    </section>
+
+  </main>
+
+  <main id="art-course-quiz-main" class="hidden">
+
+    <div class="tabs">
+
+      <div class="tab active" data-target="art-overview">교육과정 설계의 개요</div>
+      <div class="tab" data-target="art-character">성격</div>
+      <div class="tab" data-target="art-teaching">교수⋅학습 방법</div>
+      <div class="tab" data-target="art-assessment">평가</div>
+
+    </div>
+
+    <section id="art-overview" class="active">
+
+      <h2>교육과정 설계의 개요</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="creative-block">
+
+          <div class="outline-title">#교육과정 설계의 개요</div>
+          <div class="overview-question">미적 체험 영역은 <input data-answer="감각" aria-label="감각" placeholder="정답">과 <input data-answer="사고" aria-label="사고" placeholder="정답">의 연결을 통해 <input data-answer="미적 감수성" aria-label="미적 감수성" placeholder="정답">을 기르고 앎을 확장하며 <input data-answer="자신" aria-label="자신" placeholder="정답">과 <input data-answer="세계" aria-label="세계" placeholder="정답">의 의미와 가치를 <input data-answer="성찰" aria-label="성찰" placeholder="정답">하고 <input data-answer="소통" aria-label="소통" placeholder="정답">하게 한다.</div>
+          <div class="overview-question">표현 영역은 다양한 <input data-answer="발상" aria-label="발상" placeholder="정답">과 <input data-answer="매체" aria-label="매체" placeholder="정답">를 통해 느낌과 생각을 <input data-answer="시각화" aria-label="시각화" placeholder="정답">하고 <input data-answer="성찰" aria-label="성찰" placeholder="정답">하며 창의적으로 문제를 <input data-answer="해결" aria-label="해결" placeholder="정답">하는 가운데 <input data-answer="예술적 성취" aria-label="예술적 성취" placeholder="정답">를 경험하게 한다.</div>
+          <div class="overview-question">감상 영역은 다양한 <input data-answer="삶" aria-label="삶" placeholder="정답">과 <input data-answer="문화" aria-label="문화" placeholder="정답">가 반영된 미술과의 만남으로 <input data-answer="미적 판단 능력" aria-label="미적 판단 능력" placeholder="정답">을 기르고 <input data-answer="자신" aria-label="자신" placeholder="정답">과 <input data-answer="공동체" aria-label="공동체" placeholder="정답">를 이해하며 <input data-answer="미술 문화" aria-label="미술 문화" placeholder="정답">의 <input data-answer="다원적 가치" aria-label="다원적 가치" placeholder="정답">를 존중하게 한다.</div>
+          <div class="overview-question">영역별 성취기준은 지식⋅이해, 과정⋅기능, 가치⋅태도 중 <input data-answer="두 개 이상" aria-label="두 개 이상" placeholder="정답">의 내용 요소를 <input data-answer="연결" aria-label="연결" placeholder="정답">하여 진술하였다.</div>
+          <div class="overview-question">인간상: <input data-answer="자신" aria-label="자신" placeholder="정답">과 <input data-answer="세계" aria-label="세계" placeholder="정답">를 <input data-answer="이해" aria-label="이해" placeholder="정답">하고 <input data-answer="미술 문화 창조" aria-label="미술 문화 창조" placeholder="정답">에 <input data-answer="주도적" aria-label="주도적" placeholder="정답">으로 참여하는 사람</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+    <section id="art-character">
+
+      <h2>성격</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="creative-block">
+
+          <div class="outline-title">#성격</div>
+          <div class="overview-question">특히 <input data-answer="가상공간" aria-label="가상공간" placeholder="정답">까지 미술의 범위를 확대하고, 표현과 소통의 도구로 <input data-answer="디지털 매체" aria-label="디지털 매체" placeholder="정답">를 적극적으로 활용함으로써 학생들은 신체와 사고, 시간과 공간의 경험을 <input data-answer="확장" aria-label="확장" placeholder="정답">하며 <input data-answer="디지털 시대" aria-label="디지털 시대" placeholder="정답">에 필요한 소양을 기를 수 있다.</div>
+          <div class="overview-question">이를 바탕으로 학생들은 개인의 문제를 넘어 주변과 세계에서 일어나고 있는 다양한 문제에 새로운 질문을 던지고 함께 해결하면서 <input data-answer="사람" aria-label="사람" placeholder="정답">과 <input data-answer="환경" aria-label="환경" placeholder="정답">의 <input data-answer="공존" aria-label="공존" placeholder="정답">을 위한 <input data-answer="생태 전환적" aria-label="생태 전환적" placeholder="정답"> 가치를 함양하여 <input data-answer="공동체" aria-label="공동체" placeholder="정답">의 발전에 참여하는 <input data-answer="시민" aria-label="시민" placeholder="정답">으로 성장할 수 있다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+    <section id="art-teaching">
+
+      <h2>교수⋅학습 방법</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="creative-block">
+
+          <div class="outline-title">#교수⋅학습 방법</div>
+          <div class="overview-question">• <input data-answer="프로젝트 학습" aria-label="프로젝트 학습" placeholder="정답"> 방법은 문제를 심층적으로 연구하며 해결 방안을 모색하고 실행하는 교수⋅학습 방법이다. 학습자가 관심 있는 주제를 중심으로 <input data-answer="미술 영역 내" aria-label="미술 영역 내" placeholder="정답">, <input data-answer="타 교과" aria-label="타 교과" placeholder="정답"> 및 <input data-answer="타 분야" aria-label="타 분야" placeholder="정답">와 연계하여 수업을 실행할 수 있다. 문제를 해결하기 위해 충분한 기간과 단계적 수행 과정을 거치며 비판과 성찰, 상호 작용을 통한 깊이 있는 학습을 경험하고 문제를 창의적으로 해결하는 자기주도적 학습 태도를 함양할 수 있다.</div>
+          <div class="overview-question">• <input data-answer="토의⋅토론 학습" aria-label="토의⋅토론 학습" placeholder="정답"> 방법은 규칙과 단계에 따라 의견을 나누는 가운데 앎을 명료하게 하고 확장할 수 있는 교수⋅학습 방법이다. 의사결정이나 아이디어 정교화가 필요한 활동과 쟁점 중심의 활동에 활용할 수 있다. 다른 친구들과 생각과 의견을 나누며 다양한 관점을 존중하는 태도를 기를 수 있다.</div>
+          <div class="overview-question">• <input data-answer="협동 학습" aria-label="협동 학습" placeholder="정답"> 방법은 공동의 학습 문제를 설정하고 상호 작용을 통해 해결하는 교수⋅학습 방법이다. 자료 수집, 아이디어 발상, 주제에 적합한 표현 방법을 찾는 과정에서 역할을 분담하고 집단의 힘을 발휘할 수 있으며 협력적 의사소통 능력을 기를 수 있다. 협동 작품 만들기, 벽화 그리기, 전시 기획하기처럼 다양한 아이디어와 역할이 요구되는 활동에 적용할 수 있다.</div>
+          <div class="overview-question">• 학생들이 자신의 경험, 생각과 느낌을 시각적으로 표현하는 과정은 외부 세계와의 상호 관계 속에서 내면을 성찰하게 한다. 삶과의 긴밀한 연결을 만들고 의미를 구성하며 학습자의 <input data-answer="반성적 성찰" aria-label="반성적 성찰" placeholder="정답">을 돕기 위해 <input data-answer="시각 요소" aria-label="시각 요소" placeholder="정답">를 담은 신문이나 잡지, 이미지를 포함한 일기 등을 활용한 <input data-answer="서사 중심" aria-label="서사 중심" placeholder="정답">의 교수⋅학습 방법을 활용할 수 있다.</div>
+          <div class="overview-question">• 미술과에서 활용 가능한 디지털 기반 교수⋅학습 방법에는 <input data-answer="실감형 콘텐츠" aria-label="실감형 콘텐츠" placeholder="정답"> 활용 학습 방법, <input data-answer="메타버스" aria-label="메타버스" placeholder="정답"> 활용 학습 방법, <input data-answer="학습관리시스템" aria-label="학습관리시스템" placeholder="정답"> 활용 학습 방법 등을 예로 들 수 있다.</div>
+          <div class="overview-question">• <input data-answer="실감형 콘텐츠" aria-label="실감형 콘텐츠" placeholder="정답">를 활용한 활동은 <input data-answer="실재감" aria-label="실재감" placeholder="정답">을 구현하여 학습에 <input data-answer="몰입감" aria-label="몰입감" placeholder="정답">을 높이고, <input data-answer="공감각적 상호 작용" aria-label="공감각적 상호 작용" placeholder="정답">이 가능하다. 새로운 지각 경험을 통해 미적 체험, 표현, 감상의 영역을 <input data-answer="확장" aria-label="확장" placeholder="정답">할 수 있다.</div>
+          <div class="overview-question">• <input data-answer="메타버스" aria-label="메타버스" placeholder="정답">를 활용한 활동으로 <input data-answer="가상공간" aria-label="가상공간" placeholder="정답">에서 전시회를 열고 감상하거나, <input data-answer="온라인 게시판" aria-label="온라인 게시판" placeholder="정답"> 등을 활용하여 소통의 <input data-answer="장" aria-label="장" placeholder="정답">을 넓힐 수 있다.</div>
+          <div class="overview-question">• 디지털 기술을 활용하여 학습자의 개별 특성과 학습 속도에 적합한 <input data-answer="맞춤형" aria-label="맞춤형" placeholder="정답"> 학습을 도울 수 있다. <input data-answer="학습관리시스템" aria-label="학습관리시스템" placeholder="정답">을 활용하면 <input data-answer="실시간 온라인 협업" aria-label="실시간 온라인 협업" placeholder="정답">을 통해 작품 및 결과물 공유, 전시가 가능하며 학습자의 관리와 분석, 피드백 제공 등 <input data-answer="원격수업" aria-label="원격수업" placeholder="정답"> 상황에서도 학습자에게 적합한 지원으로 학습 효과를 높일 수 있다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+    <section id="art-assessment">
+
+      <h2>평가</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="creative-block">
+
+          <div class="outline-title">#평가</div>
+          <div class="overview-question">• 내용 체계와의 관련성을 고려하여 <input data-answer="학습자의 태도" aria-label="학습자의 태도" placeholder="정답">, <input data-answer="학습 과정" aria-label="학습 과정" placeholder="정답">, <input data-answer="학습 결과" aria-label="학습 결과" placeholder="정답">를 고루 평가하며, 지식⋅이해, 과정⋅기능, 가치⋅태도 세 범주의 내용이 균형 있게 평가되도록 계획하고 실행한다.</div>
+          <div class="overview-question">• 디지털 기반의 <input data-answer="학습관리 시스템" aria-label="학습관리 시스템" placeholder="정답">을 활용하여 온오프라인 연계 수업 상황에서 미적 체험, 표현, 감상 과정의 산출물을 기록 및 관리하고, 디지털 도구를 활용한 실시간 피드백과 학생 간 상호 평가가 이루어질 수 있도록 한다.</div>
+          <div class="overview-question">• <input data-answer="서술형" aria-label="서술형" placeholder="정답"> 및 <input data-answer="논술형" aria-label="논술형" placeholder="정답"> 평가와 <input data-answer="발표" aria-label="발표" placeholder="정답"> 및 <input data-answer="토의⋅토론법" aria-label="토의⋅토론법" placeholder="정답"> 등을 활용하여 미술 지식을 바탕으로 자기의 관점, 의견, 주장을 논리적이고 설득력 있게 말과 글로 다른 사람과 소통하는 능력을 파악할 수 있다.</div>
+          <div class="overview-question">• <input data-answer="포트폴리오법" aria-label="포트폴리오법" placeholder="정답">과 <input data-answer="프로세스폴리오법" aria-label="프로세스폴리오법" placeholder="정답">을 활용하여 미술 활동 과정에서의 <input data-answer="성찰" aria-label="성찰" placeholder="정답">과 <input data-answer="변화" aria-label="변화" placeholder="정답">를 파악하고 학습자의 성장 정도를 평가할 수 있다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
     </section>
 
   </main>
@@ -13247,6 +13344,7 @@
                 <button class="btn subject-btn" data-subject="science-course" data-topic="course">과학</button>
                 <button class="btn subject-btn" data-subject="english-course" data-topic="course">영어</button>
                 <button class="btn subject-btn" data-subject="music-course" data-topic="course">음악</button>
+                <button class="btn subject-btn" data-subject="art-course" data-topic="course">미술</button>
 
                 <button class="btn subject-btn" data-subject="moral-principles" data-topic="moral">도덕과 학습 지도 원리와 방법</button>
 

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -37,6 +37,7 @@ export const CONSTANTS = {
         MATH_COURSE: 'math-course',
         SCIENCE_COURSE: 'science-course',
         MUSIC_COURSE: 'music-course',
+        ART_COURSE: 'art-course',
         MORAL_COURSE: 'moral-course',
         MORAL_PRINCIPLES: 'moral-principles',
         MUSIC_ELEMENTS: 'music-elements',


### PR DESCRIPTION
## Summary
- Add Art course to curriculum subject selector
- Implement Art course sections for overview, character, teaching, and assessment with fill-in-the-blank inputs
- Update scripts and constants to support Art course functionality

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d645cf7c832c9627ef2abba54ddd