### PR TITLE
feat: add art core ideas section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2790,6 +2790,7 @@
 
       <div class="tab active" data-target="art-overview">교육과정 설계의 개요</div>
       <div class="tab" data-target="art-character">성격</div>
+      <div class="tab" data-target="art-idea">핵심 아이디어</div>
       <div class="tab" data-target="art-teaching">교수⋅학습 방법</div>
       <div class="tab" data-target="art-assessment">평가</div>
 
@@ -2827,6 +2828,34 @@
           <div class="outline-title">#성격</div>
           <div class="overview-question">특히 <input data-answer="가상공간" aria-label="가상공간" placeholder="정답">까지 미술의 범위를 확대하고, 표현과 소통의 도구로 <input data-answer="디지털 매체" aria-label="디지털 매체" placeholder="정답">를 적극적으로 활용함으로써 학생들은 신체와 사고, 시간과 공간의 경험을 <input data-answer="확장" aria-label="확장" placeholder="정답">하며 <input data-answer="디지털 시대" aria-label="디지털 시대" placeholder="정답">에 필요한 소양을 기를 수 있다.</div>
           <div class="overview-question">이를 바탕으로 학생들은 개인의 문제를 넘어 주변과 세계에서 일어나고 있는 다양한 문제에 새로운 질문을 던지고 함께 해결하면서 <input data-answer="사람" aria-label="사람" placeholder="정답">과 <input data-answer="환경" aria-label="환경" placeholder="정답">의 <input data-answer="공존" aria-label="공존" placeholder="정답">을 위한 <input data-answer="생태 전환적" aria-label="생태 전환적" placeholder="정답"> 가치를 함양하여 <input data-answer="공동체" aria-label="공동체" placeholder="정답">의 발전에 참여하는 <input data-answer="시민" aria-label="시민" placeholder="정답">으로 성장할 수 있다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+    <section id="art-idea">
+
+      <h2>핵심 아이디어</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="creative-block">
+
+          <div class="outline-title">#핵심 아이디어</div>
+          <div class="overview-question">(1) 미적 체험</div>
+          <div class="overview-question">⋅미적 체험은 <input data-answer="감각" aria-label="감각" placeholder="정답">을 깨워 <input data-answer="미적 감수성" aria-label="미적 감수성" placeholder="정답">을 풍부하게 하며 <input data-answer="미적 가치" aria-label="미적 가치" placeholder="정답">를 발견하도록 한다.</div>
+          <div class="overview-question">⋅대상과 현상을 <input data-answer="관찰" aria-label="관찰" placeholder="정답">하고 <input data-answer="지각" aria-label="지각" placeholder="정답">하는 경험은 앎을 <input data-answer="확장" aria-label="확장" placeholder="정답">하고 자신을 <input data-answer="성찰" aria-label="성찰" placeholder="정답">하게 한다.</div>
+          <div class="overview-question">⋅이미지에 대한 <input data-answer="비판적 이해" aria-label="비판적 이해" placeholder="정답">는 <input data-answer="시각적 소통" aria-label="시각적 소통" placeholder="정답">과 <input data-answer="문화적 참여" aria-label="문화적 참여" placeholder="정답">의 토대가 된다.</div>
+          <div class="overview-question">(2) 표현</div>
+          <div class="overview-question">⋅표현은 자신의 <input data-answer="느낌" aria-label="느낌" placeholder="정답">과 <input data-answer="생각" aria-label="생각" placeholder="정답">을 <input data-answer="시각화" aria-label="시각화" placeholder="정답">하는 <input data-answer="창의적 사고" aria-label="창의적 사고" placeholder="정답">와 <input data-answer="성찰" aria-label="성찰" placeholder="정답">의 <input data-answer="순환 과정" aria-label="순환 과정" placeholder="정답">으로 이루어진다.</div>
+          <div class="overview-question">⋅다양한 <input data-answer="발상" aria-label="발상" placeholder="정답">은 아이디어와 주제를 발전시키고 표현의 토대가 된다.</div>
+          <div class="overview-question">⋅작품 제작은 표현 재료와 방법, 조형 요소와 원리 등을 선택하고 활용하여 <input data-answer="창의적" aria-label="창의적" placeholder="정답">으로 문제를 해결하는 과정을 통해 <input data-answer="예술적 성취" aria-label="예술적 성취" placeholder="정답">를 경험하게 한다.</div>
+          <div class="overview-question">(3) 감상</div>
+          <div class="overview-question">⋅감상은 다양한 <input data-answer="삶" aria-label="삶" placeholder="정답">과 <input data-answer="문화" aria-label="문화" placeholder="정답">가 반영된 미술과의 만남으로 <input data-answer="자신" aria-label="자신" placeholder="정답">과 <input data-answer="공동체" aria-label="공동체" placeholder="정답">의 <input data-answer="문화" aria-label="문화" placeholder="정답">를 이해하게 한다.</div>
+          <div class="overview-question">⋅작품의 <input data-answer="내용" aria-label="내용" placeholder="정답">과 <input data-answer="형식" aria-label="형식" placeholder="정답">에 관한 맥락적 <input data-answer="이해" aria-label="이해" placeholder="정답">와 <input data-answer="비평" aria-label="비평" placeholder="정답">은 <input data-answer="미적 판단 능력" aria-label="미적 판단 능력" placeholder="정답">을 높인다.</div>
+          <div class="overview-question">⋅감상은 <input data-answer="서로 다른 관점" aria-label="서로 다른 관점" placeholder="정답">을 이해하여 삶에서 미술 문화의 <input data-answer="다원적 가치" aria-label="다원적 가치" placeholder="정답">를 존중하도록 한다.</div>
 
         </div>
 


### PR DESCRIPTION
## Summary
- add '핵심 아이디어' tab and section to the art curriculum
- document core ideas for 미적 체험, 표현, 감상

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b30e1c9960832c8d7db60b3b768f91