### PR TITLE
Add placeholder for '실음' in music teaching methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -2774,7 +2774,7 @@
       <div class="grade-container"><div><table><tbody><tr><td>
         <div class="creative-block">
           <div class="outline-title">#교수⋅학습 방법</div>
-          <div class="overview-question">&lt;음악&gt; 과목의 교수⋅학습은 실음을 중심으로 질 높은 음향이 구현될 수 있도록 하며 최신의 <input data-answer="디지털 음악실" aria-label="디지털 음악실" placeholder="정답"> 환경을 구축하고, 인공지능, 가상악기, 메타버스 및 공개 빅데이터 등을 활용한 <input data-answer="실감형 음악 학습 콘텐츠" aria-label="실감형 음악 학습 콘텐츠" placeholder="정답">와 자료를 바탕으로 다양한 교수⋅학습이 실현될 수 있도록 한다.</div>
+          <div class="overview-question">&lt;음악&gt; 과목의 교수⋅학습은 <input data-answer="실음" aria-label="실음" placeholder="정답">을 중심으로 질 높은 음향이 구현될 수 있도록 하며 최신의 <input data-answer="디지털 음악실" aria-label="디지털 음악실" placeholder="정답"> 환경을 구축하고, 인공지능, 가상악기, 메타버스 및 공개 빅데이터 등을 활용한 <input data-answer="실감형 음악 학습 콘텐츠" aria-label="실감형 음악 학습 콘텐츠" placeholder="정답">와 자료를 바탕으로 다양한 교수⋅학습이 실현될 수 있도록 한다.</div>
           <div class="overview-question">국악곡은 되도록 <input data-answer="국악기" aria-label="국악기" placeholder="정답">로 반주하여 시김새, 장단 등의 음악 요소를 살려 노래하거나 연주할 수 있도록 한다.</div>
           <div class="overview-question">국악곡은 감상을 통해 음악의 <input data-answer="쓰임" aria-label="쓰임" placeholder="정답">, <input data-answer="가치" aria-label="가치" placeholder="정답">, <input data-answer="역사⋅문화적 배경" aria-label="역사⋅문화적 배경" placeholder="정답"> 등을 충분히 이해할 수 있도록 한다.</div>
           <div class="overview-question">국악 창작 활동은 시김새, 장단 등의 음악 요소를 드러낼 수 있는 기보법-<input data-answer="가락선 악보" aria-label="가락선 악보" placeholder="정답">, <input data-answer="정간보" aria-label="정간보" placeholder="정답">, <input data-answer="구음보" aria-label="구음보" placeholder="정답"> 등-을 활용하고, 그 결과를 국악의 <input data-answer="창법" aria-label="창법" placeholder="정답">을 살려 노래하거나 <input data-answer="국악기" aria-label="국악기" placeholder="정답">로 표현할 수 있도록 한다.</div>


### PR DESCRIPTION
## Summary
- Add blank for "실음" in music subject teaching and learning section to match other placeholders

## Testing
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ba222cd8832c9a3b641cc7bbadcd