### PR TITLE
feat: add light absence guidance in achievement section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7273,6 +7273,8 @@
 
       <div class="overview-question">• 중학교 1~3학년군 '빛과 파동'과 연계된다.</div>
 
+      <div class="overview-question">• 물체를 보기 위해서는 <input data-answer="빛" aria-label="빛" placeholder="정답">이 필요하며 <input data-answer="빛" aria-label="빛" placeholder="정답">이 없을 때 <input data-answer="불편한 점" aria-label="불편한 점" placeholder="정답">을 과학 글쓰기, 그림 그리기, 역할 놀이 등의 다양한 활동으로 <input data-answer="융합" aria-label="융합" placeholder="정답">하여 전개할 수 있다.</div>
+
       <div class="overview-question">• <input data-answer="빛" aria-label="빛" placeholder="정답">의 <input data-answer="직진" aria-label="직진" placeholder="정답">, <input data-answer="반사" aria-label="반사" placeholder="정답">, <input data-answer="굴절" aria-label="굴절" placeholder="정답"> 현상을 관찰할 때 <input data-answer="컴퓨터 시뮬레이션" aria-label="컴퓨터 시뮬레이션" placeholder="정답">, <input data-answer="가상 현실" aria-label="가상 현실" placeholder="정답">, <input data-answer="증강 현실" aria-label="증강 현실" placeholder="정답"> 등을 이용하여 관찰을 보조할 수 있다.</div>
 
       </div>


### PR DESCRIPTION
## Summary
- expand science achievement criteria with activities exploring the need for light and discomfort in darkness

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b529f46cb8832c81dcaaa460f97fdd