### PR TITLE
Add geometry and measurement achievement course

### DIFF
--- a/app.js
+++ b/app.js
@@ -128,6 +128,7 @@
 
                 MATH_OPERATION: 'math-operation',
                 CHANGE_RELATION: 'change-relation',
+                GEOMETRY_MEASURE: 'geometry-measure',
 
 
 
@@ -296,6 +297,8 @@
             [CONSTANTS.SUBJECTS.MATH_OPERATION]: '수와 연산',
 
             [CONSTANTS.SUBJECTS.CHANGE_RELATION]: '변화와 관계',
+
+            [CONSTANTS.SUBJECTS.GEOMETRY_MEASURE]: '도형과 측정',
 
             [CONSTANTS.SUBJECTS.CREATIVE]: '창체',
 
@@ -2176,7 +2179,7 @@
 
        function adjustCreativeInputWidths() {
 
-           document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #moral-course-quiz-main .overview-question input[data-answer], #pe-back-quiz-main .pe-back-input, #science-std-quiz-main .overview-question input[data-answer], #english-std-quiz-main .overview-question input[data-answer], #practical-std-quiz-main .overview-question input[data-answer], #math-operation-quiz-main .overview-question input[data-answer], #change-relation-quiz-main .overview-question input[data-answer], #math-course-quiz-main .overview-question input[data-answer], #science-course-quiz-main .overview-question input[data-answer], #music-course-quiz-main .overview-question input[data-answer], #english-course-quiz-main .overview-question input[data-answer], #art-course-quiz-main .overview-question input[data-answer]')
+           document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #moral-course-quiz-main .overview-question input[data-answer], #pe-back-quiz-main .pe-back-input, #science-std-quiz-main .overview-question input[data-answer], #english-std-quiz-main .overview-question input[data-answer], #practical-std-quiz-main .overview-question input[data-answer], #math-operation-quiz-main .overview-question input[data-answer], #change-relation-quiz-main .overview-question input[data-answer], #geometry-measure-quiz-main .overview-question input[data-answer], #math-course-quiz-main .overview-question input[data-answer], #science-course-quiz-main .overview-question input[data-answer], #music-course-quiz-main .overview-question input[data-answer], #english-course-quiz-main .overview-question input[data-answer], #art-course-quiz-main .overview-question input[data-answer]')
 
                 .forEach(input => {
 
@@ -3189,6 +3192,8 @@
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.MATH_OPERATION ||
 
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.CHANGE_RELATION ||
+
+                gameState.selectedSubject === CONSTANTS.SUBJECTS.GEOMETRY_MEASURE ||
 
                 (gameState.selectedSubject === CONSTANTS.SUBJECTS.SPELLING && isSpellingBlankMode())
 
@@ -5153,6 +5158,8 @@
 
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.CHANGE_RELATION ||
 
+                    gameState.selectedSubject === CONSTANTS.SUBJECTS.GEOMETRY_MEASURE ||
+
                     (gameState.selectedSubject === CONSTANTS.SUBJECTS.SPELLING && isSpellingBlankMode())
 
                 ) {
@@ -5217,6 +5224,7 @@
 
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.CHANGE_RELATION ||
 
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.GEOMETRY_MEASURE ||
 
                             (gameState.selectedSubject === CONSTANTS.SUBJECTS.SPELLING && isSpellingBlankMode())
 
@@ -5366,6 +5374,7 @@
 
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.CHANGE_RELATION ||
 
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.GEOMETRY_MEASURE ||
 
                             (gameState.selectedSubject === CONSTANTS.SUBJECTS.SPELLING && isSpellingBlankMode())
 

--- a/index.html
+++ b/index.html
@@ -8788,6 +8788,407 @@
   </main>
 
 
+  <main id="geometry-measure-quiz-main" class="hidden">
+
+          <div class="tabs">
+
+        <div class="tab active" data-target="gm-grade1-2">1~2</div>
+
+        <div class="tab" data-target="gm-grade3-4">3~4</div>
+
+        <div class="tab" data-target="gm-grade5-6">5~6</div>
+
+      </div>
+
+    <section id="gm-grade1-2" class="active">
+
+      <h2>1~2</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊱 입체도형의 모양</div>
+
+        <div class="overview-question">[2수03-01] 교실 및 생활 주변에서 여러 가지 물건을 관찰하여 <input data-answer="직육면체" aria-label="직육면체" placeholder="정답">, <input data-answer="원기둥" aria-label="원기둥" placeholder="정답">, <input data-answer="구" aria-label="구" placeholder="정답">의 모양을 찾고, 이를 이용하여 여러 가지 모양을 만들 수 있다.</div>
+
+        <div class="overview-question">[2수03-02] <input data-answer="쌓기나무" aria-label="쌓기나무" placeholder="정답">를 이용하여 여러 가지 입체도형의 모양을 만들고, 그 모양에 대해 <input data-answer="위치" aria-label="위치" placeholder="정답">나 <input data-answer="방향" aria-label="방향" placeholder="정답">을 이용하여 말할 수 있다.</div>
+
+        <div class="overview-question">• [2수03-02] 쌓기나무로 만든 입체도형의 <input data-answer="모양" aria-label="모양" placeholder="정답">에 대해서 ‘∼의 앞’, ‘∼의 오른쪽’, ‘∼의 위’, ‘2층’ 등을 사용하여 말하게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊲 평면도형과 그 구성 요소</div>
+
+        <div class="overview-question">[2수03-03] 교실 및 생활 주변에서 여러 가지 물건을 <input data-answer="관찰" aria-label="관찰" placeholder="정답">하여 <input data-answer="삼각형" aria-label="삼각형" placeholder="정답">, <input data-answer="사각형" aria-label="사각형" placeholder="정답">, <input data-answer="원" aria-label="원" placeholder="정답">의 <input data-answer="모양" aria-label="모양" placeholder="정답">을 찾고, 이를 이용하여 여러 가지 모양을 만들 수 있다.</div>
+
+        <div class="overview-question">[2수03-04] 삼각형, 사각형, 원을 <input data-answer="직관적" aria-label="직관적" placeholder="정답">으로 이해하고, 그 모양을 그릴 수 있다.</div>
+
+        <div class="overview-question">• [2수03-04] 삼각형, 사각형, 원은 <input data-answer="예인 것" aria-label="예인 것" placeholder="정답">과 <input data-answer="예가 아닌 것" aria-label="예가 아닌 것" placeholder="정답">을 <input data-answer="분류" aria-label="분류" placeholder="정답">하는 활동을 통하여 직관적으로 이해하게 한다. 본뜨기, 도형판을 이용한 활동 등을 통해 삼각형, 사각형, 원의 모양을 그리게 할 수 있다.</div>
+
+        <div class="overview-question">[2수03-05] 삼각형, 사각형에서 각각의 <input data-answer="공통점" aria-label="공통점" placeholder="정답">을 찾아 말할 수 있다.</div>
+
+        <div class="overview-question">• 입체도형과 평면도형의 <input data-answer="모양" aria-label="모양" placeholder="정답">을 다룰 때 모양의 특징을 <input data-answer="직관적" aria-label="직관적" placeholder="정답">으로 파악하여 모양을 <input data-answer="분류" aria-label="분류" placeholder="정답">하고, 분류한 모양을 지칭하기 위해 <input data-answer="일상용어" aria-label="일상용어" placeholder="정답">를 사용하게 할 수 있다.</div>
+
+        <div class="overview-question">• 입체도형과 평면도형의 모양을 이용한 모양 만들기의 주제는 학생들에게 <input data-answer="친근한" aria-label="친근한" placeholder="정답"> 소재인 동물, 탈 것, 건물 등으로 다양하게 제시하여 수학에 대한 흥미와 관심을 갖게 한다.</div>
+
+        <div class="overview-question">• <input data-answer="쌓기나무" aria-label="쌓기나무" placeholder="정답">, <input data-answer="칠교판" aria-label="칠교판" placeholder="정답"> 등의 구체물을 이용한 모양 만들기를 통하여 도형에 대한 <input data-answer="공간 감각" aria-label="공간 감각" placeholder="정답">을 기르게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊳 양의 비교</div>
+
+        <div class="overview-question">[2수03-06] 구체물의 <input data-answer="길이" aria-label="길이" placeholder="정답">, <input data-answer="들이" aria-label="들이" placeholder="정답">, <input data-answer="무게" aria-label="무게" placeholder="정답">, <input data-answer="넓이" aria-label="넓이" placeholder="정답">를 <input data-answer="비교" aria-label="비교" placeholder="정답">하여 각각 ‘<input data-answer="길다" aria-label="길다" placeholder="정답">, <input data-answer="짧다" aria-label="짧다" placeholder="정답">’, ‘<input data-answer="많다" aria-label="많다" placeholder="정답">, <input data-answer="적다" aria-label="적다" placeholder="정답">’, ‘<input data-answer="무겁다" aria-label="무겁다" placeholder="정답">, <input data-answer="가볍다" aria-label="가볍다" placeholder="정답">’, ‘<input data-answer="넓다" aria-label="넓다" placeholder="정답">, <input data-answer="좁다" aria-label="좁다" placeholder="정답">’ 등을 구별하여 말할 수 있다.</div>
+
+        <div class="overview-question">• 양의 비교는 학생들에게 친근한 실생활 상황을 이용하고, <input data-answer="직관적" aria-label="직관적" placeholder="정답">인 비교, <input data-answer="직접" aria-label="직접" placeholder="정답"> 비교, <input data-answer="간접" aria-label="간접" placeholder="정답"> 비교 등을 상황에 따라 알맞게 다룬다.</div>
+
+        <div class="overview-question">• 저학년 학생들의 <input data-answer="한글 학습 정도" aria-label="한글 학습 정도" placeholder="정답">를 고려하여 양을 비교할 때 ‘짧다’, ‘많다’, ‘넓다’ 등과 같이 한글로 <input data-answer="쓰게" aria-label="쓰게" placeholder="정답"> 하는 것은 지양한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊴 시각과 시간</div>
+
+        <div class="overview-question">[2수03-07] 시계를 보고 시각을 ‘<input data-answer="몇 시 몇 분" aria-label="몇 시 몇 분" placeholder="정답">’까지 읽을 수 있다.</div>
+
+        <div class="overview-question">[2수03-08] <input data-answer="1시간" aria-label="1시간" placeholder="정답">과 <input data-answer="1분" aria-label="1분" placeholder="정답">의 관계를 이해하고, 시간을 ‘<input data-answer="시간" aria-label="시간" placeholder="정답">’, ‘<input data-answer="분" aria-label="분" placeholder="정답">’으로 표현할 수 있다.</div>
+
+        <div class="overview-question">[2수03-09] 실생활 문제 상황과 연결하여 <input data-answer="1분" aria-label="1분" placeholder="정답">, <input data-answer="1시간" aria-label="1시간" placeholder="정답">, <input data-answer="1일" aria-label="1일" placeholder="정답">, <input data-answer="1주일" aria-label="1주일" placeholder="정답">, <input data-answer="1개월" aria-label="1개월" placeholder="정답">, <input data-answer="1년" aria-label="1년" placeholder="정답"> 사이의 관계를 이해한다.</div>
+
+        <div class="overview-question">• 학생들이 <input data-answer="모형 시계" aria-label="모형 시계" placeholder="정답">를 조작하여 ‘몇 시’, ‘몇 시 30분’, ‘몇 시 몇 분’, ‘몇 시 몇 분 전’ 등의 시각을 읽게 한다.</div>
+
+        <div class="overview-question">• ‘<input data-answer="몇 시 몇 분 전" aria-label="몇 시 몇 분 전" placeholder="정답">’의 시각 읽기에서 5분 전, 10분 전과 같이 <input data-answer="간단한" aria-label="간단한" placeholder="정답"> 경우를 다루고, 13분 전과 같이 <input data-answer="복잡한" aria-label="복잡한" placeholder="정답"> 경우는 다루지 않는다.</div>
+
+        <div class="overview-question">• 시간의 여러 가지 단위를 지도할 때는 단위 사이의 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해하는 데 중점을 두고, <input data-answer="지나친 단위 환산" aria-label="지나친 단위 환산" placeholder="정답">은 다루지 않는다.</div>
+
+        <div class="overview-question">• 1일, 1주일, 1개월, 1년 사이의 관계를 지도할 때는 실생활 상황에서 <input data-answer="달력" aria-label="달력" placeholder="정답">을 이용하여 그 관계를 이해하게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊵 길이</div>
+
+        <div class="overview-question">[2수03-10] 길이 단위 <input data-answer="1cm" aria-label="1cm" placeholder="정답">와 <input data-answer="1m" aria-label="1m" placeholder="정답">를 알고, 이를 이용하여 주변 사물의 길이를 <input data-answer="측정" aria-label="측정" placeholder="정답">할 수 있다.</div>
+
+        <div class="overview-question">• [2수03-10] 길이의 <input data-answer="표준 단위" aria-label="표준 단위" placeholder="정답">를 도입하기 전에 구체물을 <input data-answer="직접 비교" aria-label="직접 비교" placeholder="정답">해 보거나 여러 가지 <input data-answer="임의 단위" aria-label="임의 단위" placeholder="정답">를 사용하여 구체물의 길이를 재어보는 활동을 통해 <input data-answer="표준 단위의 필요성" aria-label="표준 단위의 필요성" placeholder="정답">을 알게 한다.</div>
+
+        <div class="overview-question">[2수03-11] 1m와 1cm의 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해하고, 길이를 ‘<input data-answer="몇 m 몇 cm" aria-label="몇 m 몇 cm" placeholder="정답">’와 ‘<input data-answer="몇 cm" aria-label="몇 cm" placeholder="정답">’로 표현할 수 있다.</div>
+
+        <div class="overview-question">[2수03-12] 여러 가지 물건의 길이를 <input data-answer="어림" aria-label="어림" placeholder="정답">하고, 길이에 대한 <input data-answer="양감" aria-label="양감" placeholder="정답">을 기른다.</div>
+
+        <div class="overview-question">• [2수03-12] 생활 주변의 여러 가지 물건들의 길이를 <input data-answer="어림" aria-label="어림" placeholder="정답">해 보고 자로 측정하여 확인하는 활동과 주어진 길이에 해당하는 <input data-answer="선분" aria-label="선분" placeholder="정답">을 그려 보는 활동을 통해 길이에 대한 <input data-answer="양감" aria-label="양감" placeholder="정답">을 기르게 한다.</div>
+
+        <div class="overview-question">[2수03-13] 실생활 문제 상황과 연결하여 길이의 <input data-answer="덧셈" aria-label="덧셈" placeholder="정답">과 <input data-answer="뺄셈" aria-label="뺄셈" placeholder="정답">을 할 수 있다.</div>
+
+        <div class="overview-question">• 구체물의 길이를 재는 과정에서 <input data-answer="자의 눈금" aria-label="자의 눈금" placeholder="정답">과 일치하지 않는 길이의 측정값을 ‘<input data-answer="약" aria-label="약" placeholder="정답">’으로 표현할 수 있음을 알게 한다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+    <section id="gm-grade3-4">
+
+      <h2>3~4</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊱 도형의 기초</div>
+
+        <div class="overview-question">[4수03-01] <input data-answer="직선" aria-label="직선" placeholder="정답">, <input data-answer="선분" aria-label="선분" placeholder="정답">, <input data-answer="반직선" aria-label="반직선" placeholder="정답">을 이해하고 구별할 수 있다.</div>
+
+        <div class="overview-question">[4수03-02] <input data-answer="각" aria-label="각" placeholder="정답">과 <input data-answer="직각" aria-label="직각" placeholder="정답">을 이해하고, <input data-answer="직각" aria-label="직각" placeholder="정답">과 비교하는 활동을 통하여 <input data-answer="예각" aria-label="예각" placeholder="정답">과 <input data-answer="둔각" aria-label="둔각" placeholder="정답">을 구별할 수 있다.</div>
+
+        <div class="overview-question">[4수03-03] 직선의 <input data-answer="수직" aria-label="수직" placeholder="정답"> 관계와 <input data-answer="평행" aria-label="평행" placeholder="정답"> 관계를 이해한다.</div>
+
+        <div class="overview-question">• 직선, 선분, 반직선에 대한 평가에서는 정확한 <input data-answer="정의" aria-label="정의" placeholder="정답">나 표현보다 직선, 선분, 반직선을 서로 <input data-answer="구별" aria-label="구별" placeholder="정답">할 수 있는지에 중점을 둔다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊲 평면도형의 이동</div>
+
+        <div class="overview-question">[4수03-04] 구체물이나 평면도형의 <input data-answer="밀기" aria-label="밀기" placeholder="정답">, <input data-answer="뒤집기" aria-label="뒤집기" placeholder="정답">, <input data-answer="돌리기" aria-label="돌리기" placeholder="정답"> 활동을 통하여 그 변화를 이해한다.</div>
+
+        <div class="overview-question">• [4수03-04] 실생활에서 평면도형의 이동을 활용한 사례를 찾아서 이동에 따른 변화를 추론하고 <input data-answer="위치" aria-label="위치" placeholder="정답">나 <input data-answer="방향" aria-label="방향" placeholder="정답">이 어떻게 변화했는지 설명하게 한다.</div>
+
+        <div class="overview-question">[4수03-05] 평면에서 <input data-answer="점" aria-label="점" placeholder="정답">의 이동에 대해 <input data-answer="위치" aria-label="위치" placeholder="정답">와 <input data-answer="방향" aria-label="방향" placeholder="정답">을 이용하여 설명할 수 있다.</div>
+
+        <div class="overview-question">• [4수03-05] 평면에서 <input data-answer="점" aria-label="점" placeholder="정답">의 이동은 <input data-answer="격자" aria-label="격자" placeholder="정답">를 따라 위, 아래, 오른쪽, 왼쪽으로 ‘∼칸’, ‘∼cm’를 이동하는 수준에서 다룬다. 한 점의 이동에 대해 <input data-answer="위치" aria-label="위치" placeholder="정답">와 <input data-answer="방향" aria-label="방향" placeholder="정답">을 설명하는 데 초점을 두고, <input data-answer="꼭짓점" aria-label="꼭짓점" placeholder="정답">의 이동을 이용하여 <input data-answer="평면도형" aria-label="평면도형" placeholder="정답">의 이동을 설명하는 활동은 다루지 않는다.</div>
+
+        <div class="overview-question">• 평면도형의 이동에서 돌리고 뒤집기나 뒤집고 돌리기 등 <input data-answer="복잡한" aria-label="복잡한" placeholder="정답"> 변화를 지양한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊳 원의 구성 요소</div>
+
+        <div class="overview-question">[4수03-06] 원의 <input data-answer="중심" aria-label="중심" placeholder="정답">, <input data-answer="반지름" aria-label="반지름" placeholder="정답">, <input data-answer="지름" aria-label="지름" placeholder="정답">을 이해하고, 그 <input data-answer="성질" aria-label="성질" placeholder="정답">을 안다.</div>
+
+        <div class="overview-question">[4수03-07] <input data-answer="컴퍼스" aria-label="컴퍼스" placeholder="정답">를 이용하여 <input data-answer="여러 가지 크기" aria-label="여러 가지 크기" placeholder="정답">의 원을 그릴 수 있다.</div>
+
+        <div class="overview-question">• [4수03-07] <input data-answer="컴퍼스" aria-label="컴퍼스" placeholder="정답">를 사용하여 다양한 크기의 원을 그리는 방법을 원의 <input data-answer="성질" aria-label="성질" placeholder="정답">과 연결하여 이해하게 한다.</div>
+
+        <div class="overview-question">• 평면도형의 이동, 원 그리기 등을 이용하여 여러 가지 모양이나 무늬 만들기 활동을 통해 수학의 <input data-answer="아름다움" aria-label="아름다움" placeholder="정답">을 느끼게 할 수 있다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊴 여러 가지 삼각형</div>
+
+        <div class="overview-question">[4수03-08] 여러 가지 모양의 삼각형에 대한 <input data-answer="분류" aria-label="분류" placeholder="정답"> 활동을 통하여 <input data-answer="이등변삼각형" aria-label="이등변삼각형" placeholder="정답">, <input data-answer="정삼각형" aria-label="정삼각형" placeholder="정답">을 이해하고, 그 <input data-answer="성질" aria-label="성질" placeholder="정답">을 탐구하고 설명할 수 있다.</div>
+
+        <div class="overview-question">[4수03-09] 여러 가지 모양의 삼각형에 대한 <input data-answer="분류" aria-label="분류" placeholder="정답"> 활동을 통하여 <input data-answer="직각삼각형" aria-label="직각삼각형" placeholder="정답">, <input data-answer="예각삼각형" aria-label="예각삼각형" placeholder="정답">, <input data-answer="둔각삼각형" aria-label="둔각삼각형" placeholder="정답">을 이해한다.</div>
+
+        <div class="overview-question">• 삼각형의 <input data-answer="성질" aria-label="성질" placeholder="정답">을 <input data-answer="탐구" aria-label="탐구" placeholder="정답">하는 활동에서 구체적인 관찰, 실험, 측정 등 <input data-answer="귀납적 추론" aria-label="귀납적 추론" placeholder="정답">을 통해 성질을 이해하게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊵 여러 가지 사각형</div>
+
+        <div class="overview-question">[4수03-10] 여러 가지 모양의 사각형에 대한 <input data-answer="분류" aria-label="분류" placeholder="정답"> 활동을 통하여 <input data-answer="직사각형" aria-label="직사각형" placeholder="정답">, <input data-answer="정사각형" aria-label="정사각형" placeholder="정답">, <input data-answer="사다리꼴" aria-label="사다리꼴" placeholder="정답">, <input data-answer="평행사변형" aria-label="평행사변형" placeholder="정답">, <input data-answer="마름모" aria-label="마름모" placeholder="정답">를 이해하고, 그 <input data-answer="성질" aria-label="성질" placeholder="정답">을 탐구하고 설명할 수 있다.</div>
+
+        <div class="overview-question">• 여러 가지 사각형의 <input data-answer="성질" aria-label="성질" placeholder="정답">은 <input data-answer="구체적인 조작" aria-label="구체적인 조작" placeholder="정답"> 활동을 통하여 간단한 것만 다루고, 여러 가지 사각형 사이의 <input data-answer="관계" aria-label="관계" placeholder="정답">는 다루지 않는다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊶 다각형</div>
+
+        <div class="overview-question">[4수03-11] <input data-answer="다각형" aria-label="다각형" placeholder="정답">과 <input data-answer="정다각형" aria-label="정다각형" placeholder="정답">을 이해한다.</div>
+
+        <div class="overview-question">• [4수03-11] <input data-answer="도형판" aria-label="도형판" placeholder="정답">, <input data-answer="모양 조각" aria-label="모양 조각" placeholder="정답"> 등의 교구를 이용한 구체적인 조작 활동을 통해 다각형과 정다각형을 이해하게 한다.</div>
+
+        <div class="overview-question">[4수03-12] 주어진 도형을 이용하여 여러 가지 <input data-answer="모양" aria-label="모양" placeholder="정답">을 만들거나 채우고 설명할 수 있다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊷 시각과 시간</div>
+
+        <div class="overview-question">[4수03-13] <input data-answer="1분" aria-label="1분" placeholder="정답">과 <input data-answer="1초" aria-label="1초" placeholder="정답">의 관계를 이해하고, <input data-answer="초 단위" aria-label="초 단위" placeholder="정답">까지 시각을 읽을 수 있다.</div>
+
+        <div class="overview-question">• [4수03-12] 다양한 <input data-answer="교구" aria-label="교구" placeholder="정답">와 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답"> 등을 이용한 구체적인 활동을 통해 주어진 도형으로 여러 가지 모양을 다양하게 만들거나 채울 수 있다.</div>
+
+        <div class="overview-question">[4수03-14] 실생활 문제 상황과 연결하여 <input data-answer="초 단위" aria-label="초 단위" placeholder="정답">까지의 시간의 <input data-answer="덧셈" aria-label="덧셈" placeholder="정답">과 <input data-answer="뺄셈" aria-label="뺄셈" placeholder="정답">을 할 수 있다.</div>
+
+        <div class="overview-question">• <input data-answer="시각" aria-label="시각" placeholder="정답">과 <input data-answer="시간" aria-label="시간" placeholder="정답">의 의미는 구체적인 상황 속에서 구별하여 사용할 수 있는 정도로 이해하게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊸 길이</div>
+
+        <div class="overview-question">[4수03-15] 길이 단위 <input data-answer="1mm" aria-label="1mm" placeholder="정답">와 <input data-answer="1km" aria-label="1km" placeholder="정답">를 알고, 이를 이용하여 길이를 <input data-answer="측정" aria-label="측정" placeholder="정답">하고 <input data-answer="어림" aria-label="어림" placeholder="정답">하며 수학의 <input data-answer="유용성" aria-label="유용성" placeholder="정답">을 인식할 수 있다.</div>
+
+        <div class="overview-question">[4수03-16] <input data-answer="1cm" aria-label="1cm" placeholder="정답">와 <input data-answer="1mm" aria-label="1mm" placeholder="정답">, <input data-answer="1km" aria-label="1km" placeholder="정답">와 <input data-answer="1m" aria-label="1m" placeholder="정답">의 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해하고, 길이를 ‘몇 cm 몇 mm’와 ‘몇 mm’, ‘몇 km 몇 m’와 ‘몇 m’로 다양하게 표현할 수 있다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊹 들이</div>
+
+        <div class="overview-question">[4수03-17] 들이 단위 <input data-answer="1L" aria-label="1L" placeholder="정답">와 <input data-answer="1mL" aria-label="1mL" placeholder="정답">를 알고, 이를 이용하여 들이를 <input data-answer="측정" aria-label="측정" placeholder="정답">하고 <input data-answer="어림" aria-label="어림" placeholder="정답">하며 수학의 <input data-answer="유용성" aria-label="유용성" placeholder="정답">을 인식할 수 있다.</div>
+
+        <div class="overview-question">[4수03-18] <input data-answer="1L" aria-label="1L" placeholder="정답">와 <input data-answer="1mL" aria-label="1mL" placeholder="정답">의 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해하고, 들이를 ‘몇 L 몇 mL’와 ‘몇 mL’로 표현할 수 있다.</div>
+
+        <div class="overview-question">[4수03-19] 실생활 문제 상황과 연결하여 들이의 <input data-answer="덧셈" aria-label="덧셈" placeholder="정답">과 <input data-answer="뺄셈" aria-label="뺄셈" placeholder="정답">을 할 수 있다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊹 무게</div>
+
+        <div class="overview-question">[4수03-20] 실생활에서 무게를 나타낼 때 사용하는 단위 <input data-answer="1g" aria-label="1g" placeholder="정답">과 <input data-answer="1kg" aria-label="1kg" placeholder="정답">을 알고, 이를 이용하여 무게를 측정하고 어림하며 수학의 <input data-answer="유용성" aria-label="유용성" placeholder="정답">을 인식할 수 있다.</div>
+
+        <div class="overview-question">• [4수03-20] 초등학교에서는 <input data-answer="무게" aria-label="무게" placeholder="정답">와 <input data-answer="질량" aria-label="질량" placeholder="정답">의 개념을 엄밀하게 구분하지 않으며, 무게를 비교하고 측정하는 데에 <input data-answer="g" aria-label="g" placeholder="정답">, <input data-answer="kg" aria-label="kg" placeholder="정답">의 단위를 사용하게 한다.</div>
+
+        <div class="overview-question">[4수03-21] 1kg과 1g의 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해하고, 무게를 ‘몇 kg 몇 g’과 ‘몇 g’으로 표현할 수 있다.</div>
+
+        <div class="overview-question">[4수03-22] 실생활에서 무게를 나타낼 때 사용하는 단위 <input data-answer="1t" aria-label="1t" placeholder="정답">을 알고, 1t과 1kg의 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해한다.</div>
+
+        <div class="overview-question">[4수03-23] 실생활 문제 상황과 연결하여 무게의 <input data-answer="덧셈" aria-label="덧셈" placeholder="정답">과 <input data-answer="뺄셈" aria-label="뺄셈" placeholder="정답">을 할 수 있다.</div>
+
+        <div class="overview-question">• 들이, 무게의 표준 단위를 도입하기 전에 표준 단위의 <input data-answer="필요성" aria-label="필요성" placeholder="정답">을 알게 한다.</div>
+
+        <div class="overview-question">• 시간, 길이, 들이, 무게의 <input data-answer="단위" aria-label="단위" placeholder="정답">를 지도할 때 단위 사이의 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해하는 데 중점을 두고, <input data-answer="1km" aria-label="1km" placeholder="정답">와 <input data-answer="1cm" aria-label="1cm" placeholder="정답">의 관계, <input data-answer="1t" aria-label="1t" placeholder="정답">과 <input data-answer="1g" aria-label="1g" placeholder="정답">의 관계 등의 <input data-answer="지나친 단위 환산" aria-label="지나친 단위 환산" placeholder="정답">은 다루지 않는다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊹 각도</div>
+
+        <div class="overview-question">[4수03-24] 각의 크기의 단위인 <input data-answer="1도" aria-label="1도" placeholder="정답">를 알고, <input data-answer="각도기" aria-label="각도기" placeholder="정답">를 이용하여 각의 크기를 <input data-answer="측정" aria-label="측정" placeholder="정답">하고 <input data-answer="어림" aria-label="어림" placeholder="정답">할 수 있다.</div>
+
+        <div class="overview-question">[4수03-25] 여러 가지 방법으로 <input data-answer="삼각형" aria-label="삼각형" placeholder="정답">과 <input data-answer="사각형" aria-label="사각형" placeholder="정답">의 <input data-answer="내각의 크기의 합" aria-label="내각의 크기의 합" placeholder="정답">을 <input data-answer="추론" aria-label="추론" placeholder="정답">하고, 자신의 <input data-answer="추론" aria-label="추론" placeholder="정답"> 과정을 설명할 수 있다.</div>
+
+        <div class="overview-question">• 실제로 재거나 어림하는 측정 활동을 통하여 시간, 길이, 들이, 무게, 각도에 대한 <input data-answer="양감" aria-label="양감" placeholder="정답">을 기르게 한다.</div>
+
+        <div class="overview-question">• 길이, 들이, 무게, 각도를 측정할 때 측정도구의 눈금에 일치하지 않는 측정값을 ‘<input data-answer="약" aria-label="약" placeholder="정답">’으로 표현하게 한다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+    <section id="gm-grade5-6">
+
+      <h2>5~6</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊱 합동과 대칭</div>
+
+        <div class="overview-question">[6수03-01] 도형의 <input data-answer="합동" aria-label="합동" placeholder="정답">을 이해하고, <input data-answer="합동" aria-label="합동" placeholder="정답">인 도형의 <input data-answer="성질" aria-label="성질" placeholder="정답">을 탐구하고 설명할 수 있다.</div>
+
+        <div class="overview-question">• [6수03-01] 합동인 두 도형에서 <input data-answer="대응점" aria-label="대응점" placeholder="정답">, <input data-answer="대응변" aria-label="대응변" placeholder="정답">, <input data-answer="대응각" aria-label="대응각" placeholder="정답">을 각각 찾게 하고 <input data-answer="대응변의 길이" aria-label="대응변의 길이" placeholder="정답">와 <input data-answer="대응각의 크기" aria-label="대응각의 크기" placeholder="정답">를 비교하는 활동을 통해 합동인 도형의 <input data-answer="성질" aria-label="성질" placeholder="정답">을 탐구하고 설명하게 한다.</div>
+
+        <div class="overview-question">[6수03-02] 실생활과 연결하여 <input data-answer="선대칭도형" aria-label="선대칭도형" placeholder="정답">과 <input data-answer="점대칭도형" aria-label="점대칭도형" placeholder="정답">을 이해하고 그릴 수 있다.</div>
+
+        <div class="overview-question">• <input data-answer="선대칭도형" aria-label="선대칭도형" placeholder="정답">과 <input data-answer="점대칭도형" aria-label="점대칭도형" placeholder="정답"> 그리기를 평가할 때 모눈종이, 점판, 공학 도구 등을 이용하여 쉽게 그릴 수 있게 한다.</div>
+
+        <div class="overview-question">• 무늬 찾기, 종이 겹쳐 오리기, 도장 찍기, 데칼코마니 등 구체적인 조작 활동을 통하여 도형의 <input data-answer="합동" aria-label="합동" placeholder="정답">의 의미를 알게 한다.</div>
+
+        <div class="overview-question">• 실생활이나 자연 환경 등에서 도형의 합동, 선대칭도형, 점대칭도형의 예를 찾고 수학의 <input data-answer="아름다움" aria-label="아름다움" placeholder="정답">을 느낄 수 있게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊲 직육면체와 정육면체</div>
+
+        <div class="overview-question">[6수03-03] <input data-answer="직육면체" aria-label="직육면체" placeholder="정답">와 <input data-answer="정육면체" aria-label="정육면체" placeholder="정답">를 이해하고, <input data-answer="구성 요소" aria-label="구성 요소" placeholder="정답">와 <input data-answer="성질" aria-label="성질" placeholder="정답">을 탐구하고 설명할 수 있다.</div>
+
+        <div class="overview-question">[6수03-04] <input data-answer="직육면체" aria-label="직육면체" placeholder="정답">와 <input data-answer="정육면체" aria-label="정육면체" placeholder="정답">의 <input data-answer="겨냥도" aria-label="겨냥도" placeholder="정답">와 <input data-answer="전개도" aria-label="전개도" placeholder="정답">를 그릴 수 있다.</div>
+
+        <div class="overview-question">• 입체도형의 <input data-answer="전개도" aria-label="전개도" placeholder="정답">에 대한 평가는 전개도가 <input data-answer="될 수 있는 것" aria-label="될 수 있는 것" placeholder="정답">과 <input data-answer="될 수 없는 것" aria-label="될 수 없는 것" placeholder="정답">을 구별하는 데 중점을 둔다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊳 각기둥과 각뿔</div>
+
+        <div class="overview-question">[6수03-05] <input data-answer="각기둥" aria-label="각기둥" placeholder="정답">과 <input data-answer="각뿔" aria-label="각뿔" placeholder="정답">을 이해하고, <input data-answer="구성 요소" aria-label="구성 요소" placeholder="정답">와 <input data-answer="성질" aria-label="성질" placeholder="정답">을 탐구하고 설명할 수 있다.</div>
+
+        <div class="overview-question">[6수03-06] <input data-answer="각기둥" aria-label="각기둥" placeholder="정답">의 <input data-answer="전개도" aria-label="전개도" placeholder="정답">를 그릴 수 있다.</div>
+
+        <div class="overview-question">• <input data-answer="각기둥" aria-label="각기둥" placeholder="정답">의 전개도는 간단한 형태만 다루고, <input data-answer="각뿔" aria-label="각뿔" placeholder="정답">과 <input data-answer="원뿔" aria-label="원뿔" placeholder="정답">의 전개도는 다루지 않는다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊴 원기둥, 원뿔, 구</div>
+
+        <div class="overview-question">[6수03-07] <input data-answer="원기둥" aria-label="원기둥" placeholder="정답">, <input data-answer="원뿔" aria-label="원뿔" placeholder="정답">, <input data-answer="구" aria-label="구" placeholder="정답">를 이해하고, 구성 요소와 성질을 탐구하고 설명할 수 있다.</div>
+
+        <div class="overview-question">[6수03-08] <input data-answer="원기둥" aria-label="원기둥" placeholder="정답">의 <input data-answer="전개도" aria-label="전개도" placeholder="정답">를 그릴 수 있다.</div>
+
+        <div class="overview-question">• <input data-answer="한 직선" aria-label="한 직선" placeholder="정답">을 중심으로 <input data-answer="직사각형" aria-label="직사각형" placeholder="정답">, <input data-answer="직각삼각형" aria-label="직각삼각형" placeholder="정답">, <input data-answer="반원" aria-label="반원" placeholder="정답">을 돌리는 활동을 통하여 <input data-answer="원기둥" aria-label="원기둥" placeholder="정답">, <input data-answer="원뿔" aria-label="원뿔" placeholder="정답">, <input data-answer="구" aria-label="구" placeholder="정답">를 만들어 보게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊵 입체도형의 공간 감각</div>
+
+        <div class="overview-question">[6수03-09] 쌓기나무로 만든 입체도형을 보고 사용된 쌓기나무의 <input data-answer="개수" aria-label="개수" placeholder="정답">를 구할 수 있다.</div>
+
+        <div class="overview-question">[6수03-10] 쌓기나무로 만든 입체도형의 <input data-answer="위" aria-label="위" placeholder="정답">, <input data-answer="앞" aria-label="앞" placeholder="정답">, <input data-answer="옆" aria-label="옆" placeholder="정답">에서 본 모양을 표현할 수 있고, 이러한 표현을 보고 입체도형의 모양을 추측할 수 있다.</div>
+
+        <div class="overview-question">• [6수03-10] 여러 가지 물체, 건축물, 예술품, 쌓기나무로 만든 입체도형 등의 위, 앞, 옆에서 본 모양을 이용해서 <input data-answer="전체 모양" aria-label="전체 모양" placeholder="정답">을 <input data-answer="추측" aria-label="추측" placeholder="정답">하게 하고, 이에 대해 자신의 <input data-answer="추론" aria-label="추론" placeholder="정답"> 과정을 설명하게 한다.</div>
+
+        <div class="overview-question">• 입체도형의 구성 요소와 성질, 전개도, 쌓기나무로 만든 입체도형을 탐구할 때는 여러 가지 <input data-answer="모형" aria-label="모형" placeholder="정답">과 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 이용하게 할 수 있다.</div>
+
+        <div class="overview-question">• 쌓기나무로 만든 입체도형의 <input data-answer="위" aria-label="위" placeholder="정답">, <input data-answer="앞" aria-label="앞" placeholder="정답">, <input data-answer="옆" aria-label="옆" placeholder="정답">에서 본 모양에 대한 평가를 할 때는 간단한 모양을 이용한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊶 다각형의 둘레와 넓이</div>
+
+        <div class="overview-question">[6수03-11] 평면도형의 <input data-answer="둘레" aria-label="둘레" placeholder="정답">를 이해하고, 기본적인 평면도형의 <input data-answer="둘레" aria-label="둘레" placeholder="정답">를 구할 수 있다.</div>
+
+        <div class="overview-question">[6수03-12] 넓이 단위 1cm², 1m², 1km²를 알며, 그 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해한다.</div>
+
+        <div class="overview-question">[6수03-13] <input data-answer="직사각형" aria-label="직사각형" placeholder="정답">과 <input data-answer="정사각형" aria-label="정사각형" placeholder="정답">의 <input data-answer="넓이" aria-label="넓이" placeholder="정답">를 구하는 방법을 이해하고, 이를 구할 수 있다.</div>
+
+        <div class="overview-question">[6수03-14] <input data-answer="평행사변형" aria-label="평행사변형" placeholder="정답">, <input data-answer="삼각형" aria-label="삼각형" placeholder="정답">, <input data-answer="사다리꼴" aria-label="사다리꼴" placeholder="정답">, <input data-answer="마름모" aria-label="마름모" placeholder="정답">의 넓이를 구하는 방법을 다양하게 <input data-answer="추론" aria-label="추론" placeholder="정답">하고, 이와 관련된 문제를 해결할 수 있다.</div>
+
+        <div class="overview-question">• 삼각형의 넓이를 구할 때는 높이가 <input data-answer="삼각형의 외부" aria-label="삼각형의 외부" placeholder="정답">에 있는 것도 다룬다.</div>
+
+        <div class="overview-question">• 넓이 단위 사이의 관계 중 1cm², 1km² 사이의 <input data-answer="단위 환산" aria-label="단위 환산" placeholder="정답">은 다루지 않는다.</div>
+
+        <div class="overview-question">• 도형의 넓이는 1cm²인 <input data-answer="정사각형" aria-label="정사각형" placeholder="정답">의 <input data-answer="몇 배" aria-label="몇 배" placeholder="정답">인지를 구하는 것임을 이해하게 하고, 도형의 <input data-answer="변형" aria-label="변형" placeholder="정답">을 이용하여 넓이를 구하는 여러 가지 방법을 <input data-answer="추론" aria-label="추론" placeholder="정답">하게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊷 원주율과 원의 넓이</div>
+
+        <div class="overview-question">[6수03-15] 여러 가지 원 모양 물체의 <input data-answer="원주" aria-label="원주" placeholder="정답">와 <input data-answer="지름" aria-label="지름" placeholder="정답">을 측정하는 활동을 통하여, <input data-answer="원주율" aria-label="원주율" placeholder="정답">이 <input data-answer="일정한" aria-label="일정한" placeholder="정답"> 값임을 알고 그 <input data-answer="근삿값" aria-label="근삿값" placeholder="정답">을 사용할 수 있다.</div>
+
+        <div class="overview-question">• [6수03-15] 여러 가지 원에서 <input data-answer="원주" aria-label="원주" placeholder="정답">/<input data-answer="지름" aria-label="지름" placeholder="정답">의 값을 구하여 모든 원에서 <input data-answer="원주율" aria-label="원주율" placeholder="정답">이 <input data-answer="일정함" aria-label="일정함" placeholder="정답">을 이해하게 하고, 원주율의 근삿값으로 <input data-answer="3.14" aria-label="3.14" placeholder="정답">를 사용하게 한다.</div>
+
+        <div class="overview-question">[6수03-16] <input data-answer="원주" aria-label="원주" placeholder="정답">와 <input data-answer="원의 넓이" aria-label="원의 넓이" placeholder="정답">를 구하는 방법을 이해하고, 이를 구할 수 있다.</div>
+
+        <div class="overview-question">• [6수03-16] <input data-answer="지름" aria-label="지름" placeholder="정답">과 <input data-answer="원주율" aria-label="원주율" placeholder="정답">을 이용하면 <input data-answer="원주" aria-label="원주" placeholder="정답">를 직접 측정하지 않고도 구할 수 있음을 알게 하고, <input data-answer="직사각형의 넓이" aria-label="직사각형의 넓이" placeholder="정답">를 구하는 방법을 이용하여 <input data-answer="원의 넓이" aria-label="원의 넓이" placeholder="정답">를 구하는 방법을 이해하게 한다.</div>
+
+        <div class="overview-question">• 원주율을 지도할 때는 <input data-answer="원주" aria-label="원주" placeholder="정답">와 <input data-answer="지름" aria-label="지름" placeholder="정답">의 관계를 이해하고 원주율에 대한 양감을 기르게 한다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊸 입체도형의 겉넓이와 부피</div>
+
+        <div class="overview-question">[6수03-17] <input data-answer="직육면체" aria-label="직육면체" placeholder="정답">와 <input data-answer="정육면체" aria-label="정육면체" placeholder="정답">의 <input data-answer="겉넓이" aria-label="겉넓이" placeholder="정답">를 구하는 방법을 이해하고, 이를 구할 수 있다.</div>
+
+        <div class="overview-question">[6수03-18] 부피 단위 1cm³, 1m³를 알며, 그 <input data-answer="관계" aria-label="관계" placeholder="정답">를 이해한다.</div>
+
+        <div class="overview-question">[6수03-19] <input data-answer="직육면체" aria-label="직육면체" placeholder="정답">와 <input data-answer="정육면체" aria-label="정육면체" placeholder="정답">의 <input data-answer="부피" aria-label="부피" placeholder="정답">를 구하는 방법을 이해하고, 이를 구할 수 있다.</div>
+
+        <div class="overview-question">• 원주율, 원주, 원의 넓이, 입체도형의 겉넓이와 부피 등을 구할 때 복잡한 계산은 <input data-answer="계산기" aria-label="계산기" placeholder="정답">를 사용하게 한다.</div>
+
+        <div class="overview-question">• 겉넓이와 부피를 구하는 방법에 대하여 다양한 <input data-answer="추론" aria-label="추론" placeholder="정답">을 하게 하고, 자신의 <input data-answer="추론" aria-label="추론" placeholder="정답"> 과정을 다른 사람에게 설명하게 할 수 있다.</div>
+
+        <div class="overview-question">• 도형의 넓이와 부피를 구하는 방법의 <input data-answer="편리함" aria-label="편리함" placeholder="정답">을 인식하게 한다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+  </main>
+
+
   <main id="creative-quiz-main" class="hidden">
 
     <div class="tabs">
@@ -13608,6 +14009,8 @@
                 <button class="btn subject-btn" data-subject="math-operation" data-topic="achievement">수와 연산</button>
 
                 <button class="btn subject-btn" data-subject="change-relation" data-topic="achievement">변화와 관계</button>
+
+                <button class="btn subject-btn" data-subject="geometry-measure" data-topic="achievement">도형과 측정</button>
 
 
                 <button class="btn subject-btn" data-subject="creative" data-topic="course">창체</button>

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -29,6 +29,7 @@ export const CONSTANTS = {
         PRACTICAL_STD: 'practical-std',
         MATH_OPERATION: 'math-operation',
         CHANGE_RELATION: 'change-relation',
+        GEOMETRY_MEASURE: 'geometry-measure',
 
         CREATIVE: 'creative',
         OVERVIEW: 'overview',
@@ -111,6 +112,7 @@ export const SUBJECT_NAMES = {
     [CONSTANTS.SUBJECTS.PRACTICAL_STD]: '실과',
     [CONSTANTS.SUBJECTS.MATH_OPERATION]: '수와 연산',
     [CONSTANTS.SUBJECTS.CHANGE_RELATION]: '변화와 관계',
+    [CONSTANTS.SUBJECTS.GEOMETRY_MEASURE]: '도형과 측정',
 
     [CONSTANTS.SUBJECTS.CREATIVE]: '창체',
     [CONSTANTS.SUBJECTS.OVERVIEW]: '총론',

--- a/styles.css
+++ b/styles.css
@@ -2566,7 +2566,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #english-std-quiz-main .achievement-block,
 #practical-std-quiz-main .achievement-block,
 #math-operation-quiz-main .achievement-block,
-#change-relation-quiz-main .achievement-block {
+#change-relation-quiz-main .achievement-block,
+#geometry-measure-quiz-main .achievement-block {
   margin: 3rem 0 2rem;
   padding: 1rem;
   background: var(--bg-light);
@@ -2577,7 +2578,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #science-std-quiz-main .achievement-block::before,
 #english-std-quiz-main .achievement-block::before,
 #math-operation-quiz-main .achievement-block::before,
-#change-relation-quiz-main .achievement-block::before {
+#change-relation-quiz-main .achievement-block::before,
+#geometry-measure-quiz-main .achievement-block::before {
   content: '';
   position: absolute;
   top: -3px;
@@ -2605,7 +2607,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #english-std-quiz-main .outline-title,
 #practical-std-quiz-main .outline-title,
 #math-operation-quiz-main .outline-title,
-#change-relation-quiz-main .outline-title {
+#change-relation-quiz-main .outline-title,
+#geometry-measure-quiz-main .outline-title {
   font-size: 2rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -2686,7 +2689,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-quiz-main .overview-question,
 #math-course-quiz-main .overview-question,
 #spelling-quiz-main .overview-question,
-#change-relation-quiz-main .overview-question {
+#change-relation-quiz-main .overview-question,
+#geometry-measure-quiz-main .overview-question {
   display: block;
   line-height: 2.2; /* �?간격 ?��? */
   font-size: 2rem;
@@ -2723,6 +2727,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #english-std-quiz-main .overview-question:last-child,
 #practical-std-quiz-main .overview-question:last-child,
 #math-operation-quiz-main .overview-question:last-child,
+#geometry-measure-quiz-main .overview-question:last-child,
 #practical-quiz-main .overview-question:last-child,
 #math-course-quiz-main .overview-question:last-child,
 #spelling-quiz-main .overview-question:last-child,
@@ -2756,6 +2761,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
     #practical-std-quiz-main .overview-question,
     #math-operation-quiz-main .overview-question,
     #change-relation-quiz-main .overview-question,
+    #geometry-measure-quiz-main .overview-question,
     #practical-quiz-main .overview-question,
   #math-course-quiz-main .overview-question,
   #spelling-quiz-main .overview-question {
@@ -2778,6 +2784,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
     #practical-std-quiz-main .overview-question input,
     #math-operation-quiz-main .overview-question input,
     #change-relation-quiz-main .overview-question input,
+    #geometry-measure-quiz-main .overview-question input,
     #practical-quiz-main .overview-question input,
   #math-course-quiz-main .overview-question input,
   #korean-model-quiz-main .overview-question input,
@@ -2853,6 +2860,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .overview-question input,
 #math-operation-quiz-main .overview-question input,
 #change-relation-quiz-main .overview-question input,
+#geometry-measure-quiz-main .overview-question input,
 #practical-quiz-main .overview-question input,
 #math-course-quiz-main .overview-question input,
 #korean-model-quiz-main .overview-question input,
@@ -2964,6 +2972,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .overview-question input:focus,
 #math-operation-quiz-main .overview-question input:focus,
 #change-relation-quiz-main .overview-question input:focus,
+#geometry-measure-quiz-main .overview-question input:focus,
 #practical-quiz-main .overview-question input:focus,
 #math-course-quiz-main .overview-question input:focus,
 #korean-model-quiz-main .overview-question input:focus,
@@ -2995,6 +3004,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .overview-question input.correct,
 #math-operation-quiz-main .overview-question input.correct,
 #change-relation-quiz-main .overview-question input.correct,
+#geometry-measure-quiz-main .overview-question input.correct,
 #practical-quiz-main .overview-question input.correct,
 #math-course-quiz-main .overview-question input.correct,
 #korean-model-quiz-main .overview-question input.correct,
@@ -3025,6 +3035,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .overview-question input.incorrect,
 #math-operation-quiz-main .overview-question input.incorrect,
 #change-relation-quiz-main .overview-question input.incorrect,
+#geometry-measure-quiz-main .overview-question input.incorrect,
 #practical-quiz-main .overview-question input.incorrect,
 #math-course-quiz-main .overview-question input.incorrect,
 #korean-model-quiz-main .overview-question input.incorrect,
@@ -3055,6 +3066,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .overview-question input.retrying,
 #math-operation-quiz-main .overview-question input.retrying,
 #change-relation-quiz-main .overview-question input.retrying,
+#geometry-measure-quiz-main .overview-question input.retrying,
 #practical-quiz-main .overview-question input.retrying,
 #math-course-quiz-main .overview-question input.retrying,
 #korean-model-quiz-main .overview-question input.retrying,
@@ -3083,6 +3095,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .overview-question input.revealed,
 #math-operation-quiz-main .overview-question input.revealed,
 #change-relation-quiz-main .overview-question input.revealed,
+#geometry-measure-quiz-main .overview-question input.revealed,
 #practical-quiz-main .overview-question input.revealed,
 #math-course-quiz-main .overview-question input.revealed,
 #korean-model-quiz-main .overview-question input.revealed,
@@ -3511,13 +3524,15 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
   
   /* Math Operation & Change Relation 모바일 최적화 */
   #math-operation-quiz-main .tabs,
-  #change-relation-quiz-main .tabs {
+  #change-relation-quiz-main .tabs,
+  #geometry-measure-quiz-main .tabs {
     flex-direction: column;
     gap: 0.5rem;
   }
 
   #math-operation-quiz-main .tab,
-  #change-relation-quiz-main .tab {
+  #change-relation-quiz-main .tab,
+  #geometry-measure-quiz-main .tab {
     padding: 0.6rem 1rem;
     font-size: 1.4rem;
   }
@@ -3574,9 +3589,10 @@ input[placeholder="세부 단계"] {
   max-width: 100%;
 }
 
-/* Math Operation & Change Relation: 과목 탭 스타일 */
+/* Math Operation, Change Relation & Geometry Measure: 과목 탭 스타일 */
 #math-operation-quiz-main .tabs,
-#change-relation-quiz-main .tabs {
+#change-relation-quiz-main .tabs,
+#geometry-measure-quiz-main .tabs {
   display: flex;
   gap: 1rem;
   margin-bottom: 2rem;
@@ -3585,7 +3601,8 @@ input[placeholder="세부 단계"] {
 }
 
 #math-operation-quiz-main .tab,
-#change-relation-quiz-main .tab {
+#change-relation-quiz-main .tab,
+#geometry-measure-quiz-main .tab {
   padding: 0.8rem 1.5rem;
   background: var(--bg-light);
   border: 2px solid var(--secondary);
@@ -3596,15 +3613,17 @@ input[placeholder="세부 단계"] {
   color: var(--text-dark);
 }
 
-#math-operation-quiz-main .tab:hover,
-#change-relation-quiz-main .tab:hover {
+  #math-operation-quiz-main .tab:hover,
+  #change-relation-quiz-main .tab:hover,
+  #geometry-measure-quiz-main .tab:hover {
   background: var(--secondary);
   color: var(--text-light);
   transform: translateY(-2px);
 }
 
-#math-operation-quiz-main .tab.active,
-#change-relation-quiz-main .tab.active {
+  #math-operation-quiz-main .tab.active,
+  #change-relation-quiz-main .tab.active,
+  #geometry-measure-quiz-main .tab.active {
   background: var(--primary);
   color: var(--text-light);
   border-color: var(--primary);


### PR DESCRIPTION
## Summary
- add new 'geometry-measure' subject and mappings
- include full grades 1-6 achievement content for geometry and measurement
- wire up input handling and styles for the new course
- align geometry-measure UI styling with math-operation

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5a0303b70832c9318eb11fe644314