### PR TITLE
Add Data and Probability achievement subject

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,6 +129,7 @@
                 MATH_OPERATION: 'math-operation',
                 CHANGE_RELATION: 'change-relation',
                 GEOMETRY_MEASURE: 'geometry-measure',
+                DATA_PROBABILITY: 'data-probability',
 
 
 
@@ -299,6 +300,7 @@
             [CONSTANTS.SUBJECTS.CHANGE_RELATION]: '변화와 관계',
 
             [CONSTANTS.SUBJECTS.GEOMETRY_MEASURE]: '도형과 측정',
+            [CONSTANTS.SUBJECTS.DATA_PROBABILITY]: '자료와 가능성',
 
             [CONSTANTS.SUBJECTS.CREATIVE]: '창체',
 
@@ -2179,7 +2181,7 @@
 
        function adjustCreativeInputWidths() {
 
-           document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #moral-course-quiz-main .overview-question input[data-answer], #pe-back-quiz-main .pe-back-input, #science-std-quiz-main .overview-question input[data-answer], #english-std-quiz-main .overview-question input[data-answer], #practical-std-quiz-main .overview-question input[data-answer], #math-operation-quiz-main .overview-question input[data-answer], #change-relation-quiz-main .overview-question input[data-answer], #geometry-measure-quiz-main .overview-question input[data-answer], #math-course-quiz-main .overview-question input[data-answer], #science-course-quiz-main .overview-question input[data-answer], #music-course-quiz-main .overview-question input[data-answer], #english-course-quiz-main .overview-question input[data-answer], #art-course-quiz-main .overview-question input[data-answer]')
+        document.querySelectorAll('#creative-quiz-main .creative-question input[data-answer], #overview-quiz-main .overview-question input[data-answer], #integrated-course-quiz-main .overview-question input[data-answer], #moral-course-quiz-main .overview-question input[data-answer], #pe-back-quiz-main .pe-back-input, #science-std-quiz-main .overview-question input[data-answer], #english-std-quiz-main .overview-question input[data-answer], #practical-std-quiz-main .overview-question input[data-answer], #math-operation-quiz-main .overview-question input[data-answer], #change-relation-quiz-main .overview-question input[data-answer], #geometry-measure-quiz-main .overview-question input[data-answer], #data-probability-quiz-main .overview-question input[data-answer], #math-course-quiz-main .overview-question input[data-answer], #science-course-quiz-main .overview-question input[data-answer], #music-course-quiz-main .overview-question input[data-answer], #english-course-quiz-main .overview-question input[data-answer], #art-course-quiz-main .overview-question input[data-answer]')
 
                 .forEach(input => {
 
@@ -3194,6 +3196,7 @@
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.CHANGE_RELATION ||
 
                 gameState.selectedSubject === CONSTANTS.SUBJECTS.GEOMETRY_MEASURE ||
+                gameState.selectedSubject === CONSTANTS.SUBJECTS.DATA_PROBABILITY ||
 
                 (gameState.selectedSubject === CONSTANTS.SUBJECTS.SPELLING && isSpellingBlankMode())
 
@@ -5159,6 +5162,7 @@
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.CHANGE_RELATION ||
 
                     gameState.selectedSubject === CONSTANTS.SUBJECTS.GEOMETRY_MEASURE ||
+                    gameState.selectedSubject === CONSTANTS.SUBJECTS.DATA_PROBABILITY ||
 
                     (gameState.selectedSubject === CONSTANTS.SUBJECTS.SPELLING && isSpellingBlankMode())
 
@@ -5225,6 +5229,7 @@
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.CHANGE_RELATION ||
 
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.GEOMETRY_MEASURE ||
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.DATA_PROBABILITY ||
 
                             (gameState.selectedSubject === CONSTANTS.SUBJECTS.SPELLING && isSpellingBlankMode())
 
@@ -5375,6 +5380,7 @@
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.CHANGE_RELATION ||
 
                             gameState.selectedSubject === CONSTANTS.SUBJECTS.GEOMETRY_MEASURE ||
+                            gameState.selectedSubject === CONSTANTS.SUBJECTS.DATA_PROBABILITY ||
 
                             (gameState.selectedSubject === CONSTANTS.SUBJECTS.SPELLING && isSpellingBlankMode())
 

--- a/index.html
+++ b/index.html
@@ -9188,6 +9188,145 @@
 
   </main>
 
+<main id="data-probability-quiz-main" class="hidden">
+
+          <div class="tabs">
+
+        <div class="tab active" data-target="dp-grade1-2">1~2</div>
+
+        <div class="tab" data-target="dp-grade3-4">3~4</div>
+
+        <div class="tab" data-target="dp-grade5-6">5~6</div>
+
+      </div>
+
+    <section id="dp-grade1-2" class="active">
+
+      <h2>1~2</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊱 자료의 정리</div>
+
+        <div class="overview-question">[2수04-01] 여러 가지 사물을 정해진 <input data-answer="기준" aria-label="기준" placeholder="정답"> 또는 자신이 정한 <input data-answer="기준" aria-label="기준" placeholder="정답">으로 <input data-answer="분류" aria-label="분류" placeholder="정답">하여 개수를 세어 보고, 기준에 따른 결과를 말할 수 있다.</div>
+
+        <div class="overview-question">[2수04-02] 자료를 분류하여 <input data-answer="표" aria-label="표" placeholder="정답">로 나타내고, 자료를 <input data-answer="표" aria-label="표" placeholder="정답">로 나타내면 <input data-answer="편리한 점" aria-label="편리한 점" placeholder="정답">을 말할 수 있다.</div>
+
+        <div class="overview-question">• [2수04-02] 표를 이용하여 자료의 크기를 <input data-answer="수" aria-label="수" placeholder="정답">로 정리하면, 자료의 <input data-answer="크기" aria-label="크기" placeholder="정답">를 나타내고 <input data-answer="비교" aria-label="비교" placeholder="정답">하는 데 편리하다는 점을 통해 수학의 <input data-answer="유용성" aria-label="유용성" placeholder="정답">을 인식하게 한다.</div>
+
+        <div class="overview-question">[2수04-03] 자료를 분류하여 ○, ×, / 등을 이용한 그래프로 나타내고, 자료를 그래프로 나타내면 <input data-answer="편리한 점" aria-label="편리한 점" placeholder="정답">을 말할 수 있다.</div>
+
+        <div class="overview-question">• [2수04-03] 그래프를 이용하여 자료의 크기를 <input data-answer="시각적" aria-label="시각적" placeholder="정답">으로 나타내면, 자료의 크기를 <input data-answer="한눈에" aria-label="한눈에" placeholder="정답"> 비교하는 데 편리하다는 점을 통해 수학의 <input data-answer="유용성" aria-label="유용성" placeholder="정답">을 인식하게 한다.</div>
+
+        <div class="overview-question">• 분류하기에서는 학생들이 <input data-answer="실생활" aria-label="실생활" placeholder="정답">에서 친근하게 느낄 수 있는 소재를 활용한다.</div>
+
+        <div class="overview-question">• <input data-answer="기준" aria-label="기준" placeholder="정답">을 정하여 분류할 때는 학생들이 정한 다양한 기준을 존중하되, <input data-answer="분명하지 않은" aria-label="분명하지 않은" placeholder="정답"> 기준으로는 분류하기가 어렵다는 점을 인식하게 한다.</div>
+
+        <div class="overview-question">• 자료를 분류하여 <input data-answer="표" aria-label="표" placeholder="정답">나 <input data-answer="그래프" aria-label="그래프" placeholder="정답">를 만들 때는 자료가 <input data-answer="중복" aria-label="중복" placeholder="정답">되거나 <input data-answer="빠지지" aria-label="빠지지" placeholder="정답"> 않도록 <input data-answer="세어" aria-label="세어" placeholder="정답"> 보는 방법을 함께 지도한다.</div>
+
+        <div class="overview-question">• 표와 그래프로 나타내기는 실생활이나 환경과 관련된 자료들을 활용하되, 학생들의 수준에 비해 <input data-answer="어려운" aria-label="어려운" placeholder="정답"> 분류 대상이나 분류 기준을 사용하지 않는다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+    <section id="dp-grade3-4">
+
+      <h2>3~4</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊱 자료의 수집과 정리</div>
+
+        <div class="overview-question">[4수04-01] 자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">하여 <input data-answer="그림그래프" aria-label="그림그래프" placeholder="정답">나 <input data-answer="막대그래프" aria-label="막대그래프" placeholder="정답">로 나타내고 <input data-answer="해석" aria-label="해석" placeholder="정답">할 수 있다.</div>
+
+        <div class="overview-question">[4수04-02] 자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">하여 <input data-answer="꺾은선그래프" aria-label="꺾은선그래프" placeholder="정답">로 나타내고 해석할 수 있다.</div>
+
+        <div class="overview-question">[4수04-03] 탐구 문제를 해결하기 위해 자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">, <input data-answer="정리" aria-label="정리" placeholder="정답">하여 <input data-answer="막대그래프" aria-label="막대그래프" placeholder="정답">나 <input data-answer="꺾은선그래프" aria-label="꺾은선그래프" placeholder="정답">로 나타내고 <input data-answer="해석" aria-label="해석" placeholder="정답">할 수 있다.</div>
+
+        <div class="overview-question">• [4수04-03] 여러 가지 문제를 해결하기 위해 자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">, <input data-answer="정리" aria-label="정리" placeholder="정답">하고 그래프로 나타내어 <input data-answer="해석" aria-label="해석" placeholder="정답">하는 일련의 과정을 직접 경험하게 한다. 자료의 <input data-answer="크기" aria-label="크기" placeholder="정답">를 <input data-answer="비교" aria-label="비교" placeholder="정답">할 때는 막대그래프로, <input data-answer="시간" aria-label="시간" placeholder="정답">에 따른 <input data-answer="변화의 경향" aria-label="변화의 경향" placeholder="정답">을 알아볼 때는 꺾은선그래프로 나타내는 것이 편리함을 알고, 자료의 <input data-answer="특성" aria-label="특성" placeholder="정답">에 따라 <input data-answer="목적" aria-label="목적" placeholder="정답">에 맞는 적절한 그래프를 선택하게 한다.</div>
+
+        <div class="overview-question">• 문제 상황에 맞게 간단한 설문조사, 실험과 관찰, 공공 자료의 활용 등을 통해 자료를 직접 <input data-answer="수집" aria-label="수집" placeholder="정답">하게 한다.</div>
+
+        <div class="overview-question">• 그림그래프를 그릴 때 항목의 이름과 수량의 <input data-answer="단위" aria-label="단위" placeholder="정답">를 명확히 인식하고, 자료의 <input data-answer="개수" aria-label="개수" placeholder="정답">에 따라 그림이 나타내는 <input data-answer="단위" aria-label="단위" placeholder="정답">를 적절히 선택하게 한다.</div>
+
+        <div class="overview-question">• 막대그래프와 꺾은선그래프를 그릴 때는 <input data-answer="가로축" aria-label="가로축" placeholder="정답">과 <input data-answer="세로축" aria-label="세로축" placeholder="정답">이 각각 무엇을 나타내는지 확인하게 하고 <input data-answer="눈금 한 칸" aria-label="눈금 한 칸" placeholder="정답">이 나타내는 <input data-answer="크기" aria-label="크기" placeholder="정답">를 적절히 선택하게 한다.</div>
+
+        <div class="overview-question">• 막대그래프와 꺾은선그래프를 그릴 때 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 사용하게 할 수 있다.</div>
+
+        <div class="overview-question">• 자료 수집의 <input data-answer="목적" aria-label="목적" placeholder="정답">과 수집한 자료의 <input data-answer="특성" aria-label="특성" placeholder="정답">에 맞는 그래프로 적절히 표현되었는지를 비판적으로 판단하게 할 수 있다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+    <section id="dp-grade5-6">
+
+      <h2>5~6</h2>
+
+      <div class="grade-container"><div><table><tbody><tr><td>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊱 자료의 수집과 정리</div>
+
+        <div class="overview-question">[6수04-01] <input data-answer="평균" aria-label="평균" placeholder="정답">의 의미를 알고, 자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">하여 <input data-answer="평균" aria-label="평균" placeholder="정답">을 구하고 <input data-answer="해석" aria-label="해석" placeholder="정답">할 수 있다.</div>
+
+        <div class="overview-question">• [6수04-01] 평균은 집단의 자료를 <input data-answer="대표" aria-label="대표" placeholder="정답">하는 값임을 이해하고, 여러 집단의 평균을 <input data-answer="비교" aria-label="비교" placeholder="정답">하는 활동을 통해 수학의 <input data-answer="유용성" aria-label="유용성" placeholder="정답">을 인식하게 한다.</div>
+
+        <div class="overview-question">[6수04-02] 자료를 수집하여 <input data-answer="띠그래프" aria-label="띠그래프" placeholder="정답">나 <input data-answer="원그래프" aria-label="원그래프" placeholder="정답">로 나타내고 해석할 수 있다.</div>
+
+        <div class="overview-question">[6수04-03] <input data-answer="탐구 문제" aria-label="탐구 문제" placeholder="정답">를 설정하고, 그에 맞는 자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">, <input data-answer="정리" aria-label="정리" placeholder="정답">하여 적절한 그래프로 나타내고 <input data-answer="해석" aria-label="해석" placeholder="정답">할 수 있다.</div>
+
+        <div class="overview-question">• [6수04-03] 해결하고자 하는 문제를 설정하고 그에 맞는 자료를 <input data-answer="수집" aria-label="수집" placeholder="정답">, <input data-answer="정리" aria-label="정리" placeholder="정답">하여, 막대그래프, 꺾은선그래프, 띠그래프와 원그래프 중 적절한 그래프로 나타내고 <input data-answer="해석" aria-label="해석" placeholder="정답">하는 일련의 과정을 직접 경험하게 한다.</div>
+
+        <div class="overview-question">• 자료를 수집할 때, 간단한 설문조사, 실험이나 관찰, 공공 자료 활용과 같은 방법 중 탐구 <input data-answer="목적" aria-label="목적" placeholder="정답">에 적합한 것을 결정하게 한다.</div>
+
+        <div class="overview-question">• 평균을 구하는 방법뿐만 아니라 그 의미를 <input data-answer="직관적" aria-label="직관적" placeholder="정답">으로 파악하게 한다.</div>
+
+        <div class="overview-question">• 복잡한 자료의 <input data-answer="평균" aria-label="평균" placeholder="정답">이나 <input data-answer="백분율" aria-label="백분율" placeholder="정답">을 구할 때 계산기를 사용하게 할 수 있다.</div>
+
+        <div class="overview-question">• 조사 자료에서 전체에 대한 각 부분의 <input data-answer="비율" aria-label="비율" placeholder="정답">을 <input data-answer="비교" aria-label="비교" placeholder="정답">해야 하는 문제 상황을 제시하여 띠그래프와 원그래프의 필요성을 인식하게 한다.</div>
+
+        <div class="overview-question">• 원그래프를 그릴 때는 <input data-answer="눈금이 표시된 원" aria-label="눈금이 표시된 원" placeholder="정답">을 사용하게 한다.</div>
+
+        <div class="overview-question">• 띠그래프와 원그래프를 그릴 때 <input data-answer="공학 도구" aria-label="공학 도구" placeholder="정답">를 사용하게 할 수 있다.</div>
+
+        <div class="overview-question">• 자료 수집의 <input data-answer="목적" aria-label="목적" placeholder="정답">과 수집한 자료의 <input data-answer="특성" aria-label="특성" placeholder="정답">에 맞는 그래프로 적절히 표현되었는지, 또는 정보를 <input data-answer="왜곡" aria-label="왜곡" placeholder="정답">하는 오류가 포함되어 있지는 않은지 등을 비판적으로 판단하게 할 수 있다.</div>
+
+        </div>
+
+        <div class="achievement-block">
+
+        <div class="outline-title"># 󰊲 가능성</div>
+
+        <div class="overview-question">[6수04-04] 사건이 일어날 가능성을 <input data-answer="말" aria-label="말" placeholder="정답">로 표현하고 비교할 수 있다.</div>
+
+        <div class="overview-question">• [6수04-04] ‘<input data-answer="확실하다" aria-label="확실하다" placeholder="정답">’, ‘<input data-answer="불가능하다" aria-label="불가능하다" placeholder="정답">’, ‘<input data-answer="∼일 것 같다" aria-label="∼일 것 같다" placeholder="정답">’, ‘<input data-answer="∼아닐 것 같다" aria-label="∼아닐 것 같다" placeholder="정답">’, ‘<input data-answer="반반이다" aria-label="반반이다" placeholder="정답">’ 등 일상에서 사건이 일어날 가능성을 나타내는 다양한 표현을 이해하고, 가능성의 크기를 비교하게 한다.</div>
+
+        <div class="overview-question">[6수04-05] 사건이 일어날 가능성을 <input data-answer="수" aria-label="수" placeholder="정답">로 나타낼 수 있다.</div>
+
+        <div class="overview-question">• [6수04-05] 가능성이 직관적으로 파악되는 생활 속의 간단한 사건에 대하여 그 가능성을 <input data-answer="0" aria-label="0" placeholder="정답">, <input data-answer="1/2" aria-label="1/2" placeholder="정답">, <input data-answer="1" aria-label="1" placeholder="정답"> 등과 같은 수로 표현하게 한다. 사건이 일어날 가능성과 일어나지 않을 가능성이 <input data-answer="같은" aria-label="같은" placeholder="정답"> 경우에 사건이 일어날 가능성을 <input data-answer="1/2" aria-label="1/2" placeholder="정답">로 표현할 수 있음을 이해하게 한다.</div>
+
+        <div class="overview-question">[6수04-06] 자료를 이용하여 가능성을 <input data-answer="예상" aria-label="예상" placeholder="정답">하고, 가능성에 근거하여 적절한 <input data-answer="판단" aria-label="판단" placeholder="정답">을 내릴 수 있다.</div>
+
+        <div class="overview-question">• [6수04-06] 제비뽑기, 동전 던지기, 주사위 던지기, 회전판 돌리기 등과 같은 간단한 실험 결과를 나타낸 표나 그래프를 보고 사건이 일어날 가능성을 <input data-answer="비교" aria-label="비교" placeholder="정답">하고 대략적으로 <input data-answer="예상" aria-label="예상" placeholder="정답">하게 한다.</div>
+
+        </div>
+
+      </td></tr></tbody></table></div></div>
+
+    </section>
+
+  </main>
 
   <main id="creative-quiz-main" class="hidden">
 
@@ -14011,6 +14150,7 @@
                 <button class="btn subject-btn" data-subject="change-relation" data-topic="achievement">변화와 관계</button>
 
                 <button class="btn subject-btn" data-subject="geometry-measure" data-topic="achievement">도형과 측정</button>
+                <button class="btn subject-btn" data-subject="data-probability" data-topic="achievement">자료와 가능성</button>
 
 
                 <button class="btn subject-btn" data-subject="creative" data-topic="course">창체</button>

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -30,6 +30,7 @@ export const CONSTANTS = {
         MATH_OPERATION: 'math-operation',
         CHANGE_RELATION: 'change-relation',
         GEOMETRY_MEASURE: 'geometry-measure',
+        DATA_PROBABILITY: 'data-probability',
 
         CREATIVE: 'creative',
         OVERVIEW: 'overview',
@@ -113,6 +114,7 @@ export const SUBJECT_NAMES = {
     [CONSTANTS.SUBJECTS.MATH_OPERATION]: '수와 연산',
     [CONSTANTS.SUBJECTS.CHANGE_RELATION]: '변화와 관계',
     [CONSTANTS.SUBJECTS.GEOMETRY_MEASURE]: '도형과 측정',
+    [CONSTANTS.SUBJECTS.DATA_PROBABILITY]: '자료와 가능성',
 
     [CONSTANTS.SUBJECTS.CREATIVE]: '창체',
     [CONSTANTS.SUBJECTS.OVERVIEW]: '총론',

--- a/styles.css
+++ b/styles.css
@@ -2567,7 +2567,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .achievement-block,
 #math-operation-quiz-main .achievement-block,
 #change-relation-quiz-main .achievement-block,
-#geometry-measure-quiz-main .achievement-block {
+#geometry-measure-quiz-main .achievement-block,
+#data-probability-quiz-main .achievement-block {
   margin: 3rem 0 2rem;
   padding: 1rem;
   background: var(--bg-light);
@@ -2579,7 +2580,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #english-std-quiz-main .achievement-block::before,
 #math-operation-quiz-main .achievement-block::before,
 #change-relation-quiz-main .achievement-block::before,
-#geometry-measure-quiz-main .achievement-block::before {
+#geometry-measure-quiz-main .achievement-block::before,
+#data-probability-quiz-main .achievement-block::before {
   content: '';
   position: absolute;
   top: -3px;
@@ -2608,7 +2610,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .outline-title,
 #math-operation-quiz-main .outline-title,
 #change-relation-quiz-main .outline-title,
-#geometry-measure-quiz-main .outline-title {
+#geometry-measure-quiz-main .outline-title,
+#data-probability-quiz-main .outline-title {
   font-size: 2rem;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -2690,7 +2693,8 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #math-course-quiz-main .overview-question,
 #spelling-quiz-main .overview-question,
 #change-relation-quiz-main .overview-question,
-#geometry-measure-quiz-main .overview-question {
+#geometry-measure-quiz-main .overview-question,
+#data-probability-quiz-main .overview-question {
   display: block;
   line-height: 2.2; /* �?간격 ?��? */
   font-size: 2rem;
@@ -2728,6 +2732,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #practical-std-quiz-main .overview-question:last-child,
 #math-operation-quiz-main .overview-question:last-child,
 #geometry-measure-quiz-main .overview-question:last-child,
+#data-probability-quiz-main .overview-question:last-child,
 #practical-quiz-main .overview-question:last-child,
 #math-course-quiz-main .overview-question:last-child,
 #spelling-quiz-main .overview-question:last-child,
@@ -2762,6 +2767,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
     #math-operation-quiz-main .overview-question,
     #change-relation-quiz-main .overview-question,
     #geometry-measure-quiz-main .overview-question,
+    #data-probability-quiz-main .overview-question,
     #practical-quiz-main .overview-question,
   #math-course-quiz-main .overview-question,
   #spelling-quiz-main .overview-question {
@@ -2785,6 +2791,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
     #math-operation-quiz-main .overview-question input,
     #change-relation-quiz-main .overview-question input,
     #geometry-measure-quiz-main .overview-question input,
+    #data-probability-quiz-main .overview-question input,
     #practical-quiz-main .overview-question input,
   #math-course-quiz-main .overview-question input,
   #korean-model-quiz-main .overview-question input,
@@ -2861,6 +2868,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #math-operation-quiz-main .overview-question input,
 #change-relation-quiz-main .overview-question input,
 #geometry-measure-quiz-main .overview-question input,
+#data-probability-quiz-main .overview-question input,
 #practical-quiz-main .overview-question input,
 #math-course-quiz-main .overview-question input,
 #korean-model-quiz-main .overview-question input,
@@ -2973,6 +2981,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #math-operation-quiz-main .overview-question input:focus,
 #change-relation-quiz-main .overview-question input:focus,
 #geometry-measure-quiz-main .overview-question input:focus,
+#data-probability-quiz-main .overview-question input:focus,
 #practical-quiz-main .overview-question input:focus,
 #math-course-quiz-main .overview-question input:focus,
 #korean-model-quiz-main .overview-question input:focus,
@@ -3005,6 +3014,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #math-operation-quiz-main .overview-question input.correct,
 #change-relation-quiz-main .overview-question input.correct,
 #geometry-measure-quiz-main .overview-question input.correct,
+#data-probability-quiz-main .overview-question input.correct,
 #practical-quiz-main .overview-question input.correct,
 #math-course-quiz-main .overview-question input.correct,
 #korean-model-quiz-main .overview-question input.correct,
@@ -3036,6 +3046,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #math-operation-quiz-main .overview-question input.incorrect,
 #change-relation-quiz-main .overview-question input.incorrect,
 #geometry-measure-quiz-main .overview-question input.incorrect,
+#data-probability-quiz-main .overview-question input.incorrect,
 #practical-quiz-main .overview-question input.incorrect,
 #math-course-quiz-main .overview-question input.incorrect,
 #korean-model-quiz-main .overview-question input.incorrect,
@@ -3067,6 +3078,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #math-operation-quiz-main .overview-question input.retrying,
 #change-relation-quiz-main .overview-question input.retrying,
 #geometry-measure-quiz-main .overview-question input.retrying,
+#data-probability-quiz-main .overview-question input.retrying,
 #practical-quiz-main .overview-question input.retrying,
 #math-course-quiz-main .overview-question input.retrying,
 #korean-model-quiz-main .overview-question input.retrying,
@@ -3096,6 +3108,7 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
 #math-operation-quiz-main .overview-question input.revealed,
 #change-relation-quiz-main .overview-question input.revealed,
 #geometry-measure-quiz-main .overview-question input.revealed,
+#data-probability-quiz-main .overview-question input.revealed,
 #practical-quiz-main .overview-question input.revealed,
 #math-course-quiz-main .overview-question input.revealed,
 #korean-model-quiz-main .overview-question input.revealed,
@@ -3525,14 +3538,16 @@ body:has(#english-quiz-main:not(.hidden)) .tabs .tab {
   /* Math Operation & Change Relation 모바일 최적화 */
   #math-operation-quiz-main .tabs,
   #change-relation-quiz-main .tabs,
-  #geometry-measure-quiz-main .tabs {
+  #geometry-measure-quiz-main .tabs,
+  #data-probability-quiz-main .tabs {
     flex-direction: column;
     gap: 0.5rem;
   }
 
   #math-operation-quiz-main .tab,
   #change-relation-quiz-main .tab,
-  #geometry-measure-quiz-main .tab {
+  #geometry-measure-quiz-main .tab,
+  #data-probability-quiz-main .tab {
     padding: 0.6rem 1rem;
     font-size: 1.4rem;
   }
@@ -3592,7 +3607,8 @@ input[placeholder="세부 단계"] {
 /* Math Operation, Change Relation & Geometry Measure: 과목 탭 스타일 */
 #math-operation-quiz-main .tabs,
 #change-relation-quiz-main .tabs,
-#geometry-measure-quiz-main .tabs {
+#geometry-measure-quiz-main .tabs,
+#data-probability-quiz-main .tabs {
   display: flex;
   gap: 1rem;
   margin-bottom: 2rem;
@@ -3602,7 +3618,8 @@ input[placeholder="세부 단계"] {
 
 #math-operation-quiz-main .tab,
 #change-relation-quiz-main .tab,
-#geometry-measure-quiz-main .tab {
+#geometry-measure-quiz-main .tab,
+#data-probability-quiz-main .tab {
   padding: 0.8rem 1.5rem;
   background: var(--bg-light);
   border: 2px solid var(--secondary);
@@ -3615,7 +3632,8 @@ input[placeholder="세부 단계"] {
 
   #math-operation-quiz-main .tab:hover,
   #change-relation-quiz-main .tab:hover,
-  #geometry-measure-quiz-main .tab:hover {
+  #geometry-measure-quiz-main .tab:hover,
+  #data-probability-quiz-main .tab:hover {
   background: var(--secondary);
   color: var(--text-light);
   transform: translateY(-2px);
@@ -3623,7 +3641,8 @@ input[placeholder="세부 단계"] {
 
   #math-operation-quiz-main .tab.active,
   #change-relation-quiz-main .tab.active,
-  #geometry-measure-quiz-main .tab.active {
+  #geometry-measure-quiz-main .tab.active,
+  #data-probability-quiz-main .tab.active {
   background: var(--primary);
   color: var(--text-light);
   border-color: var(--primary);


### PR DESCRIPTION
## Summary
- introduce 새로운 '자료와 가능성' 과목 성취기준과 학년별 내용
- wire up data-probability subject in constants, app logic, and UI
- style and tab support for new 과목
- match data-probability headers to math-operation format

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa05cfec832cae1954d8b4a5beac